### PR TITLE
Task/support https configuration

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,4 @@
 - FIX Automatic device provisioning by means of Configuration Group fails due to a bug in findConfigurationGroup function (#544).
 - FIX Static attributes seem not supported in Configuration Group provisioning (#550).
+- Add: support for HTTPS requests toward CB (if IOTA_CB_URL is used) (#578)
+- Add: support HTTPS requests toward IOTAManager (if IOTA_IOTAM_URL is used) (#578)

--- a/doc/installationguide.md
+++ b/doc/installationguide.md
@@ -98,6 +98,7 @@ The following table shows the accepted environment variables, as well as the con
 
 | Environment variable      | Configuration attribute             |
 |:------------------------- |:----------------------------------- |
+| IOTA_CB_URL               | contextBroker.url                   |
 | IOTA_CB_HOST              | contextBroker.host                  |
 | IOTA_CB_PORT              | contextBroker.port                  |
 | IOTA_NORTH_HOST           | server.host                         |
@@ -106,6 +107,7 @@ The following table shows the accepted environment variables, as well as the con
 | IOTA_REGISTRY_TYPE        | deviceRegistry.type                 |
 | IOTA_LOG_LEVEL            | logLevel                            |
 | IOTA_TIMESTAMP            | timestamp                           |
+| IOTA_IOTAM_URL            | iotManager.url                      |
 | IOTA_IOTAM_HOST           | iotManager.host                     |
 | IOTA_IOTAM_PORT           | iotManager.port                     |
 | IOTA_IOTAM_PATH           | iotManager.path                     |

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -47,7 +49,8 @@ function anyIsSet(variableSet) {
  */
 function processEnvironmentVariables() {
     var environmentVariables = [
-            'IOTA_CB_HOST',
+             'IOTA_CB_URL',
+             'IOTA_CB_HOST',
              'IOTA_CB_PORT',
              'IOTA_NORTH_HOST',
              'IOTA_NORTH_PORT',
@@ -88,12 +91,13 @@ function processEnvironmentVariables() {
         }
     }
 
-    if (process.env.IOTA_CB_HOST) {
-        config.contextBroker.host = process.env.IOTA_CB_HOST;
-    }
-
-    if (process.env.IOTA_CB_PORT) {
-        config.contextBroker.port = process.env.IOTA_CB_PORT;
+    if (process.env.IOTA_CB_URL) {
+        config.contextBroker.url = process.env.IOTA_CB_URL;
+    } else if (process.env.IOTA_CB_HOST) {
+        config.contextBroker.url = "http://" + process.env.IOTA_CB_HOST;
+        if (process.env.IOTA_CB_PORT) {
+            config.contextBroker.url += ":" + process.env.IOTA_CB_PORT;
+        }
     }
 
     if (process.env.IOTA_NORTH_HOST) {
@@ -130,12 +134,13 @@ function processEnvironmentVariables() {
         config.iotManager = {};
     }
 
-    if (process.env.IOTA_IOTAM_HOST) {
-        config.iotManager.host = process.env.IOTA_IOTAM_HOST;
-    }
-
-    if (process.env.IOTA_IOTAM_PORT) {
-        config.iotManager.port = process.env.IOTA_IOTAM_PORT;
+    if (process.env.IOTA_IOTAM_URL) {
+        config.iotManager.url = process.env.IOTA_IOTAM_URL;
+    } else if (process.env.IOTA_IOTAM_HOST) {
+        config.iotManager.url = "http://" + process.env.IOTA_IOTAM_HOST;
+        if (process.env.IOTA_IOTAM_PORT) {
+            config.iotManager.url += ":" + process.env.IOTA_IOTAM_PORT;
+        }
     }
 
     if (process.env.IOTA_IOTAM_PATH) {

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -70,6 +70,7 @@ function processEnvironmentVariables() {
              'IOTA_MONGO_REPLICASET'
         ],
         iotamVariables = [
+            'IOTA_IOTAM_URL',
             'IOTA_IOTAM_HOST',
             'IOTA_IOTAM_PORT',
             'IOTA_IOTAM_PATH',

--- a/lib/fiware-iotagent-lib.js
+++ b/lib/fiware-iotagent-lib.js
@@ -82,6 +82,22 @@ function doActivate(newConfig, callback) {
 
     logger.format = logger.formatters.pipe;
 
+    if (newConfig.contextBroker) {
+        if (! newConfig.contextBroker.url && newConfig.contextBroker.host && newConfig.contextBroker.port) {
+            newConfig.contextBroker.url = "http://" + newConfig.contextBroker.host + ":" + newConfig.contextBroker.port;
+        } else if (! newConfig.contextBroker.url && newConfig.contextBroker.host && !newConfig.contextBroker.port) {
+            newConfig.contextBroker.url = "http://" + newConfig.contextBroker.host;
+        }
+    }
+
+    if (newConfig.iotManager) {
+        if (! newConfig.iotManager.url && newConfig.iotManager.host && newConfig.iotManager.port ) {
+            newConfig.iotManager.url = "http://" + newConfig.iotManager.host + ":" + newConfig.iotManager.port;
+        } else if (! newConfig.iotManager.url && newConfig.iotManager.host && !newConfig.iotManager.port ) {
+            newConfig.iotManager.url = "http://" + newConfig.iotManager.host;
+        }
+    }
+
     config.setConfig(newConfig);
 
     logger.getContext = function domainContext() {

--- a/lib/services/common/iotManagerService.js
+++ b/lib/services/common/iotManagerService.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -66,8 +68,7 @@ function register(callback) {
 
     function sendRegistration(services, callback) {
         var options = {
-            url: 'http://' + config.getConfig().iotManager.host + ':' +
-                config.getConfig().iotManager.port + config.getConfig().iotManager.path,
+            url: config.getConfig().iotManager.url + config.getConfig().iotManager.path,
             method: 'POST',
             json: {
                 protocol: config.getConfig().iotManager.protocol,

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -124,7 +124,7 @@ function getInitialValueForType(type) {
  */
 function createInitialEntity(deviceData, newDevice, callback) {
     var options = {
-            url: config.getConfig().config.contextBroker.url + '/v1/updateContext',
+            url: config.getConfig().contextBroker.url + '/v1/updateContext',
             method: 'POST',
             json: {
                 contextElements: [

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -122,8 +124,7 @@ function getInitialValueForType(type) {
  */
 function createInitialEntity(deviceData, newDevice, callback) {
     var options = {
-            url: 'http://' + config.getConfig().contextBroker.host + ':' + config.getConfig().contextBroker.port +
-                '/v1/updateContext',
+            url: config.getConfig().config.contextBroker.url + '/v1/updateContext',
             method: 'POST',
             json: {
                 contextElements: [

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ * 
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -86,8 +88,7 @@ function createRegistrationHandler(unregister, deviceData, callback) {
  */
 function sendRegistrations(unregister, deviceData, callback) {
     var options = {
-        url: 'http://' + config.getConfig().contextBroker.host + ':' +
-        config.getConfig().contextBroker.port + '/NGSI9/registerContext',
+        url: config.getConfig().config.contextBroker.url + '/NGSI9/registerContext',
         method: 'POST',
         json: {
             contextRegistrations: [

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -88,6 +88,7 @@ function createRegistrationHandler(unregister, deviceData, callback) {
  */
 function sendRegistrations(unregister, deviceData, callback) {
     var options = {
+        url: config.getConfig().contextBroker.url + '/NGSI9/registerContext',
         method: 'POST',
         json: {
             contextRegistrations: [

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -88,7 +88,6 @@ function createRegistrationHandler(unregister, deviceData, callback) {
  */
 function sendRegistrations(unregister, deviceData, callback) {
     var options = {
-        url: config.getConfig().config.contextBroker.url + '/NGSI9/registerContext',
         method: 'POST',
         json: {
             contextRegistrations: [

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -116,7 +116,7 @@ function generateNGSIOperationHandler(operationName, entityName, typeInformation
  * @return {Object}                    Containing all the information of the request but the payload.c
  */
 function createRequestObject(url, typeInformation, token) {
-    var cbHost = config.getConfig().config.contextBroker.url,
+    var cbHost = config.getConfig().contextBroker.url,
         options,
         serviceContext = {},
         headers = {

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -114,7 +116,7 @@ function generateNGSIOperationHandler(operationName, entityName, typeInformation
  * @return {Object}                    Containing all the information of the request but the payload.c
  */
 function createRequestObject(url, typeInformation, token) {
-    var cbHost = 'http://' + config.getConfig().contextBroker.host + ':' + config.getConfig().contextBroker.port,
+    var cbHost = config.getConfig().config.contextBroker.url,
         options,
         serviceContext = {},
         headers = {

--- a/lib/services/ngsi/subscriptionService.js
+++ b/lib/services/ngsi/subscriptionService.js
@@ -201,7 +201,7 @@ function unsubscribe(device, id, callback) {
     } else if (device.cbHost && device.cbHost.indexOf("://") == -1) {
         options.uri = "http://" + device.cbHost + '/v1/unsubscribeContext';
     } else {
-        options.uri = config.getConfig().config.contextBroker.url + '/v1/unsubscribeContext';
+        options.uri = config.getConfig().contextBroker.url + '/v1/unsubscribeContext';
     }
 
     request(options, createUnsuscribeHandler(device, id, callback));

--- a/lib/services/ngsi/subscriptionService.js
+++ b/lib/services/ngsi/subscriptionService.js
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Federico M. Facca - Martel Innovate
  */
 
 'use strict';
@@ -194,11 +196,12 @@ function unsubscribe(device, id, callback) {
 
     };
 
-    if (device.cbHost) {
-        options.uri = 'http://' + device.cbHost + '/v1/unsubscribeContext';
+    if (device.cbHost && device.cbHost.indexOf("://") !== -1) {
+        options.uri = device.cbHost + '/v1/unsubscribeContext';
+    } else if (device.cbHost && device.cbHost.indexOf("://") == -1) {
+        options.uri = "http://" + device.cbHost + '/v1/unsubscribeContext';
     } else {
-        options.uri = 'http://' + config.getConfig().contextBroker.host + ':' + config.getConfig().contextBroker.port +
-            '/v1/unsubscribeContext';
+        options.uri = config.getConfig().config.contextBroker.url + '/v1/unsubscribeContext';
     }
 
     request(options, createUnsuscribeHandler(device, id, callback));

--- a/test/unit/general/startup-test.js
+++ b/test/unit/general/startup-test.js
@@ -147,16 +147,14 @@ describe('Startup tests', function() {
 
         it('should not start and raise a MISSING_CONFIG_PARAMS error', function(done) {
             iotAgentLib.activate(iotAgentConfig, function(error) {
-                config.getConfig().contextBroker.host.should.equal('cbhost');
-                config.getConfig().contextBroker.port.should.equal('1111');
+                config.getConfig().contextBroker.url.should.equal('http://cbhost:1111');
                 config.getConfig().server.host.should.equal('localhost');
                 config.getConfig().server.port.should.equal('2222');
                 config.getConfig().providerUrl.should.equal('prvider:3333');
                 config.getConfig().deviceRegistry.type.should.equal('mongo');
                 config.getConfig().logLevel.should.equal('FATAL');
                 config.getConfig().timestamp.should.equal(true);
-                config.getConfig().iotManager.host.should.equal('iotamhost');
-                config.getConfig().iotManager.port.should.equal('4444');
+                config.getConfig().iotManager.url.should.equal('http://iotamhost:4444');
                 config.getConfig().iotManager.path.should.equal('/iotampath');
                 config.getConfig().iotManager.protocol.should.equal('PDI_PROTOCOL');
                 config.getConfig().iotManager.description.should.equal('The IoTAM Protocol');


### PR DESCRIPTION
* Add support for https based backends for contextBroker and IoTAgent Manager (fix  #578)

This is achieved by adding a new configuration variable URL that if present replace HOST and PORT configurations (these are maintained for backward compatibility). When URL is not specified, it is computed as it was computed in the previous version http:// + HOST + ":" + PORT.

Grunt test passed (i have quite a number of weird messages about mongo, but they appear running grunt also without my commits, so they are unrelated).

```
ubuntu@ubuntu:/media/sf_Code/city-of-data/iotagent-node-lib$ grunt test
Running "mochaTest:unit" (mochaTest) task


  Expression interpreter
    When a expression with a single value is parsed
      ✓ should return that value
    When an expression with the arithmetic operation [5 * @value] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [(6 + @value) * 3] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [@value / 12 + 1] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [(5 + 2) * (@value + 7)] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [(5 - @other) * (@value + 7)] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [3 * 5.2] is parsed
      ✓ should be interpreted appropriately
    When an expression with the arithmetic operation [@value * 5.2] is parsed
      ✓ should be interpreted appropriately
    When an expression with two strings is concatenated
      ✓ should return the concatenation of both strings
    When string transformation functions are executed
      ✓ should return the appropriate piece of the string
    When an expression contains variables with numbers
      ✓ should return the appropriate result
    When an expression contains multiple parenthesis
      ✓ should return the appropriate result
    When trim() function is executed
      ✓ should return the appropriate piece of the string
    When an expression with strings containing spaces is concatenated
      ✓ should honour the whitespaces
    When an expression with strings with single quotation marks is parsed
      ✓ should accept the strings
    When a string is concatenated with a number
      ✓ should result in a string concatenation
    When an expression with a wrong type is parsed
      ✓ should raise a WRONG_EXPRESSION_TYPE error
    When an expression with a parse error is parsed
      ✓ should raise an INVALID_EXPRESSION error
    When an string function is used with an expression
      ✓ should work on the expression value

  Expression-based transformations plugin
    When an update comes for attributes with expressions
      ✓ should apply the expression before sending the values
    When an update comes for expressions with syntax errors
      ✓ should apply the expression before sending the values
    When there are expression attributes that are just calculated (not sent by the device)
      ✓ should calculate them and add them to the payload
    When an expression with multiple variables with numbers arrive
      ✓ should calculate it and add it to the payload
    When a measure arrives and there is not enough information to calculate an expression
      ✓ should not calculate the expression

  Alarm management system
    When a new alarm is raised
      ✓ should add it to the list of risen alarms
    When a new alarm is raised multiple times
      ✓ should only add it once to the risen alarms list
    When an alarm is released
      ✓ should disappear from the alarms list
      ✓ should not affect other alarms
    When the alarm instrumentation function is used on a function
      ✓ should release the alarm if the function returns a non-error result
      ✓ should raise the alarm if the funciton returns an error result
    When an instrumented function calls the callback with a null value
      ✓ should not raise the alarm

  Secured access to the Context Broker
    When a measure is sent to the Context Broker via an Update Context operation
      ✓ should ask Keystone for a token based on the trust token
      ✓ should send the generated token in the x-auth header
    When a measure is sent to the Context Broker and the access is forbidden
      ✓ it should return a ACCESS_FORBIDDEN error to the caller
    When a measure is sent and the trust is rejected asking for the token
      ✓ it should return a AUTHENTICATION_ERROR error to the caller
    When the user requests information about a device in a protected CB
      ✓ should send the Auth Token along with the information query

  Device Service: utils
    When an existing device tries to be retrieved with retrieveOrCreate()
      ✓ should return the existing device
    When an unexisting device tries to be retrieved for an existing APIKey
      ✓ should register the device and return it
    When an unexisting device tries to be retrieved for an unexisting APIKey
      ✓ should raise an error

  IoT Manager autoregistration
    When the IoT Agent is started without a "iotManager" config parameter and empty services
      ✓ should register itself to the provided IoT Manager URL
    When the IoT Agents is started with "iotManager" config with missing attributes
      ✓ should fail with a MISSING_CONFIG_PARAMS error
    When the IoT Agents is started with "iotManager" config and multiple services
      ✓ should send all the service information to the IoT Manager in the registration
    When a new service is created in the IoT Agent
      ✓ should update the registration in the IoT Manager
    When a service is removed from the IoT Agent
      ✓ should update the registration in the IoT Manager
    When a new service with static attributes is created in the IoT Agent
      ✓ should update the registration in the IoT Manager

  Log level API
    When a new valid log level request comes to the API
      ✓ the real log level should be changed
    When the current log level is requested
      ✓ should return a 200 OK
      ✓ should return the current log level
    When a new log level request comes to the API with an invalid level
      ✓ should return a 400 error indicating the log level is not valid
    When a new log level request comes to the API without a log level
      ✓ should return a 400 error indicating the log level is missing

  MongoDB migration
    When the full migration command is executed for two databases
      ✓ should migrate all the services (48ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:8681) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
      ✓ should migrate all the devices (47ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 3)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
      ✓ should migrate all the fields for each device (42ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 5)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
      ✓ should migrate all the fields for each service (43ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 7)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 8)
    When a service migration command is executed
      ✓ should migrate just the service's  configurations (44ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 9)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 10)
      ✓ should migrate just the service's devices (43ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 11)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 12)
    When a device has an empty string in its name
      ✓ should set the name as undefined (44ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 13)
    When a subservice migration command is executed
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 14)
      ✓ should migrate just the subservice's devices
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 15)
    When a subservice migration configuration has a protocol translation table
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 16)
      ✓ should change the protocol to the translated one
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 17)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 18)

  Startup tests
    When the IoT Agent is started without a "providerUrl" config parameter
      ✓ should not start and raise a MISSING_CONFIG_PARAMS error
    When the IoT Agent is started without a "types" attribute
      ✓ should not start and raise a MISSING_CONFIG_PARAMS error
    When the IoT Agent is started with environment variables
      ✓ should not start and raise a MISSING_CONFIG_PARAMS error

  Statistics persistence service
    When a periodic persitence action is set
      ✓ should store all the records in the database (205ms)

  Statistics service
    When a new statistic is updated with add()
      ✓ should appear the modified value in the getCurrent() statistics
      ✓ should add the value to the global values
    When the global statistics are requested
      ✓ should return all the statistics that were created
    When the current statistics are reset
      ✓ should return a value of zero for any of the individual statistics
    When a new periodic stats action is set
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 19)
      ✓ should be triggered with the periodicity stated in the config.stats.interval parameter (485ms)

  Update attribute functionalities
    When a attribute update arrives to the IoT Agent as Context Provider
      ✓ should call the client handler with correct values, even if commands are not defined
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 20)

  Command functionalities
    When a device is preregistered with commands
      ✓ should register as Context Provider of the commands
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 21)
    When a command update arrives to the IoT Agent as Context Provider
      ✓ should call the client handler
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 22)
      ✓ should create the attribute with the "_status" prefix in the Context Broker
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 23)
      ✓ should create the attribute with the "_status" prefix in the Context Broker
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 24)
    When an update arrives from the south bound for a registered command
      ✓ should update its value and status in the Context Broker
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 25)
    When an error command arrives from the south bound for a registered command
      ✓ should update its status in the Context Broker
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 26)

  Command registries test [memory]
    When a new command is created in the command registry
      ✓ should not cause any error
      ✓ should appear in the listings
    When a new command has expired from the registry
      ✓ should not appear in the listings (852ms)
    When an already existing command arrives to the registry
      ✓ should not give any error
      ✓ should override the old value, and change the expiration time
    When a command listing is requested for a device
      ✓ should not return any command for other devices
      ✓ should return all the fields for each command
    When a command is removed from the queue
      ✓ should not appear in the listings

  Command registries test [mongodb]
    When a new command is created in the command registry
(node:8681) DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html
      ✓ should not cause any error (151ms)
      ✓ should appear in the listings (71ms)
    When a new command has expired from the registry
      ✓ should not appear in the listings (925ms)
    When an already existing command arrives to the registry
      ✓ should not give any error
      ✓ should override the old value, and change the expiration time
    When a command listing is requested for a device
      ✓ should not return any command for other devices
      ✓ should return all the fields for each command
    When a command is removed from the queue
      ✓ should not appear in the listings

  IoT Agent Lazy Devices
    When the IoT Agent receives an update on the device data in JSON format
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 27)
      ✓ should call the device handler with the received data
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 28)
    When the IoT Agent receives an update on the device data in XML format
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 29)
      ✓ should call the device handler with the received data
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 30)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 31)
      ✓ should return the response in XML Format
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 32)
    When the IoT Agent receives a query on the device data in XML format
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 33)
      ✓ should call the device handler with the received data
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 34)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 35)
      ✓ should return the response in XML format
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 36)
    When a IoT Agent receives an update on multiple contexts
      - should call the device handler for each of the contexts
    When a context query arrives to the IoT Agent
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 37)
      ✓ should return the information querying the underlying devices
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 38)
    When a context query arrives to the IoT Agent and no handler is set
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 39)
      ✓ should not give any error
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 40)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 41)
      ✓ should return the empty value
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 42)
    When a query arrives to the IoT Agent without any attributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 43)
      ✓ should return the information of all the attributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 44)
    When a query arrives to the IoT Agent with an empty attributes array
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 45)
      ✓ should return the information of all the attributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 46)
    When a context query arrives to the IoT Agent for a type with static attributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 47)
      ✓ should return the information adding the static attributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 48)
    When a context query arrives to the IoT Agent with a payload that is not XML nor JSON
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 49)
      ✓ should fail with a 400 error
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 50)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 51)
      ✓ should return an NGSI compliant payload
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 52)
    When a context query arrives to the IoT Agent with an invalid body
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 53)
      ✓ should fail with a 400 error
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 54)
    When the IoT Agent receives an update on the device data in JSON format for a type withinternalAttributes
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 55)
      ✓ should call the device handler with the received data
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 56)

  Polling commands
    When a command update arrives to the IoT Agent for a device with polling
      ✓ should not call the client handler
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 57)
      ✓ should create the attribute with the "_status" prefix in the Context Broker
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 58)
      ✓ should store the commands in the queue
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 59)
    When a command arrives with multiple values in the value field
      ✓ should return a 200 OK both in HTTP and in the status code (45ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 60)
    When a polling command expires
      ✓ should remove it from the queue (339ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 61)
      ✓ should mark it as ERROR in the Context Broker (334ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 62)

  In memory device registry
    When a the registry is queried for a device using an arbitrary attribute
      ✓ should return the appropriate device
    When a the registry is queried for devices in multiple services
      ✓ should return all the matching devices
    When a the registry is queried for devices in a particular service
      ✓ should return all the matching devices in  that service

  MongoDB Group Registry test
    When a new device group creation request arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 63)
      ✓ should store it in the DB (46ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 64)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 65)
      ✓ should store the service information from the headers into the DB (74ms)
    When a new device group creation request arrives with an existant (apikey, resource) pair
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 66)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 67)
      ✓ should return a DUPLICATE_GROUP error (81ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 68)
    When a device group removal request arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 69)
      ✓ should remove it from the database
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 70)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 71)
      ✓ should return a 204 OK statusCode
    When a device group update request arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 72)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 73)
      ✓ should update the values in the database
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 74)
    When a multiple device group creation arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 75)
      ✓ should create the values in the database (52ms)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 76)
    When a device group listing request arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 77)
      ✓ should return all the configured device groups from the database
    When a device group listing arrives with a limit
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 78)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 79)
      ✓ should return the appropriate count of services
    When a device info request arrives
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 80)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 81)
      ✓ should return all the configured device groups from the database

  MongoDB Device Registry
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 82)
    When a new device is connected to the IoT Agent
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 83)
      ✓ should be registered in mongodb with all its attributes (62ms)
    When a device with the same Device ID tries to register to the IOT Agent
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 84)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 85)
      ✓ should be rejected with a DUPLICATE_DEVICE_ID (69ms)
    When a device with the same Device ID but different service tries to be registered
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 86)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 87)
      ✓ should accept both devices (69ms)
    When a device is removed from the IoT Agent
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 88)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 89)
      ✓ should be removed from MongoDB
    When the registry is queried for a device using an arbitrary attribute
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 90)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 91)
      ✓ should return the appropriate device
    When the list of devices is retrieved
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 92)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 93)
      ✓ should return the limited number of devices
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 94)
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 95)
      ✓ should return the total number of devices

  Active attributes test
    When the IoT Agent receives new information from a device
(node:8681) UnhandledPromiseRejectionWarning: MongoError: topology was destroyed
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:893:78
    at handleCallback (/media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/utils.js:96:12)
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb/lib/db.js:309:5
    at /media/sf_Code/city-of-data/iotagent-node-lib/node_modules/mongodb-core/lib/connection/pool.js:436:18
    at process._tickCallback (internal/process/next_tick.js:150:11)
(node:8681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 96)
      ✓ should change the value of the corresponding attribute in the context broker
    When the IoT Agent receives new information from a device and the appendMode flag is on
      ✓ should change the value of the corresponding attribute in the context broker
    When the IoT Agent receives new information and the timestamp flag is on
      ✓ should add the timestamp to the entity and all the attributes
    When the IoTA gets a set of values with a TimeInstant and the timestamp flag is on
      ✓ should not override the received instant and should not add metadatas for this request
    When the IoT Agent receives information from a device whose type doesn't have a type name
      ✓ should fail with a 500 TYPE_NOT_FOUND error
    When the Context Broker returns an HTTP error code updating an entity
      ✓ should return ENTITY_GENERIC_ERROR an error to the caller
    When the Context Broker returns an application error code updating an entity
      ✓ should return ENTITY_GENERIC_ERROR an error to the caller
    When there is a transport error connecting to the Context Broker
      ✓ should return a ENTITY_GENERIC_ERROR error to the caller
    When the IoT Agent recieves information for a type with a configured Context Broker
      ✓ should use the Context Broker defined by the type
    When an IoT Agent receives information for a type with static attributes
      ✓ should decorate the entity with the static attributes

  Query device information in the Context Broker
    When the user requests information about a registered device
      ✓ should return the information about the desired attributes
    When the user requests information about a device that it's not in the CB
      ✓ should return a DEVICE_NOT_FOUND_ERROR
    When the user requests information and there are multiple responses, one of them a failure
      ✓ should return a DEVICE_NOT_FOUND_ERROR
    When the user requests information and there is an unknown errorCode in the response
      ✓ should return a ENTITY_GENERIC_ERROR

  Static attributes test
    When information from a device with multiple static attributes and metadata is sent
      ✓ should send a single TimeInstant per attribute

  Subscription tests
    When a client invokes the subscribe() function for device
      ✓ should send the appropriate request to the Context Broker
      ✓ should store the subscription ID in the Device Registry
    When a client invokes the unsubscribe() function for an entity
      ✓ should change the expiration date of the subscription to 0s
      ✓ should remove the id from the subscriptions array
    When a client removes a device from the registry
      ✓ should change the expiration dates of all its subscriptions to 0s
    When a new notification comes to the IoTAgent
      ✓ should invoke the user defined callback
      ✓ should invoke all the notification middlewares before the user defined callback
      ✓ should get the correspondent device information
    When a new notification arrives to the IOTA with a non-200 code
      ✓ should not call the handler

  Attribute alias plugin
    When an update comes for attributes with aliases
      ✓ should rename the attributes as expected by the mappings
    When an update comes for attributes with aliases and a different type
      ✓ should rename the attributes as expected by the mappings

  Bidirectional data plugin
    When a new provisioning request arrives to the IoTA with bidirectionality
      ✓ should subscribe to the modification of the combined attribute with all the variables
    When a device with bidirectionality subscriptions is removed
      ✓ should remove its subscriptions from the Context Broker
    When a notification arrives for a bidirectional attribute
      ✓ should execute the original handler
      ✓ should return a 200 OK
      ✓ should return the transformed values
    When a new Group provisioning request arrives with bidirectional attributes
      ✓ should subscribe to the modification of the combined attribute with all the variables
    When a notification arrives for a bidirectional attribute in a Configuration Group
      ✓ should return the transformed values

  Data Mapping Plugins: configuration provision
    When a configuration provision request arrives to a IoTA with configuration middleware
      ✓ should execute the configuration provisioning middlewares
      ✓ should still execute the configuration handlers
    When a configuration middleware returns an error
      ✓ should not execute the configuration handlers

  Data Mapping Plugins: device provision
    When a provision request arrives to a IoTA with provisioning middleware
      ✓ should execute the translation middlewares
      ✓ should continue with the registration process
      ✓ should execute the device provisioning handlers
    When a provisioning middleware returns an error
      ✓ should not continue with the registration process
      ✓ should not execute the device provisioning handlers

  Timestamp compression plugin
    When an update comes with a timestamp through the plugin
      ✓ should return an entity with all its timestamps expanded to have separators
    When an update comes with a timestamp through the plugin with metadatas
      ✓ should return an entity with all its timestamps expanded to have separators
    When a query comes for a timestamp through the plugin
      ✓ should return an entity with all its timestamps without separators (basic format)

  Event plugin
    When an update comes with an event to the plugin
      ✓ should return an entity with all its timestamps expanded to have separators

  Multi-entity plugin
    When an update comes for a multientity measurement
      ✓ should send two context elements, one for each entity
    When an update comes for a multientity defined with an expression
      ✓ should send the update value to the resulting value of the expression
    When an update comes for a multientity measurement without type for one entity
      ✓ should use the device type as a default value

  Timestamp processing plugin
    When an update comes with a timestamp through the plugin
      ✓ should return an entity with all its timestamps expanded to have separators

  Data Mapping Plugins: translation
    When a new update translation middleware is added to the IoT Agent
      ✓ should execute the translation middlewares
      ✓ should translate the appropriate attributes
    When a new query translation middleware is added to the IoT Agent
      ✓ should call the middleware
      ✓ should call the middleware

  Device Group Configuration API
    When a new device group creation request arrives
      ✓ should return a 200 OK
      ✓ should store it in the DB
      ✓ should store attributes in the DB
      ✓ should store the service information from the headers into the DB
      ✓ should call the configuration creation handler
    When a new creation request arrives for a pair (resource, apiKey) already existant
      ✓ should return a 400 DUPLICATE_GROUP error
    When a creation request arrives without the fiware-service header
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a creation request arrives without the fiware-servicepath header
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a device group with a missing mandatory attribute in the payload arrives
      ✓ should fail with a 400 WRONG_SYNTAX error
    When a device group removal request arrives
      ✓ should return a 204 OK
      ✓ should remove it from the database
      ✓ should remove it from the configuration
    When a device group removal arrives declaring a different service
      ✓ should return a 403 MISMATCHED_SERVICE error
    When a device group removal arrives declaring a different subservice
      ✓ should return a 403 MISMATCHED_SERVICE error
    When a device group removal arrives to a DB with three groups
      ✓ should remove just the selected group
    When a device group removal request arrives without the mandatory headers
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a device group removal request arrives without the mandatory parameters
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a device group update request arrives
      ✓ should return a 204 OK
      ✓ should update the appropriate values in the database
      ✓ should call the configuration creation handler
    When a device group update request arrives declaring a different service
      ✓ should return a 200 OK
    When a device group update request arrives declaring a different subservice
      ✓ should return a 200 OK
    When a device group update request arrives without the mandatory headers
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a device group update request arrives without the mandatory parameters
      ✓ should fail with a 400 MISSING_HEADERS Error
    When a device group listing request arrives
      ✓ should return a 200 OK
      ✓ should return all the configured device groups from the database
    When a device info request arrives
      ✓ should return a 200 OK
      ✓ should return all the configured device groups from the database
    When a new device from a created group arrives to the IoT Agent and sends a measure
      ✓ should use the configured data
    When a group listing request arrives with offset and limit parameters
      ✓ should return a 200 OK
      ✓ should use the limit parameter to constrain the number of entries
      ✓ should use return the total number of entities

  Device Group utils
    When an API Key is requested for a device in a group without the SingleConfiguration mode
      ✓ should return the API Key of the group
    When an API Key is requested for a device in a subservice with the SingleConfiguration mode
      ✓ should return the API Key of the related subservice
    When an API Key is requested without a provisioned group but with a configured type
      ✓ should return the API Key of the related type
    When an API Key is requested and there is no group or type configured
      ✓ should return the default API Key
    When an API Key is requested and there is no group, type or default value
      ✓ should raise an error

  Device provisioning API: Provision devices
    When a device provisioning request with all the required data arrives to the IoT Agent
      ✓ should add the device to the devices list
      ✓ should call the device provisioning handler if present
      ✓ should store the device with the provided entity id, name and type
      ✓ should store the device with the per device information
      ✓ should store fill the device ID in case only the name is provided
      ✓ should store service and subservice info from the headers along with the device data
      ✓ should create the initial entity in the Context Broker
    When a device provisioning request with a TimeInstant attribute arrives to the IoTA
      ✓ should send the appropriate requests to the Context Broker
    When a device provisioning request with the minimum required data arrives to the IoT Agent
      ✓ should send the appropriate requests to the Context Broker
      ✓ should add the device to the devices list
      ✓ should store the device with the provided entity id, name and type
    When a device provisioning request with geo:point attributes arrives
      ✓ should send the appropriate initial values to the Context Broker
    When a device provisioning request with DateTime attributes arrives
      ✓ should send the appropriate initial values to the Context Broker
    When two devices with the same ID but different services arrive to the agent
      ✓ should accept both creations
      ✓ should show the new device in each list
    When there is a connection error with a String code connecting the CB
      ✓ should return a valid return code
    When there is a connection error with a Number code connecting the CB
      ✓ should return a valid return code (three character number)
    When a device provisioning request with missing data arrives to the IoT Agent
      ✓ should raise a MISSING_ATTRIBUTES error, indicating the missing attributes
    When two device provisioning requests with the same service and Device ID arrive
      ✓ should raise a DUPLICATE_ID error, indicating the ID was already in use
    When a device provisioning request is malformed
      ✓ should raise a WRONG_SYNTAX exception
    When an agent is activated with a different base root
      ✓ should listen to requests in the new root
    When a device provisioning request without the mandatory headers arrives to the Agent
      ✓ should raise a MISSING_HEADERS error, indicating the missing attributes

  IoT Agent Device Registration
    When a new device is connected to the IoT Agent
      ✓ should register as ContextProvider of its lazy attributes
    When the Context Broker returns a NGSI error while registering a device
      ✓ should register as ContextProvider of its lazy attributes
    When the Context Broker returns an HTTP transport error while registering a device
      - should not register the device in the internal registry
      ✓ should return a REGISTRATION_ERROR error to the caller
    When a device is requested to the library using its ID
      ✓ should return all the device's information
    When an unexistent device is requested to the library using its ID
      ✓ should return a ENTITY_NOT_FOUND error
    When a device is removed from the IoT Agent
      ✓ should update the devices information in Context Broker
    When the Context Broker returns an error while unregistering a device
      - should not remove the device from the internal registry
      ✓ should return a UNREGISTRATION_ERROR error to the caller

  IoT Agent Device Update Registration
    When a device is preregistered and its registration information updated
      ✓ should register as ContextProvider of its lazy attributes
      ✓ should store the new values in the registry
    When a device is preregistered and it is updated with new commands
      ✓ should register as ContextProvider of its commands and create the additional attributes
      ✓ should store the new values in the registry
    When a update action is executed in a non registered device
      ✓ should return a DEVICE_NOT_FOUND error
    When a device register is updated in the Context Broker and the request fail to connect
      ✓ should return a REGISTRATION_ERROR error in the update action
    When a device register is updated in the Context Broker and the registration is not found
      - should create the registration anew

  Device provisioning API: List provisioned devices
    When a request for the list of provisioned devices arrive
      ✓ should return all the provisioned devices
      ✓ should return all the appropriate field names
      ✓ should return all the plugin attributes
    When a request for the information about a specific device arrives
      ✓ should return all the information on that particular device
      ✓ should return the appropriate attribute fields
    When a request for a device with plugin attributes arrives
      ✓ should return the appropriate attribute fields
    When a request for an unexistent device arrives
      ✓ should return a 404 error
    When a request for listing all the devices with a limit of 3 arrives
      ✓ should return just 3 devices
      ✓ should return a count with the complete number of devices
    When a request for listing all the devices with a offset of 3 arrives
      ✓ should skip the first 3 devices
    When a listing request arrives and there are devices in other service and servicepath
      ✓ should return just the ones in the selected service

  Device provisioning API: Remove provisioned devices
    When a request to remove a provision device arrives
      ✓ should return a 200 OK and no errors
      ✓ should remove the device from the provisioned devices list
      ✓ should return a 404 error when asking for the particular device

  Provisioning API: Single service mode
    When a new configuration arrives to an already configured subservice
      ✓ should raise a DUPLICATE_GROUP error
    When a device is provisioned with an ID that already exists in the configuration
      ✓ should raise a DUPLICATE_DEVICE_ID error
    When a device is provisioned with an ID that exists globally but not in the configuration
      ✓ should return a 201 OK
    When a device is provisioned without a type and with a default configuration type
      ✓ should be provisioned with the default type
    When a device is provisioned for a configuration
      ✓ should not raise any error
      ✓ should send the mixed data to the Context Broker

  Device provisioning API: Update provisioned devices
    When a request to update a provision device arrives
      ✓ should return a 200 OK and no errors
      ✓ should have updated the data when asking for the particular device
      ✓ should not modify the attributes not present in the update request
    When an update request arrives with a new Device ID
      ✓ should raise a 400 error
    When a wrong update request payload arrives
      ✓ should raise a 400 error
    When a device is provisioned without attributes and new ones are added through an update
      ✓ should not raise any error
      ✓ should provision the attributes appropriately
      ✓ should create the initial values for the attributes in the Context Broker
    When a device is updated to add static attributes
      ✓ should provision the attributes appropriately


  286 passing (14s)
  4 pending


Done, without errors.
```