### PR TITLE
Task/discriminate between application and transport errors

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- ADD Discrimination between transport and application error codes.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -32,10 +32,11 @@ module.exports = {
         this.name = 'UNREGISTRATION_ERROR';
         this.message = 'Error unregistering context provider for device: ' + id + ' of type: ' + type;
     },
-    EntityGenericError: function(id, type, details) {
+    EntityGenericError: function(id, type, details, code) {
         this.name = 'ENTITY_GENERIC_ERROR';
         this.message = 'Error accesing entity data for device: ' + id + ' of type: ' + type;
         this.details = details || {};
+        this.code = code || 200;
     },
     EntityNotFound: function(id) {
         this.name = 'ENTITY_NOT_FOUND';

--- a/lib/services/ngsiService.js
+++ b/lib/services/ngsiService.js
@@ -93,9 +93,8 @@ function generateNGSIOperationHandler(operationName, entityName, typeInformation
             logger.debug(context, 'Unknown error executing ' + operationName + ' operation');
 
             callback(new errors.EntityGenericError(entityName, typeInformation.type, {
-                code: response.statusCode,
                 details: body
-            }));
+            }, response.statusCode));
         }
     };
 }

--- a/test/unit/active-devices-test.js
+++ b/test/unit/active-devices-test.js
@@ -255,8 +255,8 @@ describe('Active attributes test', function() {
                 should.exist(error.name);
                 error.name.should.equal('ENTITY_GENERIC_ERROR');
                 should.exist(error.details);
-                should.exist(error.details.code);
-                error.details.code.should.equal(500);
+                should.exist(error.code);
+                error.code.should.equal(500);
                 done();
             });
         });


### PR DESCRIPTION
Discriminet the status code of the errors between application and transport errors (current approach of using the same attribute is misleading).