### PR TITLE
Move defaultResource attribute to config root

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,8 @@ have implications in the use of attributes with Context Providers, so this flag 
 * **dieOnUnexpectedError**: if this flag is activated, the IoTAgent will not capture global exception, thus dying upon any unexpected error.
 * **singleConfigurationMode**: enables the Single Configuration mode for backwards compatibility (see description in the Overview). Default to false.
 * **timestamp**: if this flag is activated, the IoT Agent will add a 'TimeInstant' metadata attribute to all the attributes updateded from device information. 
+* **defaultResource**: default string to use as resource for the registration of new Configurations (if no resource is provided).
+
 
 ## <a name="aboutapi"/> About API
 The library provides a simple operation to retrieve information about the library and the IoTA using it. A GET request

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -30,5 +30,7 @@ module.exports = {
     SUBSERVICE_HEADER: 'fiware-servicepath',
 
     COMMAND_STATUS: 'commandStatus',
-    COMMAND_RESULT: 'commandResult'
+    COMMAND_RESULT: 'commandResult',
+
+    DEFAULT_RESOURCE: '/iot/d'
 };

--- a/lib/services/common/iotManagerService.js
+++ b/lib/services/common/iotManagerService.js
@@ -26,6 +26,7 @@
 var request = require('request'),
     async = require('async'),
     errors = require('../../errors'),
+    constants = require('../../constants'),
     config = require('../../commonConfig'),
     intoTrans = require('../common/domain').intoTrans,
     logger = require('logops'),
@@ -70,7 +71,7 @@ function register(callback) {
                 protocol: config.getConfig().iotManager.protocol,
                 description: config.getConfig().iotManager.description,
                 iotagent: config.getConfig().providerUrl + '/iot',
-                resource: config.getConfig().iotManager.defaultResource,
+                resource: config.getConfig().defaultResource || constants.DEFAULT_RESOURCE,
                 services: services
             }
         };
@@ -89,7 +90,7 @@ function register(callback) {
     }
 
     function checkConfiguration(callback) {
-        var attributes = ['protocol', 'description', 'defaultResource'],
+        var attributes = ['protocol', 'description'],
             missing = [];
 
         if (!config.getConfig().providerUrl) {

--- a/test/unit/general/iotam-autoregistration-test.js
+++ b/test/unit/general/iotam-autoregistration-test.js
@@ -65,9 +65,9 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
             port: 9876,
             path: '/protocols',
             protocol: 'GENERIC_PROTOCOL',
-            description: 'A generic protocol',
-            defaultResource: '/iot/d'
-        }
+            description: 'A generic protocol'
+        },
+        defaultResource: '/iot/d'
     },
     groupCreation = {
         service: 'theService',


### PR DESCRIPTION
Move defaultResource attribute from the IoTManager section to config root (as it may be used in situations where an IoTManager is not needed).