### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/services/common/domain.js
+++ b/lib/services/common/domain.js
@@ -25,7 +25,7 @@
 
 var domain = require('domain'),
     constants = require('../../constants'),
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     logger = require('logops'),
     context = {
         op: 'IoTAgentNGSI.DomainControl'

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -26,7 +26,7 @@
 var request = require('request'),
     async = require('async'),
     apply = async.apply,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     constants = require('../../constants'),
     domain = require('domain'),
     intoTrans = require('../common/domain').intoTrans,

--- a/package.json
+++ b/package.json
@@ -35,19 +35,19 @@
     "async": "^0.9.0",
     "body-parser": "^1.11.0",
     "command-shell-lib": "1.0.0",
-    "jison": "0.4.17",
     "express": "^4.11.2",
+    "jison": "0.4.17",
     "logops": "1.0.0",
+    "mongodb": "2.1.18",
     "mongoose": "4.6.8",
     "mu2": "^0.5.20",
     "mustache": "0.8.2",
-    "node-uuid": "^1.4.1",
     "request": "^2.39.0",
     "revalidator": "^0.3.1",
     "sax": "^0.6.0",
     "underscore": "^1.7.0",
-    "xmldom": "0.1.19",
-    "mongodb": "2.1.18"
+    "uuid": "^3.0.0",
+    "xmldom": "0.1.19"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.