### PR TITLE
Update mongodb dependence in package.json

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,3 +6,4 @@
 - FIX Correctly return 404 when asking to remove a not existing device (#585)
 - Add: support HTTPS requests toward Keystone (if url is used in the authorization configuration)
 - Add: support OAuth2 provider as authentication backend (#591)
+- Upgrade mongodb dependency version to 2.2.20

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sax": "^0.6.0",
     "underscore": "^1.7.0",
     "xmldom": "0.1.19",
-    "mongodb": "2.2.10",
+    "mongodb": "2.2.20",
     "query-string": "4.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Previous version (2.2.10) is already deprecated.
Maybe this update solves issue https://github.com/telefonicaid/iotagent-node-lib/issues/577