### PR TITLE
Fix bug when trying to stop an unstarted agent

### DIFF
--- a/lib/services/northBound/northboundServer.js
+++ b/lib/services/northBound/northboundServer.js
@@ -117,7 +117,9 @@ function start(config, callback) {
 function stop(callback) {
     logger.info(context, 'Stopping IoT Agent');
 
-    northboundServer.server.close(callback);
+    if (northboundServer) {
+        northboundServer.server.close(callback);
+    }
 }
 
 exports.setUpdateHandler = contextServer.setUpdateHandler;


### PR DESCRIPTION
agentConsole.js crashed violently when issuing a *stop* command and no *start* command had been performed.