### PR TITLE
fix command name in logs

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Fix command name in some commands logs
 - Upgrade mongoose dependence version to 4.13.3

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Fix command name in some commands logs
+- Fix command name in some commands logs at debug log level
 - Upgrade mongoose dependence version to 4.13.3

--- a/lib/services/commands/commandService.js
+++ b/lib/services/commands/commandService.js
@@ -49,13 +49,13 @@ function addCommand(service, subservice, deviceId, command, callback) {
 }
 
 function updateCommand(service, subservice, deviceId, name, value, callback) {
-    logger.debug(context, 'Updating command [%] for device [%s] with value [%s]', deviceId, name, value);
+    logger.debug(context, 'Updating command [%s] for device [%s] with value [%s]', name, deviceId, value);
 
     config.getCommandRegistry().update(service, subservice, deviceId, value, callback);
 }
 
 function removeCommand(service, subservice, deviceId, name, callback) {
-    logger.debug(context, 'Removing command [%] from device [%s]', deviceId, name);
+    logger.debug(context, 'Removing command [%s] from device [%s]', name, deviceId);
 
     config.getCommandRegistry().remove(service, subservice, deviceId, name, callback);
 }


### PR DESCRIPTION
Fix logs like:
```
time=2017-12-19T07:46:13.725Z | lvl=DEBUG | corr=7157c7c7-796a-4ff8-bbfe-443fdc9ef606 | trans=7157c7c7-796a-4ff8-bbfe-443fdc9ef606 | op=IoTAgentNGSI.CommandService | srv=tsol_poc | subsrv=/pruebas | msg=Removing command [%] from device [disp4] | comp=IoTAgent respuesta
```