### PR TITLE
remove devices related to a service when device=true option used (see #596)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Fix: missing support for device=true in the delete service endpoint (see #596)
 Add protocol in device provision if not provided (#652)
 Fix: timestamp is now included just in non empty (more than id and type) multienty entitites
 Fix: object_id fields are not introduced in CB requests by alias plugin (#660)

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -27,6 +27,7 @@ var async = require('async'),
     iotManagerService = require('./../common/iotManagerService'),
     intoTrans = require('../common/domain').intoTrans,
     apply = async.apply,
+    deviceService = require('../devices/deviceService'),
     logger = require('logops'),
     config = require('../../commonConfig'),
     errors = require('../../errors'),
@@ -166,15 +167,38 @@ function handleWithIotaRegistration(callback) {
  * @param {String} resource             Resource where the devices will arrive.
  * @param {String} apikey               Api keys the devices will declare.
  */
-function remove(service, subservice, resource, apikey, callback) {
+function remove(service, subservice, resource, apikey, device, callback) {
     function extractId(deviceGroup, callback) {
         callback(null, deviceGroup._id);
+    }
+
+    function deleteDevices(device, service, subservice, id, callback) {
+        if(device) {
+            deviceService.listDevices(service, subservice, function (error, devices) {
+                if (error) {
+                   callback(error);
+                } else {
+                    if (devices && devices.count > 0){
+                      for(var device of devices.devices) {
+                        deviceService.unregister(device.id, service, subservice, function(error) {
+                            if (error) {
+                                callback(error);
+                            }
+                        });
+                      }
+                    }
+                }
+            });
+        }
+
+        callback(null, id);
     }
 
     async.waterfall([
         apply(config.getGroupRegistry().get, resource, apikey),
         apply(checkServiceIdentity, service, subservice),
         extractId,
+        apply(deleteDevices, device, service, subservice),
         config.getGroupRegistry().remove
     ], handleWithIotaRegistration(callback));
 }

--- a/lib/services/northBound/deviceGroupAdministrationServer.js
+++ b/lib/services/northBound/deviceGroupAdministrationServer.js
@@ -202,7 +202,7 @@ function handleModifyDeviceGroups(req, res, next) {
 function handleDeleteDeviceGroups(req, res, next) {
     groupService.remove(
         req.headers['fiware-service'], req.headers['fiware-servicepath'],
-        req.query.resource, req.query.apikey,
+        req.query.resource, req.query.apikey, req.query.device,
         function(error) {
             if (error) {
                 next(error);

--- a/test/unit/examples/contextAvailabilityRequests/unregisterProvisionedDevice.json
+++ b/test/unit/examples/contextAvailabilityRequests/unregisterProvisionedDevice.json
@@ -1,0 +1,28 @@
+{
+  "contextRegistrations": [
+    {
+      "entities": [
+        {
+          "type": "TheLightType",
+          "isPattern": "false",
+          "id": "TheFirstLight"
+        }
+      ],
+      "attributes": [
+        {
+          "name": "luminance",
+          "type": "lumens",
+          "isDomain": "false"
+        },
+        {
+          "name": "commandAttr",
+          "type": "commandType",
+          "isDomain": "false"
+        }
+      ],
+      "providingApplication": "http://smartGondor.com"
+    }
+  ],
+  "registrationId": "6319a7f5254b05844116584d",
+  "duration": "PT1S"
+}

--- a/test/unit/provisioning/device-group-api-test.js
+++ b/test/unit/provisioning/device-group-api-test.js
@@ -425,6 +425,7 @@ describe('Device Group Configuration API', function() {
               };
               request(options, function(error, response, body) {
                   should.not.exist(error);
+                  response.statusCode.should.equal(404);
                   done();
               });
         });


### PR DESCRIPTION
@fgalan @dcalvoalonso 
this is an attempt to fix #596, but i need a some support in understanding why i get an ECONNECT error from the nock server when unregistration are sent to context broker.

i supposed that:

```
            contextBrokerMock = nock('http://192.168.1.1:1026')
                .matchHeader('fiware-service', 'TestService')
                .matchHeader('fiware-servicepath', '/testingPath')
                .post('/NGSI9/registerContext')
                .reply(200,
                utils.readExampleFile(
                   './test/unit/examples/contextAvailabilityResponses/unregisterDevice1Success.json'));
```

would have been the only thing needed, but apparently something is still wrong (when using a real context broker there is no issue).

thx.