### PR TITLE
FIX Entity ID for virtual attributes '_status'

### DIFF
--- a/lib/services/contextServer.js
+++ b/lib/services/contextServer.js
@@ -184,7 +184,7 @@ function executeUpdateSideEffects(device, id, type, service, subservice, attribu
 
                 sideEffects.push(
                     apply(ngsi.update,
-                        device.id,
+                        device.name,
                         device.resource,
                         device.apikey,
                         newAttributes,


### PR DESCRIPTION
Updates to modify the status were issued with the ID of the device, instead of its `name` so there was a bug when the two of them were different.

