### PR TITLE
Fix for a problem with active attribute updates coming from Context Broker

### DIFF
--- a/lib/services/contextServer.js
+++ b/lib/services/contextServer.js
@@ -171,29 +171,32 @@ function createQueryResponse(req, res, results) {
 function executeUpdateSideEffects(device, id, type, service, subservice, attributes, callback) {
     var sideEffects = [];
 
-    for (var i = 0; i < device.commands.length; i++) {
-        for (var j = 0; j < attributes.length; j++) {
-            if (device.commands[i].name === attributes[j].name) {
-                var newAttributes = [
-                    {
-                        name: device.commands[i].name + '_status',
-                        type: device.commands[i].type,
-                        value: 'PENDING'
-                    }
-                ];
-
-                sideEffects.push(
-                    apply(ngsi.update,
-                        device.name,
-                        device.resource,
-                        device.apikey,
-                        newAttributes,
-                        device
-                    )
-                );
+    if(device.commands) {
+        for (var i = 0; i < device.commands.length; i++) {
+            for (var j = 0; j < attributes.length; j++) {
+                if (device.commands[i].name === attributes[j].name) {
+                    var newAttributes = [
+                        {
+                            name: device.commands[i].name + '_status',
+                            type: device.commands[i].type,
+                            value: 'PENDING'
+                        }
+                    ];
+    
+                    sideEffects.push(
+                        apply(ngsi.update,
+                            device.name,
+                            device.resource,
+                            device.apikey,
+                            newAttributes,
+                            device
+                        )
+                    );
+                }
             }
         }
     }
+    
     async.series(sideEffects, callback);
 }
 
@@ -224,7 +227,7 @@ function generateUpdateActions(req, contextElement, callback) {
             }
 
         } else {
-            attributes = device.attributes;
+            attributes = contextElement.attributes;
         }
 
         callback(null, attributes, commands, device);

--- a/test/unit/active-devices-attribute-update-test.js
+++ b/test/unit/active-devices-attribute-update-test.js
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+'use strict';
+
+var iotAgentLib = require('../../'),
+    utils = require('../tools/utils'),
+    should = require('should'),
+    logger = require('fiware-node-logger'),
+    nock = require('nock'),
+    mongoUtils = require('./mongoDBUtils'),
+    request = require('request'),
+    contextBrokerMock,
+    statusAttributeMock,
+    iotAgentConfig = {
+        contextBroker: {
+            host: '10.11.128.16',
+            port: '1026'
+        },
+        server: {
+            port: 4041
+        },
+        types: {
+            'Light': {
+                // commands are not defined
+                active: [
+                    {
+                        name: 'pressure',
+                        type: 'Hgmm'
+                    }
+                ]
+            }
+        },
+        service: 'smartGondor',
+        subservice: 'gardens',
+        providerUrl: 'http://smartGondor.com',
+        deviceRegistrationDuration: 'P1M',
+        throttling: 'PT5S'
+    },
+    device = {
+        id: 'somelight',
+        type: 'Light' 
+    };
+
+describe('Update attribute functionalities', function() {
+    
+    beforeEach(function(done) {
+        logger.setLevel('FATAL');
+        
+        nock.cleanAll();
+
+        contextBrokerMock = nock('http://10.11.128.16:1026')
+            .matchHeader('fiware-service', 'smartGondor')
+            .matchHeader('fiware-servicepath', 'gardens')
+            .post('/NGSI9/registerContext',
+                utils.readExampleFile('./test/unit/contextAvailabilityRequests/registerIoTAgentAttributeUpdates.json'))
+            .reply(200,
+                utils.readExampleFile('./test/unit/contextAvailabilityResponses/registerIoTAgent1Success.json'));
+
+        iotAgentLib.activate(iotAgentConfig, done);
+    });
+
+    afterEach(function(done) {
+        iotAgentLib.clearAll(function() {
+            iotAgentLib.deactivate(function() {
+                mongoUtils.cleanDbs(function() {
+                    nock.cleanAll();
+                    iotAgentLib.setDataUpdateHandler();
+                    iotAgentLib.setCommandHandler();
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('When a attribute update arrives to the IoT Agent as Context Provider', function() {
+        var options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/v1/updateContext',
+            method: 'POST',
+            json: {
+                contextElements: [
+                    {
+                        type: 'Light',
+                        isPattern: 'false',
+                        id: 'somelight:Light',
+                        attributes: [
+                            {
+                                name: 'pressure',
+                                type: 'Hgmm',
+                                value: '200'
+                            }
+                        ]
+                    }
+                ],
+                updateAction: 'UPDATE'
+            }
+        };
+
+        beforeEach(function(done) {
+            iotAgentLib.register(device, function(error) {
+                if(error)
+                    done("Device registration failed");
+                done();
+            });
+        });
+
+        it('should call the client handler with correct values, even if commands are not defined', function(done) {
+            var handlerCalled = false;
+
+            iotAgentLib.setDataUpdateHandler(function(id, type, attributes, callback) {
+                id.should.equal('somelight:Light');
+                type.should.equal('Light');
+                should.exist(attributes);
+                attributes.length.should.equal(1);
+                attributes[0].name.should.equal('pressure');
+                attributes[0].value.should.equal('200');
+                handlerCalled = true;
+
+                callback(null, {
+                    id: id,
+                    type: type,
+                    attributes: attributes
+                });
+            });
+
+
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                handlerCalled.should.equal(true);
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/contextAvailabilityRequests/registerIoTAgentAttributeUpdates.json
+++ b/test/unit/contextAvailabilityRequests/registerIoTAgentAttributeUpdates.json
@@ -1,0 +1,16 @@
+{
+  "contextRegistrations": [
+    {
+      "entities": [
+        {
+          "type": "Light",
+          "isPattern": "false",
+          "id": "somelight:Light"
+        }
+      ],
+      "attributes": [],
+      "providingApplication": "http://smartGondor.com"
+    }
+  ],
+  "duration": "P1M"
+}


### PR DESCRIPTION
1) The IoT agent crashes when active attribute update arrives from Context Broker and `commands` property of the entity type is not defined. Problem lays in `contextServer.executeUpdateSideEffects` not checking if the `commands` property is defined.
2) Once that was fixed, it turned out wrong attributes were passed to client handler. In `contextServer.generateUpdateActions` they were taken from `device` instead of `contextElement`.