### PR TITLE
check boolean configuration fields explicitly againts right boolean value

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
- -Fix: IOTA_SIGLE_MODE, IOTA_APPEND_MODE, IOTA_POLLING_EXPIRATION, IOTA_POLLING_DAEMON_FREQ env vars are now taken into account (previously there were ignored)
+- Fix: Check boolean config fields against right boolean value
+- Fix: IOTA_SIGLE_MODE, IOTA_APPEND_MODE, IOTA_POLLING_EXPIRATION, IOTA_POLLING_DAEMON_FREQ env vars are now taken into account (previously there were ignored)
 - Fix: IOTA_MONGO_RETRIES and IOTA_MONGO_RETRY_TIME env vars are now taken into account (previously there were ignored)
 - Add: log mongo error before raise alarm (#577)
 - Fix: automatic device provisioning by means of Configuration Group fails due to a bug in findConfigurationGroup function (#544)

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -307,7 +307,7 @@ function findConfigurationGroup(deviceObj, callback) {
         callback(null, effectiveGroup);
     }
 
-    if (config.getConfig().singleConfigurationMode) {
+    if (config.getConfig().singleConfigurationMode === true) {
         config.getGroupRegistry().find(
             deviceObj.service,
             deviceObj.subservice,

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -75,7 +75,7 @@ function validateGroup(group, callback) {
             return;
         }
 
-        if (!(config.getConfig().singleConfigurationMode === true)) {
+        if (config.getConfig().singleConfigurationMode === false) {
             if (!group.type) {
                 innerCb(new errors.MissingConfigParams(['type']));
                 return;

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -85,7 +85,7 @@ function validateGroup(group, callback) {
 
     validations.push(checkApiKeyAndResource);
 
-    if (config.getConfig().singleConfigurationMode) {
+    if (config.getConfig().singleConfigurationMode === true) {
         validations.push(checkServiceAndSubservice);
     }
 

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -43,10 +43,12 @@ var async = require('async'),
  */
 function validateGroup(group, callback) {
     var validations = [];
+    logger.debug(context, 'validateGroup %j', group);
 
     function generateDuplicateHandler(innerCb) {
         return function(error, foundGroup) {
             if (!error || foundGroup) {
+                logger.debug(context, 'generateDuplicateHander error %s foundGroup %j', error, foundGroup);
                 innerCb(new errors.DuplicateGroup(group.resource, group.apikey));
             } else {
                 innerCb();
@@ -73,7 +75,7 @@ function validateGroup(group, callback) {
             return;
         }
 
-        if (!config.getConfig().singleConfigurationMode) {
+        if (!(config.getConfig().singleConfigurationMode === true)) {
             if (!group.type) {
                 innerCb(new errors.MissingConfigParams(['type']));
                 return;

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -499,7 +499,7 @@ function sendUpdateValueNgsi1(entityName, attributes, typeInformation, token, ca
             ]
         };
 
-    if (config.getConfig().appendMode) {
+    if (config.getConfig().appendMode === true) {
         payload.updateAction = 'APPEND';
     } else {
         payload.updateAction = 'UPDATE';


### PR DESCRIPTION
An env var like:
```
  - IOTA_SINGLE_MODE=false
```
is not detected properly,  by:
```
 if (config.getConfig().singleConfigurationMode)
```
so i need to check against boolean value 

This is happening in several parts of the library, probably they work fine with node 0.10 but not with node 4 or 6