### PR TITLE
FIX Return menaingful JSON error

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- FIX Return meaningful JSON error in ENTITY_GENERIC_ERROR.

--- a/lib/services/ngsiParser.js
+++ b/lib/services/ngsiParser.js
@@ -214,8 +214,7 @@ function getErrorField(body) {
     if (body && body.contextResponses &&
         body.contextResponses[0] && body.contextResponses[0] &&
         body.contextResponses[0].statusCode && body.contextResponses[0].statusCode.code !== '200') {
-        errorField = body.contextResponses[0].statusCode.reasonPhrase +
-        ': ' + body.contextResponses[0].statusCode.details;
+        errorField = body.contextResponses[0].statusCode;
     }
 
     return errorField;


### PR DESCRIPTION
Return a meaningful JSON object in ENTITY_GENERIC_ERROR, instead of a concatenation of two of the fields.