### PR TITLE
Step: 2.5.0 -> 2.5.0-next

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,0 @@
-- Fix mustache dependence version to 2.2.1 due to detected medium vulnerability
-- Alarm raises with null error (#521)
-- Capture Mongo DB connection errors
-- Update MongoDB driver in order to fix NODE-818 error (#545)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-node-lib",
   "description": "IoT Agent library to interface with NGSI Context Broker",
-  "version": "2.5.0",
+  "version": "2.5.0-next",
   "homepage": "https://github.com/telefonicaid/iotagent-node-lib",
   "keywords": [
     "fiware",


### PR DESCRIPTION
Prepares for the next development cycle. Similar to what it was done last time, see PR https://github.com/telefonicaid/iotagent-node-lib/pull/518/files