### PR TITLE
FIX Add service and subservice headers in remove device

### DIFF
--- a/bin/iotAgentTester.js
+++ b/bin/iotAgentTester.js
@@ -438,7 +438,10 @@ function removeProvisioned(commands) {
     var options = {
         uri: 'http://' + configIot.host + ':' + configIot.port + '/iot/devices/' + commands[0],
         method: 'DELETE',
-        headers: {}
+        headers: {
+            'fiware-service': configIot.service,
+            'fiware-servicepath': configIot.subservice
+        }
     };
 
     if (token) {
@@ -544,7 +547,7 @@ function removeGroup(commands) {
     request(options, function(error, result, body) {
         if (error) {
             console.log('Couldn\'t connect with the provisioning server: ' + error.toString());
-        } else if (result.statusCode === 200 && body) {
+        } else if (result.statusCode === 200) {
             console.log('Device group for subservice [%s] removed successfully', configIot.subservice);
         } else {
             console.log('Unexpected application error. Status: ' + result.statusCode);


### PR DESCRIPTION
Remove device operation in the IoT Agent client won't work through authenticated PEP Proxies, as no fiware-service and fiware-servicepath headers were sent.