### PR TITLE
replace undefined by current alarm description

### DIFF
--- a/lib/services/common/alarmManagement.js
+++ b/lib/services/common/alarmManagement.js
@@ -97,7 +97,7 @@ function intercept(alarmName, targetFn) {
                 error = originalArguments.slice(0, 1);
 
             if (error && error.length !== 0 && error[0]) {
-                raise(alarmName);
+                raise(alarmName, error[0]);
             } else {
                 release(alarmName);
             }

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -228,7 +228,7 @@ function findBy(fields) {
             } else {
                 logger.debug(context, 'Device group for fields [%j] not found: [%j]', fields, queryObj);
 
-                callback(new errors.DeviceGroupNotFound());
+                callback(new errors.DeviceGroupNotFound(fields));
             }
         });
     };


### PR DESCRIPTION
Related with previous fix:
Fix: undefined MONGO-ALARMS in logs due to a bad mongo query. (#630, #577)