### PR TITLE
Task/extract service and subservice from headers

### DIFF
--- a/examples/deviceGroup.json
+++ b/examples/deviceGroup.json
@@ -1,0 +1,29 @@
+{
+  "services": [
+    {
+      "resource": "/deviceTest",
+      "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
+      "type": "Light",
+      "trust": "8970A9078A803H3BL98PINEQRW8342HBAMS",
+      "cbHost": "http://unexistentHost:1026",
+      "commands": [
+        {
+          "name": "wheel1",
+          "type": "Wheel"
+        }
+      ],
+      "lazy": [
+        {
+          "name": "luminescence",
+          "type": "Lumens"
+        }
+      ],
+      "active": [
+        {
+          "name": "status",
+          "type": "Boolean"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/services/deviceGroupAdministrationServer.js
+++ b/lib/services/deviceGroupAdministrationServer.js
@@ -26,7 +26,6 @@ var logger = require('fiware-node-logger'),
     errors = require('../errors'),
     restUtils = require('./restUtils'),
     groupService = require('./groupService'),
-    _ = require('underscore'),
     revalidator = require('revalidator'),
     templateGroup = require('../templates/deviceGroup.json'),
     context = {

--- a/lib/services/deviceGroupAdministrationServer.js
+++ b/lib/services/deviceGroupAdministrationServer.js
@@ -24,6 +24,7 @@
 
 var logger = require('fiware-node-logger'),
     errors = require('../errors'),
+    restUtils = require('./restUtils'),
     groupService = require('./groupService'),
     _ = require('underscore'),
     revalidator = require('revalidator'),
@@ -36,29 +37,6 @@ var logger = require('fiware-node-logger'),
         'fiware-servicepath'
     ];
 
-/**
- * Checks for the pressence of all the mandatory headers, returning a BAD_REQUEST error if any one is not found.
- *
- * @param {Object} req           Incoming request.
- * @param {Object} res           Outgoing response.
- * @param {Function} next        Invokes the next middleware in the chain.
- */
-function checkHeaders(req, res, next) {
-    var headerKeys = _.keys(req.headers),
-        missing = [];
-
-    for (var i = 0; i < mandatoryHeaders.length; i++) {
-        if (headerKeys.indexOf(mandatoryHeaders[i]) < 0) {
-            missing.push(mandatoryHeaders[i]);
-        }
-    }
-
-    if (missing.length !== 0) {
-        next(new errors.MissingHeaders(JSON.stringify(missing)));
-    } else {
-        next();
-    }
-}
 
 /**
  * Generates a middleware that checks the request body against the given revalidator template.
@@ -174,10 +152,14 @@ function handleDeleteDeviceGroups(req, res, next) {
  * @param {Object} router      Express request router object.
  */
 function loadContextRoutes(router, name) {
-    router.post('/iot/agents/' + name, checkHeaders, checkBody(templateGroup), handleCreateDeviceGroup);
-    router.get('/iot/agents/' + name, checkHeaders, handleListDeviceGroups);
-    router.put('/iot/agents/' + name, checkHeaders, handleModifyDeviceGroups);
-    router.delete('/iot/agents/' + name, checkHeaders, handleDeleteDeviceGroups);
+    router.post('/iot/agents/' + name,
+        restUtils.checkHeaders(mandatoryHeaders), checkBody(templateGroup), handleCreateDeviceGroup);
+    router.get('/iot/agents/' + name,
+        restUtils.checkHeaders(mandatoryHeaders), handleListDeviceGroups);
+    router.put('/iot/agents/' + name,
+        restUtils.checkHeaders(mandatoryHeaders), handleModifyDeviceGroups);
+    router.delete('/iot/agents/' + name,
+        restUtils.checkHeaders(mandatoryHeaders), handleDeleteDeviceGroups);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/services/deviceProvisioningServer.js
+++ b/lib/services/deviceProvisioningServer.js
@@ -65,14 +65,14 @@ function handleProvision(req, res, next) {
         }
     }
 
-    function registerDevice(body, callback) {
+    function registerDevice(service, subservice, body, callback) {
         /*jshint sub:true */
         ngsi.register({
                 id: body['name'],
                 type: body['entity_type'],
                 name: body['entity_name'],
-                service: body['service'],
-                subservice: body['service_path'],
+                service: service,
+                subservice: subservice,
                 active: body['attributes'],
                 staticAttributes: body['static_attributes'],
                 lazy: body['commands'],
@@ -88,7 +88,7 @@ function handleProvision(req, res, next) {
     async.waterfall([
         apply(restUtils.checkMandatoryQueryParams,
             ['name', 'entity_type', 'service', 'service_path', 'commands'], req.body),
-        registerDevice
+        apply(registerDevice, req.headers['fiware-service'], req.headers['fiware-servicepath'])
     ], handleProvisioningFinish);
 }
 

--- a/lib/services/deviceProvisioningServer.js
+++ b/lib/services/deviceProvisioningServer.js
@@ -32,6 +32,10 @@ var async = require('async'),
         op: 'IoTAgentNGSI.DeviceProvisioning'
     },
     apply = async.apply,
+    mandatoryHeaders = [
+        'fiware-service',
+        'fiware-servicepath'
+    ],
     provisioningAPITranslation = {
         /* jshint camelcase:false */
 
@@ -188,11 +192,11 @@ function handleUpdateDevice(req, res, next) {
  * @param {Object} router      Express request router object.
  */
 function loadContextRoutes(router) {
-    router.post('/iot/devices', handleProvision);
-    router.get('/iot/devices', handleListDevices);
-    router.get('/iot/devices/:deviceId', handleGetDevice);
-    router.put('/iot/devices/:deviceId', handleUpdateDevice);
-    router.delete('/iot/devices/:deviceId', handleRemoveDevice);
+    router.post('/iot/devices', restUtils.checkHeaders(mandatoryHeaders), handleProvision);
+    router.get('/iot/devices', restUtils.checkHeaders(mandatoryHeaders), handleListDevices);
+    router.get('/iot/devices/:deviceId', restUtils.checkHeaders(mandatoryHeaders), handleGetDevice);
+    router.put('/iot/devices/:deviceId', restUtils.checkHeaders(mandatoryHeaders), handleUpdateDevice);
+    router.delete('/iot/devices/:deviceId', restUtils.checkHeaders(mandatoryHeaders), handleRemoveDevice);
 }
 
 exports.loadContextRoutes = loadContextRoutes;

--- a/lib/services/restUtils.js
+++ b/lib/services/restUtils.js
@@ -22,7 +22,8 @@
  */
 'use strict';
 
-var errors = require('../errors');
+var errors = require('../errors'),
+    _ = require('underscore');
 
 /**
  * Checks all the mandatory attributes in the selected array are present in the presented body object.
@@ -86,5 +87,32 @@ function xmlRawBody(req, res, next) {
     }
 }
 
+/**
+ * Generates a Express middleware that checks for the pressence of all the mandatory headers, returning a BAD_REQUEST
+ * error if any one is not found.
+ *
+ * @param {Array} mandatoryHeaders           List of mandatory headers.
+ * @returns {Function} next                  Function that check the pressence of the required headers
+ */
+function checkHeaders(mandatoryHeaders) {
+    return function headerChecker(req, res, next) {
+        var headerKeys = _.keys(req.headers),
+            missing = [];
+
+        for (var i = 0; i < mandatoryHeaders.length; i++) {
+            if (headerKeys.indexOf(mandatoryHeaders[i]) < 0) {
+                missing.push(mandatoryHeaders[i]);
+            }
+        }
+
+        if (missing.length !== 0) {
+            next(new errors.MissingHeaders(JSON.stringify(missing)));
+        } else {
+            next();
+        }
+    };
+}
+
 exports.checkMandatoryQueryParams = checkMandatoryQueryParams;
 exports.xmlRawBody = xmlRawBody;
+exports.checkHeaders = checkHeaders;

--- a/lib/services/restUtils.js
+++ b/lib/services/restUtils.js
@@ -92,7 +92,7 @@ function xmlRawBody(req, res, next) {
  * error if any one is not found.
  *
  * @param {Array} mandatoryHeaders           List of mandatory headers.
- * @returns {Function} next                  Function that check the pressence of the required headers
+ * @return {Function} next                  Function that check the pressence of the required headers
  */
 function checkHeaders(mandatoryHeaders) {
     return function headerChecker(req, res, next) {

--- a/test/unit/device-provisioning-api_test.js
+++ b/test/unit/device-provisioning-api_test.js
@@ -71,7 +71,11 @@ describe('Device provisioning API: Provision devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
-            json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
+            json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json'),
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            }
         };
 
         it('should add the device to the devices list', function(done) {
@@ -120,6 +124,10 @@ describe('Device provisioning API: Provision devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionDeviceMissingParameters.json')
         };
 
@@ -141,6 +149,10 @@ describe('Device provisioning API: Provision devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/newBaseRoot/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         };
 
@@ -164,6 +176,23 @@ describe('Device provisioning API: Provision devices', function() {
                     results.length.should.equal(1);
                     done();
                 });
+            });
+        });
+    });
+    describe('When a device provisioning request without the mandatory headers arrives to the Agent', function() {
+        var options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+            method: 'POST',
+            headers: {},
+            json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionDeviceMissingParameters.json')
+        };
+
+        it('should raise a MISSING_HEADERS error, indicating the missing attributes', function(done) {
+            request(options, function(error, response, body) {
+                should.exist(body);
+                response.statusCode.should.equal(400);
+                body.name.should.equal('MISSING_HEADERS');
+                done();
             });
         });
     });

--- a/test/unit/device-provisioning-api_test.js
+++ b/test/unit/device-provisioning-api_test.js
@@ -51,7 +51,7 @@ describe('Device provisioning API: Provision devices', function() {
         iotAgentLib.activate(iotAgentConfig, function() {
             contextBrokerMock = nock('http://10.11.128.16:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice.json'))
@@ -73,8 +73,8 @@ describe('Device provisioning API: Provision devices', function() {
             method: 'POST',
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json'),
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             }
         };
 
@@ -119,14 +119,26 @@ describe('Device provisioning API: Provision devices', function() {
                 });
             });
         });
+        it('should store service and subservice info from the headers along with the device data', function(done) {
+            request(options, function(error, response, body) {
+                response.statusCode.should.equal(200);
+                iotAgentLib.listDevices(function(error, results) {
+                    should.exist(results[0].service);
+                    results[0].service.should.equal('smartGondor');
+                    should.exist(results[0].subservice);
+                    results[0].subservice.should.equal('/gardens');
+                    done();
+                });
+            });
+        });
     });
     describe('When a device provisioning request with missing data arrives to the IoT Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionDeviceMissingParameters.json')
         };
@@ -150,8 +162,8 @@ describe('Device provisioning API: Provision devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/newBaseRoot/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         };

--- a/test/unit/listProvisionedDevices-test.js
+++ b/test/unit/listProvisionedDevices-test.js
@@ -52,8 +52,8 @@ describe('Device provisioning API: List provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
@@ -61,8 +61,8 @@ describe('Device provisioning API: List provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
@@ -71,7 +71,7 @@ describe('Device provisioning API: List provisioned devices', function() {
         iotAgentLib.activate(iotAgentConfig, function() {
             contextBrokerMock = nock('http://10.11.128.16:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice.json'))
@@ -81,7 +81,7 @@ describe('Device provisioning API: List provisioned devices', function() {
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice2.json'))
@@ -107,8 +107,8 @@ describe('Device provisioning API: List provisioned devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             method: 'GET'
         };
@@ -127,8 +127,8 @@ describe('Device provisioning API: List provisioned devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             method: 'GET'
         };
@@ -152,8 +152,8 @@ describe('Device provisioning API: List provisioned devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             method: 'GET'
         };

--- a/test/unit/listProvisionedDevices-test.js
+++ b/test/unit/listProvisionedDevices-test.js
@@ -51,11 +51,19 @@ describe('Device provisioning API: List provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
         provisioning2Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
 
@@ -98,6 +106,10 @@ describe('Device provisioning API: List provisioned devices', function() {
     describe('When a request for the list of provisioned devices arrive', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             method: 'GET'
         };
 
@@ -114,6 +126,10 @@ describe('Device provisioning API: List provisioned devices', function() {
     describe('When a request for the information about a specific device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             method: 'GET'
         };
 
@@ -135,6 +151,10 @@ describe('Device provisioning API: List provisioned devices', function() {
     describe('When a request for an unexistent device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             method: 'GET'
         };
 

--- a/test/unit/removeProvisionedDevice-test.js
+++ b/test/unit/removeProvisionedDevice-test.js
@@ -51,11 +51,19 @@ describe('Device provisioning API: Remove provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
         provisioning2Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
 
@@ -106,6 +114,10 @@ describe('Device provisioning API: Remove provisioned devices', function() {
     describe('When a request to remove a provision device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             method: 'DELETE'
         };
 
@@ -121,6 +133,10 @@ describe('Device provisioning API: Remove provisioned devices', function() {
             request(options, function(error, response, body) {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+                    headers: {
+                        'fiware-service': 'TestService',
+                        'fiware-servicepath': '/testingPath'
+                    },
                     method: 'GET'
                 };
 
@@ -136,6 +152,10 @@ describe('Device provisioning API: Remove provisioned devices', function() {
             request(options, function(error, response, body) {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
+                    headers: {
+                        'fiware-service': 'TestService',
+                        'fiware-servicepath': '/testingPath'
+                    },
                     method: 'GET'
                 };
 

--- a/test/unit/removeProvisionedDevice-test.js
+++ b/test/unit/removeProvisionedDevice-test.js
@@ -52,8 +52,8 @@ describe('Device provisioning API: Remove provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
@@ -61,8 +61,8 @@ describe('Device provisioning API: Remove provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
@@ -71,7 +71,7 @@ describe('Device provisioning API: Remove provisioned devices', function() {
         iotAgentLib.activate(iotAgentConfig, function() {
             contextBrokerMock = nock('http://10.11.128.16:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice.json'))
@@ -81,7 +81,7 @@ describe('Device provisioning API: Remove provisioned devices', function() {
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice2.json'))
@@ -91,7 +91,7 @@ describe('Device provisioning API: Remove provisioned devices', function() {
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext')
                 .reply(200,
                 utils.readExampleFile(
@@ -115,8 +115,8 @@ describe('Device provisioning API: Remove provisioned devices', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             method: 'DELETE'
         };
@@ -134,8 +134,8 @@ describe('Device provisioning API: Remove provisioned devices', function() {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                     headers: {
-                        'fiware-service': 'TestService',
-                        'fiware-servicepath': '/testingPath'
+                        'fiware-service': 'smartGondor',
+                        'fiware-servicepath': '/gardens'
                     },
                     method: 'GET'
                 };
@@ -153,8 +153,8 @@ describe('Device provisioning API: Remove provisioned devices', function() {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
                     headers: {
-                        'fiware-service': 'TestService',
-                        'fiware-servicepath': '/testingPath'
+                        'fiware-service': 'smartGondor',
+                        'fiware-servicepath': '/gardens'
                     },
                     method: 'GET'
                 };

--- a/test/unit/updateProvisionedDevices-test.js
+++ b/test/unit/updateProvisionedDevices-test.js
@@ -51,11 +51,19 @@ describe('Device provisioning API: Update provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
         provisioning2Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
 
@@ -109,6 +117,10 @@ describe('Device provisioning API: Update provisioned devices', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/updateProvisionDevice.json')
         };
 
@@ -124,6 +136,10 @@ describe('Device provisioning API: Update provisioned devices', function() {
             request(optionsUpdate, function(error, response, body) {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
+                    headers: {
+                        'fiware-service': 'TestService',
+                        'fiware-servicepath': '/testingPath'
+                    },
                     method: 'GET'
                 };
 
@@ -142,6 +158,10 @@ describe('Device provisioning API: Update provisioned devices', function() {
             request(optionsUpdate, function(error, response, body) {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
+                    headers: {
+                        'fiware-service': 'TestService',
+                        'fiware-servicepath': '/testingPath'
+                    },
                     method: 'GET'
                 };
 
@@ -160,6 +180,10 @@ describe('Device provisioning API: Update provisioned devices', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
+            headers: {
+                'fiware-service': 'TestService',
+                'fiware-servicepath': '/testingPath'
+            },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/updateProvisionDeviceWithId.json')
         };
 

--- a/test/unit/updateProvisionedDevices-test.js
+++ b/test/unit/updateProvisionedDevices-test.js
@@ -52,8 +52,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionNewDevice.json')
         },
@@ -61,8 +61,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/provisionAnotherDevice.json')
         };
@@ -71,7 +71,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
         iotAgentLib.activate(iotAgentConfig, function() {
             contextBrokerMock = nock('http://10.11.128.16:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice.json'))
@@ -81,7 +81,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/registerProvisionedDevice2.json'))
@@ -91,7 +91,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .matchHeader('fiware-servicepath', 'gardens')
+                .matchHeader('fiware-servicepath', '/gardens')
                 .post('/NGSI9/registerContext',
                 utils.readExampleFile(
                     './test/unit/contextAvailabilityRequests/updateIoTAgent2.json'))
@@ -118,8 +118,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/updateProvisionDevice.json')
         };
@@ -137,8 +137,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
                     headers: {
-                        'fiware-service': 'TestService',
-                        'fiware-servicepath': '/testingPath'
+                        'fiware-service': 'smartGondor',
+                        'fiware-servicepath': '/gardens'
                     },
                     method: 'GET'
                 };
@@ -159,8 +159,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
                 var options = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
                     headers: {
-                        'fiware-service': 'TestService',
-                        'fiware-servicepath': '/testingPath'
+                        'fiware-service': 'smartGondor',
+                        'fiware-servicepath': '/gardens'
                     },
                     method: 'GET'
                 };
@@ -181,8 +181,8 @@ describe('Device provisioning API: Update provisioned devices', function() {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
             headers: {
-                'fiware-service': 'TestService',
-                'fiware-servicepath': '/testingPath'
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
             },
             json: utils.readExampleFile('./test/unit/deviceProvisioningRequests/updateProvisionDeviceWithId.json')
         };


### PR DESCRIPTION
Enforce use of fiware-service and fiware-servicepath headers for the Device Provisioning API. 