### PR TITLE
FIX Missing transport in MongoDB registers

### DIFF
--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -64,6 +64,7 @@ var async = require('async'),
  * NGSI Service for the registration.
  */
 function handleProvision(req, res, next) {
+
     function handleProvisioningFinish(error, results) {
         if (error) {
             logger.debug('Device provisioning failed due to the following error: ', error.message);
@@ -82,26 +83,26 @@ function handleProvision(req, res, next) {
         }
     }
 
-    function registerDevice(service, subservice, body, callback) {
-        /*jshint sub:true */
-        deviceService.register({
-                id: body['device_id'],
-                type: body['entity_type'],
-                name: body['entity_name'],
-                service: service,
-                subservice: subservice,
-                active: body['attributes'],
-                staticAttributes: body['static_attributes'],
-                lazy: body['lazy'],
-                commands: body['commands'],
-                timezone: body['timezone'],
-                endpoint: body['endpoint'],
-                internalAttributes: body['internal_attributes'],
-                protocol: body['protocol'],
-                transport: body['transport'],
-                internalId: null
-            },
-            callback);
+    function fillDeviceData(service, subservice, body, callback) {
+        /* jshint sub: true */
+
+        callback(null, {
+            id: body['device_id'],
+            type: body['entity_type'],
+            name: body['entity_name'],
+            service: service,
+            subservice: subservice,
+            active: body['attributes'],
+            staticAttributes: body['static_attributes'],
+            lazy: body['lazy'],
+            commands: body['commands'],
+            timezone: body['timezone'],
+            endpoint: body['endpoint'],
+            internalAttributes: body['internal_attributes'],
+            protocol: body['protocol'],
+            transport: body['transport'],
+            internalId: null
+        });
     }
 
     function provisionSingleDevice(device, callback) {
@@ -109,8 +110,9 @@ function handleProvision(req, res, next) {
             apply(statsRegistry.add, 'deviceCreationRequests', 1),
             apply(restUtils.checkMandatoryQueryParams,
                 ['device_id'], device),
-            apply(registerDevice, req.headers['fiware-service'], req.headers['fiware-servicepath']),
-            applyProvisioningHandler
+            apply(fillDeviceData, req.headers['fiware-service'], req.headers['fiware-servicepath']),
+            applyProvisioningHandler,
+            deviceService.register
         ], callback);
     }
 


### PR DESCRIPTION
Missing transport attribute in MongoDB registers due to the order of insertion in the device provisioning handlers: modifying the value in the device object doesn't reflect in MongoDB (as the save instruction is executed before the handler).