### PR TITLE
Improve readability of readthedocs documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   + [Description](#description)
   + [Device to NGSI Mapping](#device-to-ngsi-mapping)
   + [Features](#features)
-  + [The ´TimeInstant´ element](#the-%C2%B4timeinstant%C2%B4-element)
+  + [The `TimeInstant` element](#the-timeinstant-element)
   + [Implementation decisions](#implementation-decisions)
 * [Build and Install](#build-and-install)
 * [API Overview](#api-overview)
@@ -235,7 +235,7 @@ to a command update to the device.
 
 ![General ](https://raw.githubusercontent.com/telefonicaid/iotagent-node-lib/master/img/iotAgentLib.png "Architecture Overview")
 
-### The ´TimeInstant´ element
+### The `TimeInstant` element
 
 As part of the device to entity mapping process the IoT Agent creates and updates automatically a special timestamp.
 This timestamp is represented as two different properties of the mapped entity::
@@ -1060,7 +1060,7 @@ The command line testing tools make use of the [command-node Node.js library](ht
 utils. In order to help creating testing tools for IoTAgents of specific protocols, all the commands of the library tester are offered as a array
 that can be directly imported into other Command Line tools, using the following steps:
 
-* Require the ´iotagent-node-lib´ command line module in your command line tool:
+* Require the `iotagent-node-lib` command line module in your command line tool:
 ```
   var iotaCommands = require('iotagent-node-lib').commandLine;
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Index
 
 * [Overview](#overview)
-* [Build & Install](#build--install)
+* [Build and Install](#build-and-install)
 * [API Overview](#api-overview)
   + [About API](#about-api)
   + [Device Provisioning API](#device-provisioning-api)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@
 ## Index
 
 * [Overview](#overview)
+  + [Description](#description)
+  + [Device to NGSI Mapping](#device-to-ngsi-mapping)
+  + [Features](#features)
+  + [The ´TimeInstant´ element](#the-%C2%B4timeinstant%C2%B4-element)
+  + [Implementation decisions](#implementation-decisions)
 * [Build and Install](#build-and-install)
 * [API Overview](#api-overview)
   + [About API](#about-api)
   + [Device Provisioning API](#device-provisioning-api)
+  + [Configuration API](#configuration-api)
 * [Advanced Topics](#advanced-topics)
   + [Secured access to the Context Broker](#secured-access-to-the-context-broker)
   + [Data mapping plugins](#data-mapping-plugins)
@@ -18,6 +24,7 @@
 * [Testing](#testing)
   + [Agent Console](#agent-console)
   + [Agent tester](#agent-tester)
+* [Development documentation](#-development-documentation)
 
 ## Overview
 ### Description

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # FIWARE IoT Agent Framework
 
 [![License badge](https://img.shields.io/badge/license-AGPL-blue.svg)](https://opensource.org/licenses/AGPL-3.0)
-[![Documentation badge](https://readthedocs.org/projects/fiware-iotagent-node-lib/badge/?version=latest)](http://fiware-iotagent-ul.readthedocs.org/en/latest/?badge=latest)
+[![Documentation badge](https://readthedocs.org/projects/iotagent-node-lib/badge/?version=latest)](http://iotagent-node-lib.readthedocs.org/en/latest/?badge=latest)
 [![Support badge]( https://img.shields.io/badge/support-sof-yellowgreen.svg)](http://stackoverflow.com/questions/tagged/fiware)
 
 ## Index
 
 * [Overview](#overview)
-* [Build & Install](#buildinstall)
-* [API Overview](#apioverview)
-  * [About API](#aboutapi)
-  * [Device Provisioning API](#provisioningapi)
-  * [Configuration API](#configurationapi)
-* [Advanced Topics](#advancedtopics)
-  * [Secured access to the Context Broker](#securedaccess)
-  * [Data mapping plugins](#datamapping)
-  * [Old IoTAgent data migration](#datamigration)
-* [Testing](#librarytesting)
-* [Development Documentation](#development)
+* [Build & Install](#build--install)
+* [API Overview](#api-overview)
+  + [About API](#about-api)
+  + [Device Provisioning API](#device-provisioning-api)
+* [Advanced Topics](#advanced-topics)
+  + [Secured access to the Context Broker](#secured-access-to-the-context-broker)
+  + [Data mapping plugins](#data-mapping-plugins)
+  + [Old IoTAgent data migration](#old-iotagent-data-migration)
+* [Testing](#testing)
+  + [Agent Console](#agent-console)
+  + [Agent tester](#agent-tester)
 
-## <a name="overview"/> Overview
+## Overview
 ### Description
 This project aims to provide a Node.js module to enable IoT Agent developers to build custom agents for their devices that can
 easily connect to NGSI Context Brokers (such as [Orion](https://github.com/telefonicaid/fiware-orion) ). 
@@ -228,7 +228,7 @@ to a command update to the device.
 
 ![General ](https://raw.githubusercontent.com/telefonicaid/iotagent-node-lib/master/img/iotAgentLib.png "Architecture Overview")
 
-### <a name="TimeInstant"/>The ´TimeInstant´ element
+### The ´TimeInstant´ element
 
 As part of the device to entity mapping process the IoT Agent creates and updates automatically a special timestamp.
 This timestamp is represented as two different properties of the mapped entity::
@@ -267,15 +267,15 @@ one (In-memory Registry) and a persistent one (based in MongoDB).
 entity model, if there is any, is a responsability of the particular IoT Agent implementation, or of another third
 party library.
 
-## <a name="buildinstall"/> Build & Install
+##  Build and Install
 
 Information about how to configure the Library can be found at the corresponding section of the [Installation & Administration Guide](doc/installationguide.md).
 
 This library has no packaging or build processes. Usage of the library is explained in the [User & Programmers Manual](doc/usermanual.md).
 
-## <a name="apioverview"/> API Overview
+##  API Overview
 
-### <a name="aboutapi"/> About API
+### About API
 The library provides a simple operation to retrieve information about the library and the IoTA using it. A GET request
 to the `/iot/about` path, will show a payload like the following:
 ```
@@ -288,7 +288,7 @@ to the `/iot/about` path, will show a payload like the following:
 ```
 the `version` field will be read from the `iotaVersion` field of the config, if it exists.
 
-### <a name="provisioningapi"/> Device Provisioning API
+### Device Provisioning API
 #### Overview
 The IoT Agents offer a provisioning API where devices can be preregistered, so all the information about service and 
 subservice mapping, security information and attribute configuration can be specified in a per device way instead of 
@@ -539,7 +539,7 @@ Payload example:
 }
 ```
 
-### <a name="configurationapi"/> Configuration API
+### Configuration API
 For some services, there will be no need to provision individual devices, but it will make more sense to provision
 different device groups, each of one mapped to a different type of entity in the context broker. How the type of entity
 is assigned to a device will depend on the Southbound technology (e.g.: path, port, APIKey...). Once the device has an
@@ -674,8 +674,8 @@ The IoT Agent can be configured to expect certain kinds of devices, with preconf
 * **trust**: trust token to use for secured access to the Context Broker for this type of devices (optional; only needed for secured scenarios).
 * **cbHost**: Context Broker host url. This option can be used to override the global CB configuration for specific types of devices.
 
-## <a name="advancedtopics"/> Advanced Topics
-### <a name="securedaccess"/> Secured access to the Context Broker
+## Advanced Topics
+### Secured access to the Context Broker
 For access to instances of the Context Broker secured with a [PEP Proxy](https://github.com/telefonicaid/fiware-orion-pep), an authentication mechanism based in Keystone Trust tokens is provided. A Trust token is a long-term token that can be issued by any user to give another user permissions to impersonate him with a given role in a given project.
 
 For the authentication mechanisms to work, the `authentication` attribute in the configuration has to be fully configured, and the `authentication.enabled` subattribute should have the value `true`.
@@ -707,7 +707,7 @@ curl http://${KEYSTONE_HOST}/v3/OS-TRUST/trusts \
 
 Apart from the generation of the trust, the use of secured Context Brokers should be transparent to the user of the IoT Agent.
 
-### <a name="datamapping"/> Data mapping plugins
+### Data mapping plugins
 #### Overview
 The IoT Agent Library provides a plugin mechanism in order to facilitate reusing code that makes small transformations on 
 incoming data (both from the device and from the context consumers). This mechanism is based in the use of middlewares,
@@ -834,7 +834,7 @@ For each attribute in the `reverse` array, an expression must be defined to calc
 attributes. This value will be passed to the underlying protocol with the `object_id` name. Details about how the value
 is then progressed to the device are protocol-specific.
 
-### <a name="datamigration"/> Old IoTAgent data migration
+### Old IoTAgent data migration
 In order to ease the transition from the old IoTAgent implementation (formerly known as IDAS) to the new Node.js based
 implementations, a data migration tool has been developed. This data migration tool has been integrated as a command
 in the IoTAgent command line tester.
@@ -861,7 +861,7 @@ They show the values existing in the original DB that had no translation for the
 If you want to restrict the migration for certain services and subservices, just substitute the `*` value for the particular
 service and subservice you want to use.
 
-## <a name="librarytesting"/> Testing
+## Testing
 ### Agent Console
 A command line client to experiment with the library is packed with it. The command line client can be started using the following command:
 ```

--- a/doc/Contribution.md
+++ b/doc/Contribution.md
@@ -12,30 +12,37 @@ In order to start contributing:
 1. Fork this repository clicking on the "Fork" button on the upper-right area of the page.
 
 2. Clone your just forked repository:
-<pre>
+
+```console
 git clone https://github.com/your-github-username/iotagent-node-lib.git
-</pre>
+```
+
 3. Add the main iotagent-node-lib repository as a remote to your forked repository (use any name for your remote
 repository, it does not have to be iotagent-node-lib, although we will use it in the next steps):
-<pre>
+
+```console
 git remote add iotagent-node-lib https://github.com/telefonicaid/iotagent-node-lib.git
-</pre>
+```
 
 Before starting your contribution, remember to synchronize the `master` branch in your forked repository with the `master`
 branch in the main iotagent-node-lib repository, by following this steps
 
 1. Change to your local `master` branch (in case you are not in it already):
-<pre>
-  git checkout master
-</pre>
+
+```console
+git checkout master
+```
 2. Fetch the remote changes:
-<pre>
-  git fetch iotagent-node-lib
-</pre>
+
+```console
+git fetch iotagent-node-lib
+```
+
 3. Merge them:
-<pre>
-  git rebase iotagent-node-lib/master
-</pre>
+
+```console
+git rebase iotagent-node-lib/master
+```
 
 Contributions following these guidelines will be added to the `master` branch, and released in the next version. The
 release process is explaind in the *Releasing* section below.

--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -3,26 +3,25 @@
 ## Index
 
 * [Overview](#overview)
-* [Measurement transformation](#transformation)
-  * [Expression definition](#definition)
-  * [Variable values](#values)
-  * [Expression execution](#execution)
-* [Language description](#description)
-  * [Types](#types)
-  * [Values](#values)
-  * [Allowed operations](#operations)
-* [Examples of expressions](#examples)
-* [NGSIv2 support](#ngsiv2)
+  + [Protocol](#protocol)
+  + [Requirements](#requirements)
+* [Basic IOTA](#basic-iota)
+* [IOTA With Active attributes](#iota-with-active-attributes)
+* [IOTA With Lazy attributes](#iota-with-lazy-attributes)
+  + [Previous considerations](#previous-considerations)
+  + [Implementation](#implementation)
+* [Configuration management](#configuration-management)
+  + [Provisioning handlers](#provisioning-handlers)
 
-## <a name="overview"/> Overview
+## Overview
 The IoTAgent Library provides an expression language for measurement transformation, that can be used to adapt the
 information coming from the South Bound APIs to the information reported to the Context Broker. Expressions in this
 language can be configured for provisioned attributes as explained in the Device Provisioning API section in the
 main README.md.
 
-## <a name="transformation"/> Measurement transformation
+##  Measurement transformation
 
-### <a name="definition"/> Expression definition
+### Expression definition
 
 Expressions can be defined for Active attributes, either in the Device provisioning or in the Configuration provisioning.
 The following example shows a device provisioning payload with defined expressions:
@@ -65,19 +64,20 @@ expression patterns).
 
 The exact same syntax works for Configuration and Device provisioning.
 
-### <a name="values"/> Variable values
+### Variable values
 
 Attribute expressions can contain values taken from the value of other attributes. Those values have, by default, the
-String type. For most arithmetic operations ('*', '/', etc...) if a variable is involved, its value will be cast to
+String type. For most arithmetic operations (`*`, `/`, etc...) if a variable is involved, its value will be cast to
 Number, regardless of the original type. For, example, if a variable @humidity has the value `'50'` (a String value),
 the following expression:
+
 ```
 ${@humidity * 10}
 ```
 will give `500` as the result (i.e.: the value `'50'` is cast to number, to get `50`, that is then multiplied by 10). If
 this cast fails (because the value of the variable is not a number, e.g.: `'Fifty'`), the overall result will be `NaN`.
 
-### <a name="execution"/> Expression execution
+### Expression execution
 
 Whenever a new measurement arrives to the IoTAgent for a device with declared expressions, all of the expressions for
 the device will be checked for execution: for all the defined active attributes containing expressions, the IoTAgent
@@ -142,9 +142,9 @@ As `spaces` attribute is included, then the expression is evaluated, so overridi
 }
 ```
 
-## <a name="description"/> Language description
+## Language description
 
-### <a name="types"/> Types
+### Types
 
 The way the parse() function works (at expressionParser.js) is as follows:
 
@@ -153,12 +153,12 @@ The way the parse() function works (at expressionParser.js) is as follows:
 
 However, the usage that the Expression Translation plugin does of that function is using always String type. That means that at the end, the result of the expression will be always cast to String. However, in NGSIv2 that String result could be re-cast to the right type (i.e. the one defined for the attribute in the provision operation). Have a look at the [NGSIv2 support](#ngsiv2) for more information on this.
 
-### <a name="values"/> Values
+### Values
 
 #### Variables
 
 All the information reported in the measurement received by the IoT Agent is available for the expression to use. For
-every attribute coming from the South Bound, a variable with the syntax '@<object_id>' will be created for its use in
+every attribute coming from the South Bound, a variable with the syntax `@<object_id>` will be created for its use in
 the expression language.
 
 #### Constants
@@ -171,7 +171,7 @@ Current allowed characters are:
 - All the alphanumerical characters
 - Whitespaces
 
-### <a name="operations"/> Allowed operations
+### Allowed operations
 
 The following operations are currently available, divided by attribute type
 
@@ -197,7 +197,7 @@ starting at posisiton `start` and ending at position `<end>`.
 
 Parenthesis can be used to define precedence in the operations. Whitespaces between tokens are generally ignored.
 
-## <a name="examples"/> Examples of expressions
+## Examples of expressions
 
 The following table shows expressions and their expected outcomes for a measure with two attributes: "@value" with value
 6 and "@name" with value "DevId629".
@@ -212,7 +212,7 @@ The following table shows expressions and their expected outcomes for a measure 
 | '"Pruebas " + "De Strings"' | 'Pruebas De Strings'  |
 | '@name value is @value'     | 'DevId629 value is 6' |
 
-## <a name="ngsiv2"/> NGSIv2 support
+## NGSIv2 support
 
 As it is explained in previous sections, expressions can have two return types: String or Number, being the former one the default. Whenever an expression is executed without error, its result will be cast to the configured type. 
 

--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -3,15 +3,16 @@
 ## Index
 
 * [Overview](#overview)
-  + [Protocol](#protocol)
-  + [Requirements](#requirements)
-* [Basic IOTA](#basic-iota)
-* [IOTA With Active attributes](#iota-with-active-attributes)
-* [IOTA With Lazy attributes](#iota-with-lazy-attributes)
-  + [Previous considerations](#previous-considerations)
-  + [Implementation](#implementation)
-* [Configuration management](#configuration-management)
-  + [Provisioning handlers](#provisioning-handlers)
+* [Measurement transformation](#measurement-transformation)
+  + [Expression definition](#expression-definition)
+  + [Variable values](#variable-values)
+  + [Expression execution](#expression-execution)
+* [Language description](#language-description)
+  + [Types](#types)
+  + [Values](#values)
+  + [Allowed operations](#allowed-operations)
+* [Examples of expressions](#examples-of-expressions)
+* [NGSIv2 support](#ngsiv2-support)
 
 ## Overview
 The IoTAgent Library provides an expression language for measurement transformation, that can be used to adapt the

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -3,13 +3,17 @@
 ## Index
 
 * [Overview](#overview)
-* [Basic IOTA](#basic)
-* [IOTA With active attributes](#active)
-* [IOTA With lazy attributes](#lazy)
-* [IOTA With commands](#commands)
-* [Configuration control](#configuration)
+  + [Protocol](#protocol)
+  + [Requirements](#requirements)
+* [Basic IOTA](#basic-iota)
+* [IOTA With Active attributes](#iota-with-active-attributes)
+* [IOTA With Lazy attributes](#iota-with-lazy-attributes)
+  + [Previous considerations](#previous-considerations)
+  + [Implementation](#implementation)
+* [Configuration management](#configuration-management)
+  + [Provisioning handlers](#provisioning-handlers)
 
-## <a name="overview"/> Overview
+## Overview
 This document's goal is to show how to develop a new IOT Agent step by step. To do so, a simple invented HTTP protocol
 will be used, so it can be tested with simple command line instructions as `curl` and `nc`. 
 
@@ -29,7 +33,7 @@ Where:
 This tutorial expects a Node.js v0.10 (at least) installed and working on your machine. It also expects you to have
 access to a Context Broker (without any security proxies).
 
-## <a name="basic"/> Basic IOTA
+##  Basic IOTA
 In this first chapter, we will develop an IOT Agent with a fully working northbound API and no southbound
 API. This may seem useless (and indeed it is) but will serve us well on showing the basic steps in the creation
 of an IOTA.
@@ -76,7 +80,7 @@ node index.js
 
 The northbound interface should now be fully functional, i.e.: management of device registrations and configurations.
 
-## <a name="active"/> IOTA With Active attributes
+## IOTA With Active attributes
 
 In the previous section we created an IOTA that exposed just the Northbound interface, but that was pretty useless
 (aside from its didactic use). In this section we are going to create a simple Southbound interface. It's important
@@ -225,7 +229,7 @@ curl -X GET 'http://127.0.0.1:8080/iot/d?i=ULSensor&k=abc&d=t|15,l|19.6' -i
 ```
 Now you should be able to see the measures in the Context Broker entity of the device.
 
-## <a name="lazy"/> IOTA With Lazy attributes
+## IOTA With Lazy attributes
 
 ### Previous considerations
 The IoT Agents also give the possibility for the device to be asked about the value of one of its measures, instead of 
@@ -477,7 +481,7 @@ Content-Length: 3
 This same response can be used both for updates and queries for testing purposes (even though in the former the body won't
 be read).
 
-## <a name="configuration"/> Configuration management
+## Configuration management
 
 For some IoT Agents, it will be useful to know what devices or configurations were registered in the Agent, or to do some
 actions whenever a new device is registered. All this configuration and provisioning actions can be performed using two

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -40,11 +40,14 @@ of an IOTA.
  
 First of all, we have to create the Node project. Create a folder to hold your project and type the following 
 instruction:
-```
+
+```console
 npm init
 ```
+
 This will create the `package.json` file for our project. Now, add the following lines to your project file:
-```
+
+```json
   "dependencies": {
     "iotagent-node-lib": "*"
   },
@@ -52,7 +55,8 @@ This will create the `package.json` file for our project. Now, add the following
 ```
 
 And install the dependencies, executing, as usual:
-```
+
+```console
 npm install
 ```
 
@@ -61,7 +65,8 @@ can be copied from the `config-basic-example.js` file, in this same folder. Crea
 in the root folder of your project. Remember to change the Context Broker IP to your local Context Broker.
 
 Now we can begin with the code of our IOTA. The very minimum code we need to start an IOTA is the following:
-``` javascript
+
+```javascript
 var iotAgentLib = require('iotagent-node-lib'),
     config = require('./config');
 
@@ -74,7 +79,8 @@ iotAgentLib.activate(config, function(error) {
 ```
 
 The IOTA is now ready to be used. Execute it with the following command:
-```
+
+```console
 node index.js
 ```
 
@@ -90,11 +96,15 @@ help him in its development. In this example, we will use Express as such librar
 
 In order to add the Express dependency to your project, add the following line to the `dependencies` section of the
 `package.json`:
-```
+
+```json
     "express": "*",
 ```
+
 The require section would end up like this (the standard `http` module is also needed):
-``` javascript
+
+
+```javascript
 var iotAgentLib = require('iotagent-node-lib'),
     http = require('http'),
     express = require('express'),
@@ -105,7 +115,8 @@ your code as well.
 
 Now, in order to accept connections in our code, we have to start express first. With this purpose in mind, we will
 create a new function `initSouthbound()`, that will be called from the initialization code of our IOTA:
-``` javascript
+
+```javascript
 function initSouthbound(callback) {
     southboundServer = {
         server: null,
@@ -128,7 +139,8 @@ path `/iot/d` using the middleware `manageULRequest()`. This middleware will con
 the library methods we need in order to progress the information to the Context Broker. The code of this middleware
 would be as follows:
 
-``` javascript
+
+```javascript
 function manageULRequest(req, res, next) {
     var values;
 
@@ -157,7 +169,8 @@ function manageULRequest(req, res, next) {
 
 For this middleware we have made use of a function `parseUl()` that parses the data payload and transforms it 
 in the data object expected by the update function (i.e.: an attribute array with NGSI syntax):
-``` javascript
+
+```javascript
 function parseUl(data, device) {
     function findType(name) {
         for (var i=0; i < device.active.length; i++) {
@@ -185,7 +198,8 @@ function parseUl(data, device) {
 ```
 
 Here as an example of the output of the function return for the UL payload `t|15,l|19.6`:
-``` javascript
+
+```json
 [
     {
         "name": "t",
@@ -203,7 +217,8 @@ Here as an example of the output of the function return for the UL payload `t|15
 The last thing to do is to invoke the initialization function inside the IOTA startup function. The next excerpt
 show the modifications in the `activate()` function:
 
-``` javascript
+
+```javascript
 iotAgentLib.activate(config, function(error) {
     if (error) {
         console.log('There was an error activating the IOTA');
@@ -219,14 +234,17 @@ iotAgentLib.activate(config, function(error) {
     }   
 });
 ```
+
 Some logs were added in this piece of code to help debugging.
 
 Once the IOTA is finished the last thing to do is to test it. To do so, launch the IOTA and provision a new device
 (an example for provisioning can be found in the `examples/howtoProvisioning1.json` file). Once the device is 
 provisioned, send a new measure by using the example command:
-```
+
+```console
 curl -X GET 'http://127.0.0.1:8080/iot/d?i=ULSensor&k=abc&d=t|15,l|19.6' -i
 ```
+
 Now you should be able to see the measures in the Context Broker entity of the device.
 
 ## IOTA With Lazy attributes
@@ -237,9 +255,11 @@ reporting it. In order to do so, the device must be capable of receiving message
 going to simulate an HTTP server with `nc` in order to see the values sent by the IOTA. We also have to decide a syntax
 for the protocol request for asking the device about a measure. For clarity, we will use the same HTTP GET request we
 used to report a measure, but indicating the attribute to ask instead of the data payload. Something like:
-```
+
+```console
 curl -X GET 'http://127.0.0.1:9999/iot/d?i=ULSensor&k=abc&q=t,l' -i
 ```
+
 In a real implementation, the server will need to know the URL and port where the devices are listening, in order to
 send the request to the appropriate device. For this example, we will assume that the device is listening in port 9999
 in localhost. For more complex cases, the mechanism to bind devices to addresses would be IOTA-specific (e.g.: the 
@@ -255,11 +275,14 @@ Both types of calls to the device will be distinguished by the presence or absen
 
 A HTTP request library will be needed in order to make those calls. To this extent, `mikeal/request` library will be used.
 In order to do so, add the following require statement to the initialiation code:
-```
+
+```javascript
     request = require('request');
 ```
+
 and add the `request` dependency to the `package.json` file: 
-```
+
+```json
   "dependencies": [
   [...]
   
@@ -269,7 +292,8 @@ and add the `request` dependency to the `package.json` file:
 ```
 
 The require section should now look like this:
-``` javascript
+
+```javascript
 var iotAgentLib = require('iotagent-node-lib'),
     http = require('http'),
     express = require('express'),
@@ -282,7 +306,8 @@ var iotAgentLib = require('iotagent-node-lib'),
 The main step to complete in order to implement the Lazy attributes mechanism in the IOTA is to provide handlers for the context
 provisioning requests. At this point, we should provide two handlers: the updateContext and the queryContext handlers.
 To do so, we must first define the handlers themselves:
-``` javascript
+
+```javascript
 function queryContextHandler(id, type, service, subservice, attributes, callback) {
     var options = {
         url: 'http://127.0.0.1:9999/iot/d',
@@ -310,7 +335,8 @@ In order to format the response from the device in a readable way, we created a 
 the values to its correspondent attributes. This function assumes the type of all the attributes is "string" (this will
 not be the case in a real scenario, where the IOTA should retrieve the associated device to guess the type of its 
 attributes). Here is the code for the `createResponse()` function:
-``` javascript
+
+```javascript
 function createResponse(id, type, attributes, body) {
     var values = body.split(','),
         responses = [];
@@ -332,7 +358,8 @@ function createResponse(id, type, attributes, body) {
 ```
 
 #### UpdateContext implementation
-``` javascript
+
+```javascript
 function updateContextHandler(id, type, service, subservice, attributes, callback) {
     var options = {
         url: 'http://127.0.0.1:9999/iot/d',
@@ -363,7 +390,8 @@ attributes.
 
 For this handler we have used a helper function called `createQueryFromAttributes()`, that transforms the NGSI representation
 of the attributes to the UL type expected by the device:
-``` javascript
+
+```javascript
 function createQueryFromAttributes(attributes) {
     var query = "";
 
@@ -382,7 +410,8 @@ function createQueryFromAttributes(attributes) {
 #### Handler registration
 Once both handlers have been defined, they have to be registered in the IOTA, adding the following code to the setup
 function:
-``` javascript
+
+```javascript
     iotAgentLib.setDataUpdateHandler(updateContextHandler);
     iotAgentLib.setDataQueryHandler(queryContextHandler);
 ```
@@ -390,7 +419,8 @@ function:
 #### IOTA Testing
 In order to test it, we need to create an HTTP server simulating the device. The quickest way to do that may be using 
 netcat. In order to start it just run the following command from the command line (Linux and Mac only):
-```
+
+```console
 nc -l 9999
 ```
 This will open a simple TCP server listening on port 9999, where the requests from the IOTA will be printed. In order for
@@ -404,14 +434,15 @@ one (or you can modify it to accept more requests and give more complex response
 to the same folder of your IoTAgent (as it uses the same dependencies). In order to run the echo server, just
 execute the following command:
 
-```
+```console
 node echo.js
 ```
 
 Once the mock server has been started (either nc or the echo server), proceed with the following steps to test your implementation:
 
 1. Provision a device with two lazy attributes. The following request can be used as an example:
-```
+
+```console
 POST /iot/devices HTTP/1.1
 Host: localhost:4041
 Content-Type: application/json
@@ -444,7 +475,8 @@ Postman-Token: 993ac66b-72da-9e96-ab46-779677a5896a
 ```
 
 2. Execute a queryContext or updateContext against one of the entity attributes (use a NGSI client of curl command).
-```
+
+```console
 POST /v1/queryContext HTTP/1.1
 Host: localhost:1026
 Content-Type: application/json
@@ -496,7 +528,8 @@ are receiving whenever a new device or configuration is provisioned.
 
 We need to complete two steps to have a working set of provisioning handlers. First of all, defining the handlers themselves.
 Here we can see the definition of the configuration handler:
-``` javascript
+
+```javascript
 function configurationHandler(configuration, callback) {
     console.log('\n\n* REGISTERING A NEW CONFIGURATION:\n%s\n\n', JSON.stringify(configuration, null, 4));
     callback(null, configuration);
@@ -511,7 +544,8 @@ Note also that the same `device` or `configuration` object is passed along to th
 of the values provisioned by the user, to add or restrict information in the provisioning. To test this feature, let's 
 use the provisioning handler to change the value of the type of the provisioning device to 'CertifiedType' (reflecting
 some validation process performed on the provisioning):
-``` javascript
+
+```javascript
 function provisioningHandler(device, callback) {
     console.log('\n\n* REGISTERING A NEW DEVICE:\n%s\n\n', JSON.stringify(device, null, 4));
     device.type = 'CertifiedType';
@@ -520,7 +554,8 @@ function provisioningHandler(device, callback) {
 ```
 
 Once the handlers are defined, the new set of handlers has to be registered into the IOTAgent:
-``` javascript
+
+```javascript
     iotAgentLib.setConfigurationHandler(configurationHandler);
     iotAgentLib.setProvisioningHandler(provisioningHandler);
 ```

--- a/doc/installationguide.md
+++ b/doc/installationguide.md
@@ -1,6 +1,6 @@
 # Installation & Administration Guide
 
-## <a name="configuration"/> Configuration
+## Configuration
 The `activate()` function that starts the IoT Agent receives as single parameter with the configuration for the IoT Agent.
 The Agent Console reads the same configuration from the `config.js` file.
 
@@ -8,13 +8,16 @@ The Agent Console reads the same configuration from the `config.js` file.
 These are the parameters that can be configured in the global section:
 * **logLevel**: minimum log level to log. May take one of the following values: DEBUG, INFO, ERROR, FATAL. E.g.: 'DEBUG'.
 * **contextBroker**: connection data to the Context Broker (host and port). E.g.:
+
 ```
 	{
 	host: '192.168.56.101',
 	port: '1026'
     	}
 ```
+
  * If you want to use NGSIv2 (only sending updates for active attributes):
+
 ```
   {
     host: '192.168.56.101',
@@ -22,14 +25,18 @@ These are the parameters that can be configured in the global section:
     ngsiVersion: 'v2'
   }
 ``` 
+
 * **server**: configuration used to create the Context Server (port where the IoT Agent will be listening as a Context Provider and base root to prefix all the paths). The `port` attribute is required. If no `baseRoot` attribute is used, '/' is used by default. E.g.:
+
 ```
 	{
 	baseRoot: '/',
         port: 4041
     	}
+
 ```
 * **stats**: configure the periodic collection of statistics. Use `interval` in milliseconds to set the time between stats writings.
+
 ```
     stats: {
         interval: 100
@@ -43,7 +50,8 @@ These are the parameters that can be configured in the global section:
   (alternatively `host` and `port` but if you use this combination, the IoT Agent will assume that the protocol is HTTP), the `user` and `password` to which it is delegated
   the `trust` verification.
   E.g.:
-    ```
+
+```
     {
           enabled: true,
           url: 'https://localhost:5000',
@@ -51,7 +59,8 @@ These are the parameters that can be configured in the global section:
           user: 'iotagent',
           password: 'iotagent'
     }
-    ```
+```
+
   In `oauth2` based authentication, the `trust` associated to the `device` or `deviceGroup` is a `refresh_token` issued by a specific user for the Context Broker client. 
   The authentication process use the [`refresh_token` grant type](https://tools.ietf.org/html/rfc6749#section-1.5) to obtain an `access_token`
   that can be used to authenticate the request to the Context Broker.
@@ -63,7 +72,8 @@ These are the parameters that can be configured in the global section:
   that the protocol is HTTP), the `tokenPath` to which the validation request should be sent, the `clientId` and `clientSecret` that identify the Context Broker,
   and the `header` field that should be used to send the authentication request (that will be send in the form `Authorization: Bearer <access_token>`).
   E.g.:
-    ```
+
+```
     {
         enabled: true,
         type: 'oauth2',
@@ -73,17 +83,21 @@ These are the parameters that can be configured in the global section:
         clientSecret: 'c8d58d16-0a42-400e-9765-f32e154a5a9e',
         tokenPath: '/auth/realms/default/protocol/openid-connect/token'
     }
-    ```
+```
+
 * **deviceRegistry**: type of Device Registry to create. Currently, two values are supported: `memory` and `mongodb`. If the former is configured, a transient memory-based device registry will be used to register all the devices. This registry will be emptied whenever the process is restarted. If the latter is selected, a MongoDB database will be used to store all the device information, so it will be persistent from one execution to the other. Mongodb databases must be configured in the `mongob` section (as described bellow). E.g.:
+
 ```
 {
   type: 'mongodb'
 }
 ```
+
 * **mongodb**: configures the MongoDB driver for those repositories with 'mongodb' type. If the `host` parameter is a list of comma-separated IPs, they will
 be considered to be part of a Replica Set. In that case, the optional property `replicaSet` should contain the Replica Set name. The MongoBD driver will
 retry the connection at startup time `retries` times, waiting `retryTime` seconds between attempts, if those attributes are present (default values
 are 5 and 5 respectively). E.g.:
+
 ```
 {
   host: 'localhost',
@@ -94,10 +108,12 @@ are 5 and 5 respectively). E.g.:
 
 }
 ```
+
 * **iotManager**: configures all the information needed to register the IoT Agent in the IoTManager. If this section is
  present, the IoTA will try to register to a IoTAM in the `host`, `port` and `path` indicated, with the information
  configured in the object. The IoTAgent URL that will be reported will be the `providedUrl` (described below) with the
  added `agentPath`:
+
 ```
 {
     host: 'mockediotam.com',
@@ -108,6 +124,7 @@ are 5 and 5 respectively). E.g.:
     agentPath: '/iot'
 }
 ```
+
 * **types**: See **Type Configuration** in the [Configuration API](#configurationapi) section below.
 * **eventType**: Default type for the Events (useful only with the `addEvents` plugin).
 * **service**: default service for the IoT Agent. If a device is being registered, and no service information comes with the device data, and no service information is configured for the given type, the default IoT agent service will be used instead. E.g.: 'smartGondor'.

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -5,23 +5,23 @@
 * [Overview](#overview)
 * [Requirements](#requirements)
 * [Theory](#theory)
-  * [Overview](#theoryoverview)
-  * [Data interaction payloads (NGSIv10)](#payloads)
-  * [Scenario 1: active attributes](#scn1active)
-  * [Scenario 2: lazy attributes](#scn2lazy)
-  * [Scenario 3: command attributes](#scn3command)
-  * [How to select an scenario](#scenarioselection)
+  + [Overview](#overview-1)
+  + [Data interaction payloads (NGSIv10)](#data-interaction-payloads-ngsiv10)
+  + [Scenario 1: active attributes](#scenario-1-active-attributes)
+  + [Scenario 2: lazy attributes](#scenario-2-lazy-attributes)
+  + [Scenario 3: commands](#scenario-3-commands)
+  + [How to select an scenario](#how-to-select-an-scenario)
 * [Practice](#practice)
-  * [Overview](#practiceoverview)
-  * [Retrieving a token](#token)
-  * [Scenario 1: active attributes (happy path)](#activehp)
-  * [Scenario 1: active attributes (error)](#activeerror)
-  * [Scenario 2: lazy attributes (happy path)](#lazyhp)
-  * [Scenario 2: lazy attributes (error)](#lazyerror)
-  * [Scenario 3: commands (happy path)](#commandshp)
-  * [Scenario 3: commands (error)](#commandserror)
+  + [Overview](#overview-2)
+  + [Retrieving a token](#retrieving-a-token)
+  + [Scenario 1: active attributes (happy path)](#scenario-1-active-attributes-happy-path)
+  + [Scenario 1: active attributes (error)](#scenario-1-active-attributes-error)
+  + [Scenario 2: lazy attributes (happy path)](#scenario-2-lazy-attributes-happy-path)
+  + [Scenario 2: lazy attributes (error)](#scenario-2-lazy-attributes-error)
+  + [Scenario 3: commands (happy path)](#scenario-3-commands-happy-path)
+  + [Scenario 3: commands (error)](#scenario-3-commands-error)
 
-## <a name="overview"/> Overview
+## Overview
 This document's target is to explain in detail how the IoTAgent interacts with the Context Broker in all the possible
 IoT Scenarios that are supported by this library.
 
@@ -37,7 +37,7 @@ information should always be sent:
 * X-Auth-Token header with a valid unexpired token for a user that has admin permissions in the subservice. In this case
 the user "adminiota2ngsi" will be used for all interactions
 
-## <a name="requirements"/> Requirements
+## Requirements
 The practical part of this document has the following requirements:
 
 * A Unix-line command line interpreter. All the workshop will take place in the command line, making use of different
@@ -51,9 +51,9 @@ command-line tools to simulate the different interactions.
 
 * Basic knowledge of the NGSI model and HTTP interfaces.
 
-## <a name="theory"/> Theory
+## Theory
 
-### <a name="theoryoverview"/> Overview
+### Overview
 
 #### General purpose of the IoT Agents
 Inside the FIWARE Architecture, the IoT Agents work as protocol translation gateways, used to fill the gap between
@@ -90,7 +90,7 @@ socket open waiting for the response until all the interaction scenario ends, re
 through the same socket that initiated the request
 ```
 
-### <a name="payloads"/> Data interaction payloads (NGSIv10)
+### Data interaction payloads (NGSIv10)
 
 There are only two kinds of possible data interactions between the IoTAgents and the Context Broker: the queryContext and
 updateContext interactions described in NGSIv10. Lots of examples can be found in the
@@ -256,7 +256,7 @@ Application level errors can be specified for each entity in this payload.
 This special payload can be used to specify general errors with the request, that are not associated to any particular
 Context Element, but with the request as a whole.
 
-### <a name="scn1active"/> Scenario 1: active attributes
+### Scenario 1: active attributes
 
 ![General ](../img/scenario1.png "Scenario 1: active attributes")
 
@@ -270,7 +270,7 @@ This scenario leaves all the data locally stored in the Context Broker, so the u
 NGSI APIs offered by the Context Broker (including subscriptions). This data queries are completely separate from the
 updating process, and can occur at any time (they are to completely different process).
 
-### <a name="scn2lazy"/> Scenario 2: lazy attributes
+### Scenario 2: lazy attributes
 
 ![General ](../img/scenario2.png "Scenario 2: lazy attributes")
 
@@ -295,7 +295,7 @@ This scenario can be used for both updates and queries. The only difference betw
 to use: updateContext actions for the update (and thus, P1 and R1 payloads); and queryContext actions for the queries
 (and thus P2 and R2 payloads).
 
-### <a name="scn3command"/> Scenario 3: commands
+### Scenario 3: commands
 
 ![General ](../img/scenario3.png "Scenario 3: commands")
 
@@ -315,7 +315,7 @@ set of arguments of the command. Only updateContext operations will be used to i
 * Another attribute will be used as the *result attribute*. This attribute will be updated from the IoTAgent, and its
 value stored in the Context Broker. This attribute will contain the result of the command (this result can be information
 in case the command was a "information retrieval" command or the result of an action if it was an "actuator command").
-Typically, the name of this attribute will be the same of the input attribute, with an additional sufix ("_info").
+Typically, the name of this attribute will be the same of the input attribute, with an additional sufix (`_info`).
 
 * Another attribute with the same characteristics as the later will be used to indicate whether the command has ended
 successfully or whether an error has been reported.
@@ -338,7 +338,7 @@ This scenario leaves all the data locally stored in the Context Broker, so the u
 NGSI APIs offered by the Context Broker (as shown in the (7) and (8) requests in the diagram). This data queries are
 completely separate from the updating process, and can occur at any time (they are to completely different process).
 
-### <a name="scenario selection"/> How to select an scenario
+### How to select an scenario
 
 The three different scenarios can be used in different situations:
 
@@ -346,9 +346,9 @@ The three different scenarios can be used in different situations:
 * **Scenario 2**: designed for interactions started by the User that are fast enough to be performed synchronously (within the time of an HTTP timeout).
 * **Scenario 3**: designed for interactions started by the User that are too slow to be performed synchrounously.
 
-## <a name="practice"/> Practice
+## Practice
 
-### <a name="practiceoverview"> Overview
+### Overview
 The following sections will show a series of examples of all the interactions that can be found in each scenario.
 
 Initial requests are shown as full Curl commands (that can be used to reproduce the example).
@@ -365,7 +365,7 @@ Along this document, IP addresses and passwords will be concealed. Substitute th
 A postman collection is available alongside this document to help in reproducing this examples. It can be found
 [here](./doc/NorthboundInteractions.postman_collection).
 
-### <a name="token"/> Retrieving a token
+### Retrieving a token
 
 This scenario assumes that the IoTAgent is connected to an Orion Context Broker secured by a Steelskin PEP, so every
 request to the Context Broker should be authenticated.
@@ -422,7 +422,7 @@ The User token that needs to be used in the authorization header will be returne
 `X-Subject-Token`. This value should be appended in the `X-Auth-Token` header for all the requests made to the
 Context Broker (as it will be seen in the examples).
 
-### <a name="activehp"/> Scenario 1: active attributes (happy path)
+### Scenario 1: active attributes (happy path)
 
 In this scenario, a device actively sends data to the IoT Agent, that transforms that data into a NGSI request
 that is sent to the Context Broker. This request has the following format (P1):
@@ -520,7 +520,7 @@ The Context Broker will reply with the updated data values in R2 format (200 OK)
 }
 ```
 
-### <a name="activeerror"/> Scenario 1: active attributes (error)
+### Scenario 1: active attributes (error)
 
 Two kind of errors can appear in this scenario. If there is an error updating the information, the Context Broker will
 replay with a payload like the following:
@@ -568,7 +568,7 @@ The following error payload is also valid in standard NGSI:
 Different kinds of errors can return their information in different formats, so NGSI implementations should check for
 the existence of both.
 
-### <a name="lazyhp"/> Scenario 2: lazy attributes (happy path)
+### Scenario 2: lazy attributes (happy path)
 
 Scenario 2 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
 must register its lazy attributes for each device, with a request like the following:
@@ -708,12 +708,12 @@ its original request (200 OK):
 }
 ```
 
-### <a name="lazyerror"/> Scenario 2: lazy attributes (error)
+### Scenario 2: lazy attributes (error)
 
 Being fully synchronous, errors for scenario 2 follow the same patterns as for scenario 1. If the IoTAgent returns an
 error, that error must follow the NGSI payloads described in the Scenario 1 error defined above.
 
-### <a name="commandshp"/> Scenario 3: commands (happy path)
+### Scenario 3: commands (happy path)
 
 #### Context Provider Registration
 Scenario 3 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
@@ -987,7 +987,7 @@ The Context Broker replies with all the desired data, in R2 format (200 OK):
 }
 ```
 
-### <a name="commandserror"/> Scenario 3: commands (error)
+### Scenario 3: commands (error)
 
 In Scenario 3, errors can happen asynchronously, out of the main interactions. When the IoTAgent detects an error
 executing the underlying command (i.e.: an error connecting with the device, or an error in the device itself),

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -84,11 +84,10 @@ This interactions can be mapped to three different scenarios (that will be detai
 Along this document, the term "synchronous interaction" will be widely used, so we will define its specific meaning here.
 Inside the scope of the IoTAgents documentation, a "synchronous scenario" will have the following definition:
 
-```
-Synchronous scenario is the one in which the actor that initiates the communication leaves its HTTP
-socket open waiting for the response until all the interaction scenario ends, receiving the results
-through the same socket that initiated the request
-```
+>Synchronous scenario is the one in which the actor that initiates the communication leaves its HTTP
+>socket open waiting for the response until all the interaction scenario ends, receiving the results
+>through the same socket that initiated the request
+
 
 ### Data interaction payloads (NGSIv10)
 
@@ -116,7 +115,7 @@ documentation for more details.
 
 This payload is associated to an update operation (POST /v1/updateContext).
 
-```
+```json
 {
     "contextElements": [
         {
@@ -152,7 +151,7 @@ don't exist.
 
 #### R1 - UpdateContext (response)
 
-```
+```json
 {
     "contextResponses": [
         {
@@ -190,7 +189,7 @@ Application level errors can be specified for each entity in this payload.
 #### P2 - QueryContext (request)
 This payload is associate to a query operation (POST /v1/queryContext).
 
-```
+```json
 {
     "entities": [
         {
@@ -204,6 +203,7 @@ This payload is associate to a query operation (POST /v1/queryContext).
     ]
 }
 ```
+
 The payload specifies the following information:
 
 * The list of target entities whose information is going to be retrieved.
@@ -212,7 +212,7 @@ The payload specifies the following information:
 
 #### R2 - QueryContext (response)
 
-```
+```json
 {
     "contextResponses": [
         {
@@ -244,7 +244,7 @@ Application level errors can be specified for each entity in this payload.
 
 #### E1 - Error
 
-```
+```json
 {
     "errorCode": {
         "code": "404",
@@ -371,7 +371,8 @@ This scenario assumes that the IoTAgent is connected to an Orion Context Broker 
 request to the Context Broker should be authenticated.
 
 In order to retrieve a token from the Keystone Identity Manager, the following request can be used:
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -d '{
 	"auth": {
 		"identity": {
@@ -394,7 +395,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 ```
 
 Keystone will reply with the following answer (201 Created):
-```
+
+```json
 {
   "token": {
     "issued_at": "2016-10-10T07:32:40.160439Z",
@@ -426,7 +428,8 @@ Context Broker (as it will be seen in the examples).
 
 In this scenario, a device actively sends data to the IoT Agent, that transforms that data into a NGSI request
 that is sent to the Context Broker. This request has the following format (P1):
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
     -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <Token>" -d '{
     "contextElements": [
@@ -448,7 +451,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 ```
 
 If the request is correct, the Context Broker will reply with the following R1 response (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -478,7 +482,8 @@ can be queried.
 
 Whenever the User wants to query this value, he can use any of the NGSI mechanisms for retrieving data. E.g. he can
 use a standard queryContext request, as the following one (P2):
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -495,7 +500,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 ```
 
 The Context Broker will reply with the updated data values in R2 format (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -524,7 +530,8 @@ The Context Broker will reply with the updated data values in R2 format (200 OK)
 
 Two kind of errors can appear in this scenario. If there is an error updating the information, the Context Broker will
 replay with a payload like the following:
-```
+
+```console
 {
   "contextResponses": [
     {
@@ -549,6 +556,7 @@ replay with a payload like the following:
   ]
 }
 ```
+
 It is worth mentioning that the Context Broker will reply with a 200 OK status code, as in standard NGSI, the HTTP codes
 refer to transport protocol level errors, while the status codes inside of a payload give information about the
 application level protocol.
@@ -556,7 +564,8 @@ application level protocol.
 The example shows an error updating an unexistent attribute (due to the use of UPDATE instead of APPEND).
 
 The following error payload is also valid in standard NGSI:
-```
+
+```json
 {
   "errorCode": {
     "code": "404",
@@ -572,7 +581,8 @@ the existence of both.
 
 Scenario 2 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
 must register its lazy attributes for each device, with a request like the following:
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-service: workshop" \
   -H "fiware-servicepath:  /iota2ngsi " -H "x-auth-token: <token>" -d '{
     "contextRegistrations": [
@@ -598,8 +608,10 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 }
 ' "https://<platform-ip>:10027/v1/registry/registerContext"
 ```
+
 If everything has gone OK, the Context Broker will return the following payload:
-```
+
+```json
 {
   "duration": "P1M",
   "registrationId": "57fb4642fdc8301538a65a04"
@@ -612,7 +624,7 @@ The registration of the attributes is performed once in the lifetime of the Devi
 In this scenario, a User actively asks for a particular piece of data from a device. The scenario starts with the
 request from the User to the Context Broker (P2):
 
-```
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -631,7 +643,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 The Context Broker receives this request and detects that it can be served by a Context Provider (the IoT Agent), so
 it redirects the exact same request to the IoT Agent. The following excerpt shows the full HTTP frame containing
 the redirection data:
-```
+
+```console
 POST /v1/queryContext HTTP/1.1
 Host: <target-host>:1026
 fiware-service: workshop
@@ -657,7 +670,8 @@ Fiware-Correlator: f77eea0a-8ebe-11e6-bab7-fa163e78b904
 ```
 
 If the requested data is available in the IoT Agent, it will answer with a R2 response (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -681,9 +695,11 @@ If the requested data is available in the IoT Agent, it will answer with a R2 re
   ]
 }
 ```
+
 Once the Context Broker has IoTAgent answer, it will forward it to the user in the same socket the user used for
 its original request (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -718,7 +734,8 @@ error, that error must follow the NGSI payloads described in the Scenario 1 erro
 #### Context Provider Registration
 Scenario 3 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
 must register its commands for each device, with a request like the following:
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-service: workshop" \
   -H "fiware-servicepath:  /iota2ngsi " -H "x-auth-token: <token>" -d '{
     "contextRegistrations": [
@@ -744,13 +761,16 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
 }
 ' "https://<platform-ip>:10027/v1/registry/registerContext"
 ```
+
 If everything has gone OK, the Context Broker will return the following payload:
-```
+
+```json
 {
   "duration": "P1M",
   "registrationId": "41adf79dc5a0bba830a6f3824"
 }
 ```
+
 This ID can be used to update the registration in the future.
 
 The registration of the commands is performed once in the lifetime of the Device.
@@ -758,7 +778,8 @@ The registration of the commands is performed once in the lifetime of the Device
 #### Command Execution
 
 Scenario 3 begins with the request for a command from the User to the Context Broker (P1):
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [
@@ -778,10 +799,12 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
     "updateAction": "UPDATE"
 } ' "https://<platform-ip>:10027/v1/updateContext"
 ```
+
 The Context Broker receives this command and detects that it can be served by a Context Provider (the IoT Agent), so
 it redirects the exact same request to the IoT Agent. The following excerpt shows the full HTTP frame containing
 the redirection data:
-```
+
+```console
 POST /v1/updateContext HTTP/1.1
 Host: <target-host>:1026
 fiware-service: workshop
@@ -810,10 +833,11 @@ Fiware-Correlator: 9cae9496-8ec7-11e6-80fc-fa163e734aab
   "updateAction" : "UPDATE"
 }
 ```
+
 The IoT Agent detects the selected attribute is a command, and replies to the Context Broker with the following
 payload (200 OK):
 
-```
+```json
 {
   "contextResponses": [
     {
@@ -837,12 +861,13 @@ payload (200 OK):
   ]
 }
 ```
+
 This response just indicates that the IoT Agent has received the command successfully, and gives no information about
 the requested information or command execution.
 
 The Context Broker, forwards the same response to the user, thus replying the original request (200 OK):
 
-```
+```json
 {
   "contextResponses": [
     {
@@ -875,7 +900,7 @@ request will be.
 Once the IoT Agent has executed the command or retrieved the information from the device, it reports the results
 to the Context Broker, with an updateContext (P1):
 
-```
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [
@@ -900,11 +925,13 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
     "updateAction": "APPEND"
 } ' "https://<platform-ip>:10027/v1/updateContext"
 ```
+
 This update does not modify the original command attribute, but two auxiliary attributes, that are not provided by the
 IoT Agent (usually, those attributes has the same name as the command, with an added suffix).
 
 The Context Broker replies to the IoT Agent with a R1 payload (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -933,6 +960,7 @@ The Context Broker replies to the IoT Agent with a R1 payload (200 OK):
   ]
 }
 ```
+
 This operation stores the retrieved values locally in the Context Broker, so it can be retrieved with standard NGSI
 mechanisms.
 
@@ -940,7 +968,8 @@ mechanisms.
 
 Whenever the User wants to know the status and result of the command, he can query the information in the Context
 Broker, using, for example, a standard queryContext request (P2):
-```
+
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -956,8 +985,10 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
     ]
 }' "https://<platform-ip>:10027/v1/queryContext"
 ```
+
 The Context Broker replies with all the desired data, in R2 format (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {
@@ -993,7 +1024,7 @@ In Scenario 3, errors can happen asynchronously, out of the main interactions. W
 executing the underlying command (i.e.: an error connecting with the device, or an error in the device itself),
 the error information can be updated with the same mechanism used for result reporting. E.g.:
 
-```
+```console
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [
@@ -1018,8 +1049,10 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
     "updateAction": "APPEND"
 } ' "https://<platform-ip>:10027/v1/updateContext"
 ```
+
 In this case, the Context Broker reply with the following response (200 OK):
-```
+
+```json
 {
   "contextResponses": [
     {

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -4,7 +4,7 @@
 * [Overview](#overview)
 * [Logs](#logs)
 * [Alarms](#alarms)
-* [Error naming code](#errorcode)
+* [Error naming code](#error-naming-code)
 
 ## Overview
 The following document shows all the errors that can appear in an IoT Agent using this library, and gives a brief

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -6,11 +6,11 @@
 * [Alarms](#alarms)
 * [Error naming code](#errorcode)
 
-## <a name="overview"/>  Overview
+## Overview
 The following document shows all the errors that can appear in an IoT Agent using this library, and gives a brief
 idea of the severity and how to react to those errors.
 
-## <a name="logs"/>  Logs
+## Logs
 The following section contains the error log entries that can appear in the IoT Agents logs, grouped by category.
 
 ### GENERAL-001 Couldn\'t find callback in listDevices() call.
@@ -85,7 +85,7 @@ Check connectivity between the machines, the status of the remote Context Broker
 Validation templates were not found. Check all the validation templates are properly located in the IoTAgent Library
 folder and that the file permissions are correct.
 
-## <a name="alarms"/> Alarms
+## Alarms
 
 The following table shows the alarms that can be raised in the IoTAgent library. All the alarms are signaled by a
 error log starting with the prefix "Raising [%s]:" (where %s is the alarm name). All the alarms are released by an info
@@ -104,7 +104,7 @@ while the 'Severity' criterium is as follows:
 * **Warning** - It is happening something that must be notified
 
 
-## <a name="errorcode"/> Error naming code
+## Error naming code
 Every error has a code composed of a prefix and an ID, codified with the following table:
 
 | Prefix           | Type of operation      |

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -2,17 +2,29 @@
 
 ## Index
 
-* [Usage](#usage)
-  * [Stats Registry](#statsregistry)
-  * [Alarm Module](#alarms)
-  * [Logs](#logs)
-  * [Transactions](#transactions)
-  * [Library Overview](#overview)
-  * [Function reference](#reference)
-* [Development Documentation](#development)
 
-## <a name="usage"/> Usage
-### <a name="statsregistry"/> Stats Registry
+* [Usage](#usage)
+  + [Stats Registry](#stats-registry)
+  + [Alarm module](#alarm-module)
+  + [Logs](#logs)
+  + [Transactions](#transactions)
+  + [Library overview](#library-overview)
+  + [Function reference](#function-reference)
+* [Development documentation](#development-documentation)
+  + [Contributions](#contributions)
+  + [Project build](#project-build)
+  + [Testing](#testing)
+  + [Coding guidelines](#coding-guidelines)
+  + [Continuous testing](#continuous-testing)
+  + [Source Code documentation](#source-code-documentation)
+  + [Code Coverage](#code-coverage)
+  + [Code complexity](#code-complexity)
+  + [PLC](#plc)
+  + [Development environment](#development-environment)
+  + [Site generation](#site-generation)
+
+## Usage
+### Stats Registry
 The library provides a mechanism for the periodic reporting of stats related to the library's work. In order to activate
 the use of the periodic stats, it must be configured in the config file, as described in the [Configuration](#configuration)
 section.
@@ -33,7 +45,7 @@ iotagentLib.statsRegistry.add('statName', statIncrementalValue, callback)
 The first time this function is invoked, it will add the new stat to the registry. Subsequent calls will add the value
 to the specified stat both to the current and global measures. The stat will be cleared in each interval as usual.
 
-### <a name="alarms"/> Alarm module
+### Alarm module
 
 The library provide an alarm module that can be used to track through the logs alarms raised in the IoTAgent. This module
 provides:
@@ -50,7 +62,7 @@ when it returns a success an alarm is ceased (`intercept()`).
 
 All this functions can be accessed through the `.alarms` attribute of the library.
 
-### <a name="logs"/> Logs
+### Logs
 The IoT Agent Library makes use of the [Logops logging library](https://github.com/telefonicaid/logops). This library
 is required in a `logger` object, shared between all of the modules. In order for the logging to be consistent across
 the diferent modules of an IoTAgent (i.e.: the ones provided by the IoTA Library as well as those created for the
@@ -69,7 +81,7 @@ for future logs.
 Returns the current log level, in a json payload with a single attribute `level`.
 
 
-### <a name="transactions"/> Transactions
+### Transactions
 The library implements a concept of transactions, in order to follow the execution flow the library follows when treating
 requests entering both from the Northbound and the Southbound.
 
@@ -89,20 +101,22 @@ this component will be used as the correlator.
 During the duration of a transaction, all the log entries created by the code will write the current Transaction ID and
 correlator for the operation being executed.
 
-### <a name="overview"/> Library overview
+### Library overview
 In order to use the library, add the following dependency to your package.json file:
-```
+
+```json
 "iotagent-node-lib": "*"
 ```
 In order to use this library, first you must require it:
-```
+
+```javascript
 var iotagentLib = require('iotagent-node-lib');
 ```
 The library supports four groups of features, one for each direction of the communication:
 client-to-server and server-to-client (and each flow both for the client and the server). Each feature set is defined
 in the following sections.
 
-### <a name="reference"/> Function reference
+### Function reference
 ##### iotagentLib.activate()
 ###### Signature
 ```
@@ -183,8 +197,8 @@ setCommandResult(entityName, resource, apikey, commandName, commandResult, statu
 ```
 ###### Description
 Update the result of a command in the Context Broker. The result of the command has two components: the result
-of the command itself will be represented with the sufix '_result' in the entity while the status is updated in the
-attribute with the '_info' sufix.
+of the command itself will be represented with the sufix `_result` in the entity while the status is updated in the
+attribute with the `_info` sufix.
 
 ###### Params
  * entityName: Name of the entity holding the command.
@@ -549,7 +563,7 @@ Stores the information about the IoTAgent for further use in the `retrieveVersio
 
 
 
-## <a name="development"/> Development documentation
+## Development documentation
 ### Contributions
 All contributions to this project are welcome. Developers planning to contribute should follow the [Contribution Guidelines](./docs/contribution.md)
 
@@ -557,7 +571,7 @@ All contributions to this project are welcome. Developers planning to contribute
 The project is managed using Grunt Task Runner.
 
 For a list of available task, type
-```bash
+```console
 grunt --help
 ```
 
@@ -572,13 +586,13 @@ The test environment is preconfigured to run [BDD](http://chaijs.com/api/bdd/) t
 Module mocking during testing can be done with [proxyquire](https://github.com/thlorenz/proxyquire)
 
 To run tests, type
-```bash
+```console
 grunt test
 ```
 
 Tests reports can be used together with Jenkins to monitor project quality metrics by means of TAP or XUnit plugins.
 To generate TAP report in `report/test/unit_tests.tap`, type
-```bash
+```console
 grunt test-report
 ```
 
@@ -588,14 +602,14 @@ jshint, gjslint
 Uses provided .jshintrc and .gjslintrc flag files. The latter requires Python and its use can be disabled
 while creating the project skeleton with grunt-init.
 To check source code style, type
-```bash
+```console
 grunt lint
 ```
 
 Checkstyle reports can be used together with Jenkins to monitor project quality metrics by means of Checkstyle
 and Violations plugins.
 To generate Checkstyle and JSLint reports under `report/lint/`, type
-```bash
+```console
 grunt lint-report
 ```
 
@@ -604,7 +618,7 @@ grunt lint-report
 
 Support for continuous testing by modifying a src file or a test.
 For continuous testing, type
-```bash
+```console
 grunt watch
 ```
 
@@ -614,7 +628,7 @@ dox-foundation
 
 Generates HTML documentation under `site/doc/`. It can be used together with jenkins by means of DocLinks plugin.
 For compiling source code documentation, type
-```bash
+```console
 grunt doc
 ```
 
@@ -625,14 +639,14 @@ Istanbul
 Analizes the code coverage of your tests.
 
 To generate an HTML coverage report under `site/coverage/` and to print out a summary, type
-```bash
+```console
 # Use git-bash on Windows
 grunt coverage
 ```
 
 To generate a Cobertura report in `report/coverage/cobertura-coverage.xml` that can be used together with Jenkins to
 monitor project quality metrics by means of Cobertura plugin, type
-```bash
+```console
 # Use git-bash on Windows
 grunt coverage-report
 ```
@@ -644,14 +658,14 @@ Plato
 Analizes code complexity using Plato and stores the report under `site/report/`. It can be used together with jenkins
 by means of DocLinks plugin.
 For complexity report, type
-```bash
+```console
 grunt complexity
 ```
 
 ### PLC
 
 Update the contributors for the project
-```bash
+```console
 grunt contributors
 ```
 
@@ -659,13 +673,14 @@ grunt contributors
 ### Development environment
 
 Initialize your environment with git hooks.
-```bash
+```console
 grunt init-dev-env
 ```
 
 We strongly suggest you to make an automatic execution of this task for every developer simply by adding the following
 lines to your `package.json`
-```
+
+```json
 {
   "scripts": {
      "postinstall": "grunt init-dev-env"
@@ -679,7 +694,7 @@ lines to your `package.json`
 There is a grunt task to generate the GitHub pages of the project, publishing also coverage, complexity and JSDocs pages.
 In order to initialize the GitHub pages, use:
 
-```bash
+```console
 grunt init-pages
 ```
 
@@ -687,7 +702,7 @@ This will also create a site folder under the root of your repository. This site
 history, and associated to the gh-pages branch, created for publishing. This initialization action should be done only
 once in the project history. Once the site has been initialized, publish with the following command:
 
-```bash
+```console
 grunt site
 ```
 

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -119,7 +119,8 @@ in the following sections.
 ### Function reference
 ##### iotagentLib.activate()
 ###### Signature
-```
+
+```javascript
 function activate(newConfig, callback)
 ```
 ###### Description
@@ -129,7 +130,8 @@ Activates the IoT Agent to start listening for NGSI Calls (acting as a Context P
 
 ##### iotagentLib.deactivate()
 ###### Signature
-```
+
+```javascript
 function deactivate(callback)
 ```
 ###### Description
@@ -138,8 +140,9 @@ Stops the HTTP server.
 
 ##### iotagentLib.register()
 ###### Signature
-```
-registerDevice(deviceObj, callback)
+
+```javascript
+function registerDevice(deviceObj, callback)
 ```
 ###### Description
 Register a new device in the IoT Agent. This registration will also trigger a Context Provider registration in the Context Broker for all its lazy attributes.
@@ -165,7 +168,8 @@ If the device has been previously preprovisioned, the missing data will be compl
 
 ##### iotagentLib.unregister()
 ###### Signature
-```
+
+```javascript
 function unregisterDevice(id, service, subservice, callback)
 ```
 ###### Description
@@ -177,8 +181,9 @@ Unregister a device from the Context broker and the internal registry.
 
 ##### iotagentLib.update()
 ###### Signature
-```
-update(entityName, attributes, typeInformation, token, callback)
+
+```javascript
+function update(entityName, attributes, typeInformation, token, callback)
 ```
 ###### Description
 Makes an update in the Device's entity in the context broker, with the values given in the 'attributes' array. This
@@ -192,8 +197,9 @@ array should comply to the NGSI's attribute format.
 
 ##### iotagentLib.setCommandResult()
 ###### Signature
-```
-setCommandResult(entityName, resource, apikey, commandName, commandResult, status, deviceInformation, callback)
+
+```javascript
+function setCommandResult(entityName, resource, apikey, commandName, commandResult, status, deviceInformation, callback)
 ```
 ###### Description
 Update the result of a command in the Context Broker. The result of the command has two components: the result
@@ -211,17 +217,20 @@ attribute with the `_info` sufix.
 
 ##### iotagentLib.listDevices()
 ###### Signature
-```
+
+```javascript
 function listDevices(callback)
 function listDevices(limit, offset, callback)
 function listDevices(service, subservice, limit, offset, callback)
 ```
+
 ###### Description
 Return a list of all the devices registered in the specified service and subservice. This function can be invoked in
 three different ways:
 * with just one parameter (the callback)
 * with three parameters (service, subservice and callback)
 * or with five parameters (including limit and offset).
+
 ###### Params
 * service: service from where the devices will be retrieved.
 * subservice: subservice from where the devices will be retrieved.
@@ -230,7 +239,8 @@ three different ways:
 
 ##### iotagentLib.setDataUpdateHandler()
 ###### Signature
-```
+
+```javascript
 function setDataUpdateHandler(newHandler)
 ```
 ###### Description
@@ -239,7 +249,8 @@ with the following parameters: (id, type, service, subservice, attributes, callb
 updating the corresponding values in the devices with the appropriate protocol.
 
 Once all the updates have taken place, the callback must be invoked with the updated Context Element. E.g.:
-```
+
+```javascript
     callback(null, {
         type: 'TheType',
         isPattern: false,
@@ -261,7 +272,8 @@ entity, and all the results will be combined into a single response.
 
 ##### iotagentLib.setDataQueryHandler()
 ###### Signature
-```
+
+```javascript
 function setDataQueryHandler(newHandler)
 ```
 ###### Description
@@ -270,7 +282,8 @@ with the following parameters: (id, type, service, subservice, attributes, callb
 corresponding information from the devices and return a NGSI entity with the requested values.
 
 The callback must be invoked with the updated Context Element, using the information retrieved from the devices. E.g.:
-```
+
+```javascript
     callback(null, {
         type: 'TheType',
         isPattern: false,
@@ -287,12 +300,14 @@ The callback must be invoked with the updated Context Element, using the informa
 
 In the case of NGSI requests affecting multiple entities, this handler will be called multiple times, one for each
 entity, and all the results will be combined into a single response.
+
 ###### Params
  * newHandler: User handler for query requests.
 
 ##### iotagentLib.setNotificationHandler()
 ###### Signature
-```
+
+```javascript
 function setNotificationHandler(newHandler)
 ```
 ###### Description
@@ -300,7 +315,8 @@ Sets the new handler for incoming notifications. The notifications are sent by t
 with the subscribe() function.
 
 The handler must adhere to the following signature:
-```
+
+```javascript
 function mockedHandler(device, data, callback)
 ```
 The `device` parameter contains the device object corresponding to the entity whose changes were notified
@@ -315,7 +331,8 @@ The handler is expected to call its callback once with no parameters (failing to
 
 ##### iotagentLib.setConfigurationHandler()
 ###### Signature
-```
+
+```javascript
 function setConfigurationHandler(newHandler)
 ```
 ###### Description
@@ -323,7 +340,8 @@ Sets the new user handler for the configuration updates. This handler will be ca
 created or an old configuration is updated.
 
 The handler must adhere to the following signature:
-```
+
+```javascript
 function(newConfiguration, callback)
 ```
 The `newConfiguration` parameter will contain the newly created configuration. The handler is expected to call its
@@ -335,7 +353,8 @@ handler will be called once for each of the configurations (both in the case of 
 
 ##### iotagentLib.getDevice()
 ###### Signature
-```
+
+```javascript
 function getDevice(deviceId, service, subservice, callback)
 ```
 ###### Description
@@ -347,7 +366,8 @@ Retrieve all the information about a device from the device registry.
 
 ##### iotagentLib.getDeviceByName()
 ###### Signature
-```
+
+```javascript
 function getDeviceByName(deviceName, service, subservice, callback)
 ```
 ###### Description
@@ -360,7 +380,8 @@ Retrieve a device from the registry based on its entity name.
 
 ##### iotagentLib.getDevicesByAttribute()
 ###### Signature
-```
+
+```javascript
 function getDevicesByAttribute(attributeName, attributeValue, service, subservice, callback)
 ```
 ###### Description
@@ -375,7 +396,8 @@ Retrieve all the devices having an attribute named `name` with value `value`.
 
 ##### iotagentLib.retrieveDevice()
 ###### Signature
-```
+
+```javascript
 function retrieveDevice(deviceId, apiKey, callback)
 ```
 ###### Description
@@ -388,7 +410,8 @@ for the given data.
 
 ##### iotagentLib.mergeDeviceWithConfiguration()
 ###### Signature
-```
+
+```javascript
 function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuration, callback)
 ```
 ###### Description
@@ -403,7 +426,8 @@ device). The first argument indicates what fields would be merged.
 
 ##### iotagentLib.getConfiguration()
 ###### Signature
-```
+
+```javascript
 function getConfiguration(resource, apikey, callback)
 ```
 ###### Description
@@ -416,7 +440,8 @@ Gets the device group identified by the given (`resource`, `apikey`) pair.
 
 ##### iotagentLib.findConfiguration()
 ###### Signature
-```
+
+```javascript
 function findConfiguration(service, subservice, callback)
 ```
 ###### Description
@@ -428,7 +453,8 @@ Find a device group based on its service and subservice.
 
 ##### iotagentLib.getEffectiveApiKey()
 ###### Signature
-```
+
+```javascript
 function getEffectiveApiKey(service, subservice, type, callback)
 ```
 ###### Description
@@ -441,7 +467,8 @@ Get the API Key for the selected service if there is any, or the default API Key
 
 ##### iotagentLib.subscribe()
 ###### Signature
-```
+
+```javascript
 function subscribe(device, triggers, content, callback)
 ```
 ###### Description
@@ -454,7 +481,8 @@ Creates a subscription for the IoTA to the entity representing the selected devi
 
 ##### iotagentLib.unsubscribe()
 ###### Signature
-```
+
+```javascript
 function unsubscribe(device, id, callback)
 ```
 ###### Description
@@ -467,7 +495,8 @@ Removes a single subscription from the selected device, identified by its id.
 
 ##### iotagentLib.ensureSouthboundDomain()
 ###### Signature
-```
+
+```javascript
 function ensureSouthboundTransaction(context, callback)
 ```
 ###### Description
@@ -481,7 +510,8 @@ If the function is executed in the context of a previous transaction, just the c
 
 
 ##### iotagentLib.finishSouthBoundTransaction()
-```
+
+```javascript
 function finishSouthboundTransaction(callback)
 ```
 ###### Description
@@ -495,7 +525,8 @@ to the servers using the standard Express mechanisms.
 
 ##### iotagentLib.middlewares.handleError()
 ###### Signature
-```
+
+```javascript
 function handleError(error, req, res, next)
 ```
 ###### Description
@@ -505,7 +536,8 @@ returning 500 when no error code has been found.
 
 ##### iotagentLib.middlewares.traceRequest()
 ###### Signature
-```
+
+```javascript
 function traceRequest(req, res, next)
 ```
 ###### Description
@@ -514,7 +546,8 @@ Express middleware for tracing the complete request arriving to the IoTA in debu
 
 ##### iotagentLib.middlewares.changeLogLevel()
 ###### Signature
-```
+
+```javascript
 function changeLogLevel(req, res, next)
 ```
 ###### Description
@@ -522,7 +555,8 @@ Changes the log level to the one specified in the request.
 
 ##### iotagentLib.middlewares.ensureType()
 ###### Signature
-```
+
+```javascript
 function ensureType(req, res, next)
 ```
 ###### Description
@@ -530,7 +564,8 @@ Ensures the request type is one of the supported ones.
 
 ##### iotagentLib.middlewares.validateJson()
 ###### Signature
-```
+
+```javascript
 function validateJson(template)
 ```
 ###### Description
@@ -543,7 +578,8 @@ Returns an Express middleware used in request validation with the given template
 
 ##### iotagentLib.middlewares.retrieveVersion()
 ###### Signature
-```
+
+```javascript
 function retrieveVersion(req, res, next)
 ```
 ###### Description
@@ -552,7 +588,8 @@ Middleware that returns all the IoTA information stored in the module.
 
 ##### iotagentLib.middlewares.setIotaInformation()
 ###### Signature
-```
+
+```javascript
 function setIotaInformation(newIoTAInfo)
 ```
 ###### Description
@@ -571,6 +608,7 @@ All contributions to this project are welcome. Developers planning to contribute
 The project is managed using Grunt Task Runner.
 
 For a list of available task, type
+
 ```console
 grunt --help
 ```
@@ -586,12 +624,14 @@ The test environment is preconfigured to run [BDD](http://chaijs.com/api/bdd/) t
 Module mocking during testing can be done with [proxyquire](https://github.com/thlorenz/proxyquire)
 
 To run tests, type
+
 ```console
 grunt test
 ```
 
 Tests reports can be used together with Jenkins to monitor project quality metrics by means of TAP or XUnit plugins.
 To generate TAP report in `report/test/unit_tests.tap`, type
+
 ```console
 grunt test-report
 ```
@@ -602,6 +642,7 @@ jshint, gjslint
 Uses provided .jshintrc and .gjslintrc flag files. The latter requires Python and its use can be disabled
 while creating the project skeleton with grunt-init.
 To check source code style, type
+
 ```console
 grunt lint
 ```
@@ -609,6 +650,7 @@ grunt lint
 Checkstyle reports can be used together with Jenkins to monitor project quality metrics by means of Checkstyle
 and Violations plugins.
 To generate Checkstyle and JSLint reports under `report/lint/`, type
+
 ```console
 grunt lint-report
 ```
@@ -618,6 +660,7 @@ grunt lint-report
 
 Support for continuous testing by modifying a src file or a test.
 For continuous testing, type
+
 ```console
 grunt watch
 ```
@@ -628,6 +671,7 @@ dox-foundation
 
 Generates HTML documentation under `site/doc/`. It can be used together with jenkins by means of DocLinks plugin.
 For compiling source code documentation, type
+
 ```console
 grunt doc
 ```
@@ -639,6 +683,7 @@ Istanbul
 Analizes the code coverage of your tests.
 
 To generate an HTML coverage report under `site/coverage/` and to print out a summary, type
+
 ```console
 # Use git-bash on Windows
 grunt coverage
@@ -646,6 +691,7 @@ grunt coverage
 
 To generate a Cobertura report in `report/coverage/cobertura-coverage.xml` that can be used together with Jenkins to
 monitor project quality metrics by means of Cobertura plugin, type
+
 ```console
 # Use git-bash on Windows
 grunt coverage-report
@@ -658,6 +704,7 @@ Plato
 Analizes code complexity using Plato and stores the report under `site/report/`. It can be used together with jenkins
 by means of DocLinks plugin.
 For complexity report, type
+
 ```console
 grunt complexity
 ```
@@ -665,6 +712,7 @@ grunt complexity
 ### PLC
 
 Update the contributors for the project
+
 ```console
 grunt contributors
 ```
@@ -673,6 +721,7 @@ grunt contributors
 ### Development environment
 
 Initialize your environment with git hooks.
+
 ```console
 grunt init-dev-env
 ```
@@ -694,6 +743,7 @@ lines to your `package.json`
 There is a grunt task to generate the GitHub pages of the project, publishing also coverage, complexity and JSDocs pages.
 In order to initialize the GitHub pages, use:
 
+
 ```console
 grunt init-pages
 ```
@@ -701,6 +751,7 @@ grunt init-pages
 This will also create a site folder under the root of your repository. This site folder is detached from your repository's
 history, and associated to the gh-pages branch, created for publishing. This initialization action should be done only
 once in the project history. Once the site has been initialized, publish with the following command:
+
 
 ```console
 grunt site


### PR DESCRIPTION
* The link to readthedocs on the main readme has been corrected
* Readthedocs is unable to handle `<a href="xx">` anchor tags, this also messes up the sidebar in readthedocs. These have been removed.
* Table of Contents (ToC) has been regenerated for each documentation file.
* Readthedocs cannot handle fenced code blocks - an extra linefeed has been added where necessary.

To be honest the ToC is both confusing and unnecessary for the readthedocs documentation - it is generated on the sidebar automatically. Second level headings are also not indented by readthedocs

My preference would be to remove the extra table of contents on each readthedocs, but I have done a 1-to-1 replacement for now, therefore some pages have a ToC, others do not. Some have a one level ToC, others a 2 level ToC.



