### PR TITLE
Release/2.5.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix mustache dependence version to 2.2.1 due to detected medium vulnerability
 - Alarm raises with null error (#521)
 - Capture Mongo DB connection errors
 - Update MongoDB driver in order to fix NODE-818 error (#545)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Upgrade mongoose to 4.13.3
 - Fix mustache dependence version to 2.2.1 due to detected medium vulnerability
 - Alarm raises with null error (#521)
 - Capture Mongo DB connection errors

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-node-lib",
   "description": "IoT Agent library to interface with NGSI Context Broker",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "homepage": "https://github.com/telefonicaid/iotagent-node-lib",
   "keywords": [
     "fiware",
@@ -38,7 +38,7 @@
     "jison": "0.4.17",
     "express": "^4.11.2",
     "logops": "1.0.0",
-    "mongoose": "4.6.8",
+    "mongoose": "4.13.3",
     "mu2": "^0.5.20",
     "mustache": "2.2.1",
     "node-uuid": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iotagent-node-lib",
   "description": "IoT Agent library to interface with NGSI Context Broker",
-  "version": "2.4.0-next",
+  "version": "2.5.0",
   "homepage": "https://github.com/telefonicaid/iotagent-node-lib",
   "keywords": [
     "fiware",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "logops": "1.0.0",
     "mongoose": "4.6.8",
     "mu2": "^0.5.20",
-    "mustache": "0.8.2",
+    "mustache": "2.2.1",
     "node-uuid": "^1.4.1",
     "request": "2.39.0 - 2.81.0",
     "revalidator": "^0.3.1",


### PR DESCRIPTION
the proposed modification in #544 works OK 👍 
The bug seems to be in file **lib/services/devices/deviceService.js**, function findConfigurationGroup:

        config.getGroupRegistry().findBy(['service', 'subservice', 'type'])(
            deviceObj.service,
            deviceObj.subservice,
            deviceObj.type,
            handlerGroupFind);
Using the following function instead, auto provisioning works fine:

        config.getGroupRegistry().findType(
            deviceObj.service,
            deviceObj.subservice,
            deviceObj.type,
            handlerGroupFind);
grunt test is OK
Thanks to integrate it as soon as possible