### PR TITLE
Fixes #643

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -24,3 +24,4 @@
 - FIX: check foundGroup count in generateDuplicateHandle (#633)
 - Fix: allow provision device entity with multientity attributes (#628)
 - Fix: multientity with multiple measures in ngsiv2 (#635)
+- Fix: aligns expression plugin and config.autocast casting (#643)

--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -227,8 +227,8 @@ Currently, the expression parser does not support JSON Arrays and JSON document.
 1. Variables will be cast to String no matter the expression type (see [comments above](#types) regarding this)
 2. The expression will be applied
 3. The output type will be cast again to the original attribute type.
-  * If attribute type is "Integer" then the value is casted to integer (JSON number)
-  * If attribute type is "Float" then the value is casted to float (JSON number)
+  * If attribute type is "Number" and the value is an `Integer`, then the value is casted to integer (JSON number)
+  * If attribute type is "Number" and the value is a `Float`, then the value is casted to float (JSON number)
   * If attribute type is "Boolean" then the value is cast to boolean (JSON boolean). In order to do this conversion, only `true` or `1` are cast to true.
   * If attribute type is "None" then the value is cast to null (JSON null)
 
@@ -252,10 +252,10 @@ status: true
 
 More examples of this workflow are presented below for the different types of attributes supported in NGSIv2 and the two possible types of expressions: Integer (arithmetic operations) or Strings.
 
-* pressure (of type "Integer"): 52 -> ${@pressure * 20} -> ${ 52 * 20 } -> $ { 1040 } -> $ { "1040"} -> 1040
-* pressure (of type "Integer"): 52 -> ${trim(@pressure)} -> ${trim("52")} -> $ { "52" } -> $ { "52"} -> 52
-* consumption (of type "Float"): 0.44 -> ${@consumption * 20} -> ${ 0.44 * 20 } -> $ { 8.8 } -> $ { "8.8"} -> 8.8
-* consumption (of type "Float"): 0.44 -> ${trim(@consumption)} -> ${trim("0.44")} -> $ { "0.44" } -> $ { "0.44"} -> 0.44
+* pressure (of type "Number" and value's type "Integer"): 52 -> ${@pressure * 20} -> ${ 52 * 20 } -> $ { 1040 } -> $ { "1040"} -> 1040
+* pressure (of type "Number"  and value's type "Integer"): 52 -> ${trim(@pressure)} -> ${trim("52")} -> $ { "52" } -> $ { "52"} -> 52
+* consumption (of type "Number"  and value's type "Float"): 0.44 -> ${@consumption * 20} -> ${ 0.44 * 20 } -> $ { 8.8 } -> $ { "8.8"} -> 8.8
+* consumption (of type "Number"  and value's type "Float"): 0.44 -> ${trim(@consumption)} -> ${trim("0.44")} -> $ { "0.44" } -> $ { "0.44"} -> 0.44
 * active (of type "None"): null -> ${@active * 20} -> ${ 0 * 20 } -> $ { 0 } -> $ { "0"} -> null
 * active (of type "None"): null -> ${trim(@active)} -> ${trim("null")} -> $ { "null" } -> $ { "null"} -> null
 * update (of type "Boolean"): true -> ${@update * 20} -> ${ 1 * 20 } -> $ { 20 } -> $ { "20"} -> False

--- a/lib/plugins/expressionParser.js
+++ b/lib/plugins/expressionParser.js
@@ -159,6 +159,17 @@ function applyExpression(expression, context, typeInformation) {
 
 function expressionApplier(context, typeInformation) {
     return function(attribute) {
+
+        /**
+         * Determines if a value is of type float
+         *
+         * @param      {String}   value       Value to be analyzed
+         * @return     {boolean}              True if float, False otherwise.
+         */
+        function isFloat(value) {
+            return !isNaN(value) && value.toString().indexOf('.') !== -1;
+        }
+
         var newAttribute = {
             name: attribute.name,
             type: attribute.type
@@ -169,11 +180,11 @@ function expressionApplier(context, typeInformation) {
 
         newAttribute.value = applyExpression(attribute.expression, context, typeInformation);
 
-        if (attribute.type === 'Integer') {
-            newAttribute.value = Number.parseInt(newAttribute.value);
-        }
-        else if (attribute.type === 'Float') {
+        if (attribute.type === 'Number' && isFloat(newAttribute.value)) {
             newAttribute.value = Number.parseFloat(newAttribute.value);
+        }
+        else if (attribute.type === 'Number' && Number.parseInt(newAttribute.value)) {
+            newAttribute.value = Number.parseInt(newAttribute.value);
         }
         else if (attribute.type === 'Boolean') {
             newAttribute.value = (newAttribute.value === 'true' || newAttribute.value === '1');

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin1.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin1.json
@@ -1,6 +1,6 @@
 {
   "pressure": {
     "value": 1040,
-    "type": "Integer"
+    "type": "Number"
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin11.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin11.json
@@ -1,6 +1,6 @@
 {
   "pressure": {
     "value": 52,
-    "type": "Integer"
+    "type": "Number"
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin12.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin12.json
@@ -1,6 +1,6 @@
 {
   "consumption_x": {
-    "type": "Float",
+    "type": "Number",
     "value": 0.44
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin13.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin13.json
@@ -1,10 +1,10 @@
 {
   "pressure": {
-    "type": "Integer",
+    "type": "Number",
     "value": 10
   },
   "consumption_x": {
-    "type": "Float",
+    "type": "Number",
     "value": 200
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin2.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin2.json
@@ -1,6 +1,6 @@
 {
   "pressure":{
-    "type": "Integer",
+    "type": "Number",
     "value": 1040 
   },
   "humidity":{

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin3.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin3.json
@@ -1,6 +1,6 @@
 {
   "consumption": {
-    "type": "Float",
+    "type": "Number",
     "value": 0.44
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin4.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin4.json
@@ -1,6 +1,6 @@
 {
   "pressure25":{
-    "type": "Integer",
+    "type": "Number",
     "value": 52 
   },
   "humidity12":{

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin8.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin8.json
@@ -1,6 +1,6 @@
 {
   "consumption": {
-    "type": "Float",
+    "type": "Number",
     "value": 8.8
   }
 }

--- a/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
@@ -51,12 +51,12 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 'p',
                         name: 'pressure',
-                        type: 'Integer'
+                        type: 'Number'
                     },
                     {
                         object_id: 'e',
                         name: 'consumption',
-                        type: 'Float'
+                        type: 'Number'
                     },
                     {
                         object_id: 'a',
@@ -81,7 +81,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 'x',
                         name: 'consumption_x',
-                        type: 'Float',
+                        type: 'Number',
                         expression: '${@pressure * 20}'
                     }
                 ]
@@ -94,7 +94,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 'p',
                         name: 'pressure',
-                        type: 'Integer',
+                        type: 'Number',
                         expression: '${@pressure * / 20}'
                     }
                 ]
@@ -107,13 +107,13 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 'p',
                         name: 'pressure',
-                        type: 'Integer',
+                        type: 'Number',
                         expression: '${@pressure * 20}'
                     },
                     {
                         object_id: 'e',
                         name: 'consumption',
-                        type: 'Float',
+                        type: 'Number',
                         expression: '${@consumption * 20}'
                     },
                     {
@@ -149,18 +149,18 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 'p',
                         name: 'pressure',
-                        type: 'Integer',
+                        type: 'Number',
                         expression: '${trim(@pressure)}'
                     },
                     {
                         object_id: 'p25',
                         name: 'pressure25',
-                        type: 'Integer'
+                        type: 'Number'
                     },
                     {
                         object_id: 'e',
                         name: 'consumption',
-                        type: 'Float',
+                        type: 'Number',
                         expression: '${trim(@consumption)}'
                     },
                     {
@@ -240,7 +240,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 52
             },
             {
@@ -276,7 +276,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p25',
-                type: 'Integer',
+                type: 'Number',
                 value: 52
             },
             {
@@ -311,7 +311,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 52
             }
         ];
@@ -341,7 +341,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 52
             }
         ];
@@ -371,7 +371,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 52
             }
         ];
@@ -402,7 +402,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'e',
-                type: 'Float',
+                type: 'Number',
                 value: 0.44
             }
         ];
@@ -433,7 +433,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'e',
-                type: 'Float',
+                type: 'Number',
                 value: 0.44
             }
         ];
@@ -464,7 +464,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'e',
-                type: 'Float',
+                type: 'Number',
                 value: 0.44
             }
         ];
@@ -740,7 +740,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'x',
-                type: 'Float',
+                type: 'Number',
                 value: 0.44
             }
         ];
@@ -770,7 +770,7 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 10
             }
         ];
@@ -801,12 +801,12 @@ describe('Expression-based transformations plugin', function() {
         var values = [
             {
                 name: 'x',
-                type: 'Float',
+                type: 'Number',
                 value: 0.44
             },
             {
                 name: 'p',
-                type: 'Integer',
+                type: 'Number',
                 value: 10
             }
         ];


### PR DESCRIPTION
With NGSIv2, casting in expression plugin considers that attributes with Integer and Float values use `type Number.

This follows:
- https://www.w3schools.com/js/js_json_datatypes.asp, JSON native type for Integer or Floats is Number.
- Partial Representations section of http://telefonicaid.github.io/fiware-orion/api/v2/stable/

Unit tests are modified (and passed) properly.