### PR TITLE
FIX Queries to the registries based on service

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -11,3 +11,5 @@
 - Fix List devices: the returned count value should be the total count of registered devices (#199).
 - Fix Asking for the list of configurations of a subservice return results for all services #(209).
 - Fix Integrate Node.js IOTAgents with the IOTA Manager (and the administration portal) (#159).
+- Fix Service based filtering in MongoDB registries won't work.
+

--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -112,7 +112,7 @@ function removeDevice(id, callback) {
  */
 function listDevices(service, subservice, limit, offset, callback) {
     var condition = {},
-        query = Device.model.find(condition).sort();
+        query;
 
     if (service) {
         condition.service = service;
@@ -121,6 +121,8 @@ function listDevices(service, subservice, limit, offset, callback) {
     if (subservice) {
         condition.subservice = subservice;
     }
+
+    query = Device.model.find(condition).sort();
 
     if (limit) {
         query.limit(parseInt(limit, 10));

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -101,11 +101,13 @@ function createGroup(group, callback) {
  */
 function listGroups(service, limit, offset, callback) {
     var condition = {},
-        query = Group.model.find(condition).sort();
+        query;
 
     if (service) {
         condition.service = service;
     }
+
+    query = Group.model.find(condition).sort();
 
     if (limit) {
         query.limit(parseInt(limit, 10));


### PR DESCRIPTION
Queries to the MongoDB registries based on service was not working (the condition was stablished after the query was executed).