### PR TITLE
log releasing alarm as error instead of info in order to not loose it…

### DIFF
--- a/lib/services/common/alarmManagement.js
+++ b/lib/services/common/alarmManagement.js
@@ -53,7 +53,7 @@ function raise(alarmName, description) {
 function release(alarmName) {
     if (alarmRepository[alarmName]) {
         delete alarmRepository[alarmName];
-        logger.info(context, 'Releasing [%s]', alarmName);
+        logger.error(context, 'Releasing [%s]', alarmName);
     }
 }
 


### PR DESCRIPTION
log releasing alarm as error instead of info in order to not loose it when loglevel is error

Fixes: https://github.com/telefonicaid/iotagent-node-lib/issues/532


