### PR TITLE
ADD Mosquitto Docker files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:7
+
+COPY aclfile /root/
+COPY startMosquitto.sh /bin
+
+RUN yum update -y && yum install -y wget \
+  && wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-7.noarch.rpm && yum localinstall -y --nogpgcheck epel-release-7-7.noarch.rpm \
+  && yum install -y npm git \
+  && yum install -y mosquitto\
+  && mkdir /var/log/mosquitto\
+  && chown mosquitto:mosquitto /var/log/mosquitto\
+  && touch /etc/mosquitto/pwfile\
+  && mv /etc/mosquitto/mosquitto.conf.example /etc/mosquitto/mosquitto.conf\
+  && sed -i '$ i acl_file /etc/mosquitto/aclfile\npassword_file /etc/mosquitto/pwfile' /etc/mosquitto/mosquitto.conf\
+  && mv /root/aclfile /etc/mosquitto/aclfile
+
+EXPOSE 1883
+
+ENTRYPOINT /bin/startMosquitto.sh

--- a/docker/aclfile
+++ b/docker/aclfile
@@ -1,0 +1,12 @@
+topic read $SYS/#
+
+topic write /+/+/attributes
+topic write /+/+/attributes/#
+topic write /+/+/configuration/commands
+topic read /+/+/configuration/values
+
+user iota
+topic /#
+
+pattern write $SYS/broker/connection/%c/state
+

--- a/docker/startMosquitto.sh
+++ b/docker/startMosquitto.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+mosquitto_passwd -b /etc/mosquitto/pwfile iota ${IOTA_PASS}
+/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
Create a Mosquitto Docker image to use with the IoT Agents accepting MQTT.