### PR TITLE
Task/globally installable commands

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Add package.json bin information to publish library commands.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "bugs": {
     "url": "https://github.com/telefonicaid/iotagent-node-lib/issues"
   },
+  "bin": {
+    "agentConsole": "bin/agentConsole.js",
+    "iotAgentTester": "bin/iotAgentTester.js"
+  },
   "main": "lib/fiware-iotagent-lib",
   "engines": {
     "node": ">=0.10.8"


### PR DESCRIPTION
Add `bin` attribute to the package.json to make the commands provided by the library globally installable.