### PR TITLE
Task/include groups in clear all

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Add groupRegistry.clear() to the clearAll function.

--- a/lib/fiware-iotagent-lib.js
+++ b/lib/fiware-iotagent-lib.js
@@ -86,7 +86,12 @@ function doActivate(newConfig, callback) {
         groupRegistry = require('./services/groups/groupRegistryMemory');
     }
 
-    exports.clearAll = registry.clear;
+    exports.clearAll = function(callback) {
+        async.series([
+            registry.clear,
+            groupRegistry.clear
+        ], callback);
+    };
 
     async.series([
         apply(registry.init, newConfig),


### PR DESCRIPTION
Clear also the Group registry (not only the Device registry) in the library's clearAll() function.