### PR TITLE
check foundGroup count in generateDuplicateHandler

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -20,3 +20,4 @@
 - Fix: timestampProcessPlugin supports processing an array of NGSI entities in NGSIv2 (#621)
 - Fix: undefined MONGO-ALARMS in logs due to a bad mongo query. (#630, #577)
 - Fix: multientity ngsiv1 duplicated attributes in entity (#627)
+- FIX: check foundGroup count in generateDuplicateHandle (#644)

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -47,8 +47,8 @@ function validateGroup(group, callback) {
 
     function generateDuplicateHandler(innerCb) {
         return function(error, foundGroup) {
-            if (!error || foundGroup) {
-                logger.debug(context, 'generateDuplicateHander error %s foundGroup %j', error, foundGroup);
+            logger.debug(context, 'generateDuplicateHander error %s and foundGroup %j', error, foundGroup);
+            if (foundGroup && foundGroup.count > 0) {
                 innerCb(new errors.DuplicateGroup(group.resource, group.apikey));
             } else {
                 innerCb();

--- a/lib/services/groups/groupService.js
+++ b/lib/services/groups/groupService.js
@@ -48,7 +48,7 @@ function validateGroup(group, callback) {
     function generateDuplicateHandler(innerCb) {
         return function(error, foundGroup) {
             logger.debug(context, 'generateDuplicateHander error %s and foundGroup %j', error, foundGroup);
-            if (foundGroup && foundGroup.count > 0) {
+            if (!error || (foundGroup && foundGroup.count > 0)) {
                 innerCb(new errors.DuplicateGroup(group.resource, group.apikey));
             } else {
                 innerCb();


### PR DESCRIPTION
https://github.com/telefonicaid/iotagent-node-lib/issues/633

after increase mongodb driver version cursor now returns a non empty foundGroup like:
foundGroup {"count":0,"services":[]} 
