### PR TITLE
FIX Store callback do not return device itself

### DIFF
--- a/lib/services/deviceRegistryMemory.js
+++ b/lib/services/deviceRegistryMemory.js
@@ -42,7 +42,7 @@ function storeDevice(newDevice, callback) {
         registeredDevices[newDevice.id].creationDate = Date.now();
 
         logger.debug(context, 'Storing device with id [%s] and type [%s]', newDevice.id, newDevice.type);
-        callback(null);
+        callback(null, newDevice);
     }
 }
 


### PR DESCRIPTION
Fix callback in the store() function of the Memory Registry (didn't return the device).