### PR TITLE
Clarified North/South, removed anchors, added code highlights

### DIFF
--- a/doc/Contribution.md
+++ b/doc/Contribution.md
@@ -13,14 +13,14 @@ In order to start contributing:
 
 2. Clone your just forked repository:
 
-```console
+```bash
 git clone https://github.com/your-github-username/iotagent-node-lib.git
 ```
 
 3. Add the main iotagent-node-lib repository as a remote to your forked repository (use any name for your remote
 repository, it does not have to be iotagent-node-lib, although we will use it in the next steps):
 
-```console
+```bash
 git remote add iotagent-node-lib https://github.com/telefonicaid/iotagent-node-lib.git
 ```
 
@@ -29,18 +29,18 @@ branch in the main iotagent-node-lib repository, by following this steps
 
 1. Change to your local `master` branch (in case you are not in it already):
 
-```console
+```bash
 git checkout master
 ```
 2. Fetch the remote changes:
 
-```console
+```bash
 git fetch iotagent-node-lib
 ```
 
 3. Merge them:
 
-```console
+```bash
 git rebase iotagent-node-lib/master
 ```
 

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -282,7 +282,7 @@ In order to do so, add the following require statement to the initialiation code
 
 and add the `request` dependency to the `package.json` file:
 
-```json
+```
   "dependencies": [
   [...]
 

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -14,7 +14,7 @@
   + [Provisioning handlers](#provisioning-handlers)
 
 ## Overview
-This document's goal is to show how to develop a new IOT Agent step by step. To do so, a simple invented HTTP protocol
+This document's goal is to show how to develop a new IoT Agent step by step. To do so, a simple invented HTTP protocol
 will be used, so it can be tested with simple command line instructions as `curl` and `nc`.
 
 ### Protocol
@@ -33,10 +33,13 @@ Where:
 This tutorial expects a Node.js v0.10 (at least) installed and working on your machine. It also expects you to have
 access to a Context Broker (without any security proxies).
 
-##  Basic IOTA
-In this first chapter, we will develop an IOT Agent with a fully working NGSI traffic on the North port and no native
-traffic south of the IoT Agent. This may seem useless (and indeed it is) but will serve us well on showing the basic
-steps in the creation of an IoT Agent.
+##  Basic IoT Agent
+
+In this first chapter, we will just develop an IoT Agent with a fully connected North Port. This will
+send and receive NSGI traffic and can be administered using the IoT Agent's Device Provisioning
+API. The South Port will remain unconnected and no native protocol traffic will be sent to the devices.
+This may seem useless (and indeed it is) but it will serve us well on showing the basic steps in the creation
+of an IoT Agent.
 
 First of all, we have to create the Node project. Create a folder to hold your project and type the following
 instruction:
@@ -64,7 +67,7 @@ The first step is to write a configuration file, that will be used to tune the b
 can be copied from the `config-basic-example.js` file, in this same folder. Create a `config.js` file with it
 in the root folder of your project. Remember to change the Context Broker IP to your local Context Broker.
 
-Now we can begin with the code of our IOTA. The very minimum code we need to start an IOTA is the following:
+Now we can begin with the code of our IoT Agent. The very minimum code we need to start an IoT Agent is the following:
 
 ```javascript
 var iotAgentLib = require('iotagent-node-lib'),
@@ -78,7 +81,7 @@ iotAgentLib.activate(config, function(error) {
 });
 ```
 
-The IOTA is now ready to be used. Execute it with the following command:
+The IoT Agent is now ready to be used. Execute it with the following command:
 
 ```bash
 node index.js
@@ -86,13 +89,13 @@ node index.js
 
 The North Port interface should now be fully functional, i.e.: management of device registrations and configurations.
 
-## IOTA With Active attributes
+## IoT Agent With Active attributes
 
-In the previous section we created an IOTA that exposed just the North Port interface, but that was pretty useless
+In the previous section we created an IoT Agent that exposed just the North Port interface, but that was pretty useless
 (aside from its didactic use). In this section we are going to create a simple South Port interface. It's important
-to remark that the nature of the traffic South of the IoT Agent itself has nothing to do with the creation process of an IoT Agent.
-Each device protocol will use its own mechanisms and it is up to the IoTA developer to find any libraries that would
-help him in its development. In this example, we will use Express as such library.
+to remark that the nature of the traffic South of the IoT Agent itself has nothing to do with the creation process
+of an IoT Agent. Each device protocol will use its own mechanisms and it is up to the IoT Agent developer to find
+any libraries that would help him in its development. In this example, we will use Express as such library.
 
 In order to add the Express dependency to your project, add the following line to the `dependencies` section of the
 `package.json`:
@@ -114,7 +117,7 @@ And install the dependencies as usual with `npm install`. You will have to requi
 your code as well.
 
 Now, in order to accept connections in our code, we have to start express first. With this purpose in mind, we will
-create a new function `initSouthbound()`, that will be called from the initialization code of our IOTA:
+create a new function `initSouthbound()`, that will be called from the initialization code of our IoT Agent:
 
 ```javascript
 function initSouthbound(callback) {
@@ -135,9 +138,9 @@ function initSouthbound(callback) {
 ```
 
 This Express code sets up a HTTP server, listening in the 8080 port, that will handle incoming requests targeting
-path `/iot/d` using the middleware `manageULRequest()`. This middleware will contain all the Southbound logic, and
-the library methods we need in order to progress the information to the Context Broker. The code of this middleware
-would be as follows:
+path `/iot/d` using the middleware `manageULRequest()`. This middleware will contain all the logic south of the
+IoT Agent, and the library methods we need in order to progress the information to the Context Broker. The code
+of this middleware would be as follows:
 
 
 ```javascript
@@ -214,7 +217,7 @@ Here as an example of the output of the function return for the UL payload `t|15
 ]
 ```
 
-The last thing to do is to invoke the initialization function inside the IOTA startup function. The next excerpt
+The last thing to do is to invoke the initialization function inside the IoT Agent startup function. The next excerpt
 show the modifications in the `activate()` function:
 
 
@@ -237,7 +240,7 @@ iotAgentLib.activate(config, function(error) {
 
 Some logs were added in this piece of code to help debugging.
 
-Once the IOTA is finished the last thing to do is to test it. To do so, launch the IOTA and provision a new device
+Once the IOTA is finished the last thing to do is to test it. To do so, launch the IoT Agent and provision a new device
 (an example for provisioning can be found in the `examples/howtoProvisioning1.json` file). Once the device is
 provisioned, send a new measure by using the example command:
 
@@ -262,8 +265,8 @@ curl -X GET 'http://127.0.0.1:9999/iot/d?i=ULSensor&k=abc&q=t,l' -i
 
 In a real implementation, the server will need to know the URL and port where the devices are listening, in order to
 send the request to the appropriate device. For this example, we will assume that the device is listening in port 9999
-in localhost. For more complex cases, the mechanism to bind devices to addresses would be IOTA-specific (e.g.: the
-OMA Lightweight M2M IOTA captures the address of the device in the device registration, and stores the device-specific
+in localhost. For more complex cases, the mechanism to bind devices to addresses would be IoT-Agent-specific (e.g.: the
+OMA Lightweight M2M IoT Agent captures the address of the device in the device registration, and stores the device-specific
 information in a MongoDB document).
 
 Being lazy attributes of a read/write nature, another syntax has to be declared for updating. This syntax will mimic
@@ -303,8 +306,8 @@ var iotAgentLib = require('iotagent-node-lib'),
 ### Implementation
 
 #### QueryContext implementation
-The main step to complete in order to implement the Lazy attributes mechanism in the IOTA is to provide handlers for the context
-provisioning requests. At this point, we should provide two handlers: the updateContext and the queryContext handlers.
+The main step to complete in order to implement the Lazy attributes mechanism in the IoT Agent is to provide handlers for the context
+provisioning requests. At this point, we should provide two handlers: the `updateContext` and the `queryContext` handlers.
 To do so, we must first define the handlers themselves:
 
 ```javascript
@@ -333,7 +336,7 @@ are returned, the values are returned to the caller, in the NGSI attribute forma
 
 In order to format the response from the device in a readable way, we created a `createResponse()` function that maps
 the values to its correspondent attributes. This function assumes the type of all the attributes is "string" (this will
-not be the case in a real scenario, where the IOTA should retrieve the associated device to guess the type of its
+not be the case in a real scenario, where the IoT Agent should retrieve the associated device to guess the type of its
 attributes). Here is the code for the `createResponse()` function:
 
 ```javascript
@@ -408,7 +411,7 @@ function createQueryFromAttributes(attributes) {
 ```
 
 #### Handler registration
-Once both handlers have been defined, they have to be registered in the IOTA, adding the following code to the setup
+Once both handlers have been defined, they have to be registered in the IoT Agent, adding the following code to the setup
 function:
 
 ```javascript
@@ -423,7 +426,7 @@ netcat. In order to start it just run the following command from the command lin
 ```bash
 nc -l 9999
 ```
-This will open a simple TCP server listening on port 9999, where the requests from the IOTA will be printed. In order for
+This will open a simple TCP server listening on port `9999`, where the requests from the IoT Agent will be printed. In order for
 the complete workflow to work (and to receive the response in the application side), the HTTP response has to be written
 in the `nc` console (although for testing purposes this is not needed).
 
@@ -438,7 +441,7 @@ execute the following command:
 node echo.js
 ```
 
-Once the mock server has been started (either nc or the echo server), proceed with the following steps to test your implementation:
+Once the mock server has been started (either `nc` or the `echo` server), proceed with the following steps to test your implementation:
 
 1. Provision a device with two lazy attributes. The following request can be used as an example:
 
@@ -501,8 +504,10 @@ Postman-Token: 1dc568a1-5588-059c-fa9b-ff217a7d7aa2
 
 3. Check the received request in the nc console is the expected one.
 
-4. (In case you use netcat). Answer the request with an appropriate HTTP response and check the result of the queryContext or updateContext request
-is the expected one. An example of HTTP response, for a query to the t and l attributes would be:
+4. (In case you use netcat). Answer the request with an appropriate HTTP response and check the
+  result of the `queryContext` or `updateContext` request is the expected one. An example of HTTP response,
+  for a query to the `t` and `l` attributes would be:
+
 ```
 HTTP/1.0 200 OK
 Content-Type: text/plain
@@ -510,6 +515,7 @@ Content-Length: 3
 
 5,6
 ```
+
 This same response can be used both for updates and queries for testing purposes (even though in the former the body won't
 be read).
 
@@ -521,7 +527,7 @@ mechanisms: the provisioning handlers and the provisioning API.
 
 ### Provisioning handlers
 
-The handlers provide a way for the IOTA to act whenever a new device, or configuration is provisioned. This can be used
+The handlers provide a way for the IoT Agent to act whenever a new device, or configuration is provisioned. This can be used
 for registering the device in external services, for storing important information about the device, or to listen in new
 ports in the case of new configuration. For the simple example we are developing, we will just print the information we
 are receiving whenever a new device or configuration is provisioned.
@@ -538,11 +544,11 @@ function configurationHandler(configuration, callback) {
 As we can see, the handlers receive the device or configuration that is being provisioned, as well as a callback. The
 handler MUST call the callback once in order for the IOTA to work properly. If an error is passed as a parameter to the
 callback, the provisioning will be aborted. If no error is passed, the provisioning process will continue. This mechanism
-can be used to implement security mechanisms or to filter the provisioning of devices to the IOTA.
+can be used to implement security mechanisms or to filter the provisioning of devices to the IoT Agent.
 
-Note also that the same `device` or `configuration` object is passed along to the callback. This lets the IOTA change some
+Note also that the same `device` or `configuration` object is passed along to the callback. This lets the IoT Agent change some
 of the values provisioned by the user, to add or restrict information in the provisioning. To test this feature, let's
-use the provisioning handler to change the value of the type of the provisioning device to 'CertifiedType' (reflecting
+use the provisioning handler to change the value of the type of the provisioning device to `CertifiedType` (reflecting
 some validation process performed on the provisioning):
 
 ```javascript
@@ -553,7 +559,7 @@ function provisioningHandler(device, callback) {
 }
 ```
 
-Once the handlers are defined, the new set of handlers has to be registered into the IOTAgent:
+Once the handlers are defined, the new set of handlers has to be registered into the IoT Agent:
 
 ```javascript
     iotAgentLib.setConfigurationHandler(configurationHandler);
@@ -562,4 +568,4 @@ Once the handlers are defined, the new set of handlers has to be registered into
 
 Now we can test our implementation by sending provisioning requests to the North Port of the IoT Agent. If we provision a new device
 into the platform, and then we ask for the list of provisioned devices, we shall see the type of the provisioned device
-has changed to 'CertifiedType'.
+has changed to `CertifiedType`.

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -56,10 +56,12 @@ command-line tools to simulate the different interactions.
 ### Overview
 
 #### General purpose of the IoT Agents
+
 Inside the FIWARE Architecture, the IoT Agents work as protocol translation gateways, used to fill the gap between
-South Bound protocols (typically lightweight protocols aimed to constrained devices) and the NGSI protocol used to
-communicate FIWARE components. This translation process can be customized by the user with provisioning instructions,
-using the Device Provisioning APIs.
+traffic sent and received on the South Port (typically lightweight protocols aimed to constrained devices) and
+traffic sent and received on the North Port which uses the standard NGSI protocol to communicate FIWARE components.
+This translation process can be customized by the user with provisioning instructions, using the Device Provisioning
+APIs.
 
 So, all IoT Agents interacts with three different actors:
 * **Devices**, in the South Bound

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -1,4 +1,4 @@
-# Northbound NGSI Interactions
+# Traffic North of the IoT Agent -  NGSI Interactions
 
 ## Index
 
@@ -372,7 +372,7 @@ request to the Context Broker should be authenticated.
 
 In order to retrieve a token from the Keystone Identity Manager, the following request can be used:
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -d '{
 	"auth": {
 		"identity": {
@@ -429,7 +429,7 @@ Context Broker (as it will be seen in the examples).
 In this scenario, a device actively sends data to the IoT Agent, that transforms that data into a NGSI request
 that is sent to the Context Broker. This request has the following format (P1):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
     -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <Token>" -d '{
     "contextElements": [
@@ -483,7 +483,7 @@ can be queried.
 Whenever the User wants to query this value, he can use any of the NGSI mechanisms for retrieving data. E.g. he can
 use a standard queryContext request, as the following one (P2):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -531,7 +531,7 @@ The Context Broker will reply with the updated data values in R2 format (200 OK)
 Two kind of errors can appear in this scenario. If there is an error updating the information, the Context Broker will
 replay with a payload like the following:
 
-```console
+```bash
 {
   "contextResponses": [
     {
@@ -582,7 +582,7 @@ the existence of both.
 Scenario 2 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
 must register its lazy attributes for each device, with a request like the following:
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-service: workshop" \
   -H "fiware-servicepath:  /iota2ngsi " -H "x-auth-token: <token>" -d '{
     "contextRegistrations": [
@@ -624,7 +624,7 @@ The registration of the attributes is performed once in the lifetime of the Devi
 In this scenario, a User actively asks for a particular piece of data from a device. The scenario starts with the
 request from the User to the Context Broker (P2):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -644,7 +644,7 @@ The Context Broker receives this request and detects that it can be served by a 
 it redirects the exact same request to the IoT Agent. The following excerpt shows the full HTTP frame containing
 the redirection data:
 
-```console
+```bash
 POST /v1/queryContext HTTP/1.1
 Host: <target-host>:1026
 fiware-service: workshop
@@ -735,7 +735,7 @@ error, that error must follow the NGSI payloads described in the Scenario 1 erro
 Scenario 3 relies on the Context Provider mechanism of the Context Broker. For this scenario to work, the IoTAgent
 must register its commands for each device, with a request like the following:
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-service: workshop" \
   -H "fiware-servicepath:  /iota2ngsi " -H "x-auth-token: <token>" -d '{
     "contextRegistrations": [
@@ -779,7 +779,7 @@ The registration of the commands is performed once in the lifetime of the Device
 
 Scenario 3 begins with the request for a command from the User to the Context Broker (P1):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [
@@ -804,7 +804,7 @@ The Context Broker receives this command and detects that it can be served by a 
 it redirects the exact same request to the IoT Agent. The following excerpt shows the full HTTP frame containing
 the redirection data:
 
-```console
+```bash
 POST /v1/updateContext HTTP/1.1
 Host: <target-host>:1026
 fiware-service: workshop
@@ -900,7 +900,7 @@ request will be.
 Once the IoT Agent has executed the command or retrieved the information from the device, it reports the results
 to the Context Broker, with an updateContext (P1):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [
@@ -969,7 +969,7 @@ mechanisms.
 Whenever the User wants to know the status and result of the command, he can query the information in the Context
 Broker, using, for example, a standard queryContext request (P2):
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "entities": [
@@ -1024,7 +1024,7 @@ In Scenario 3, errors can happen asynchronously, out of the main interactions. W
 executing the underlying command (i.e.: an error connecting with the device, or an error in the device itself),
 the error information can be updated with the same mechanism used for result reporting. E.g.:
 
-```console
+```bash
 curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -H "Fiware-Service: workshop" \
   -H "Fiware-ServicePath:  /iota2ngsi " -H "X-Auth-Token: <token>" -d '{
     "contextElements": [

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -34,9 +34,9 @@ in the configuration file. Check the configuration file and add all the required
 
 ### IOTAM-001: Error updating information in the IOTAM. Status Code [%d]
 
-The IoTAgent could not contact the IoTAgent manager to update its information. This condition may indicate a lack of
-connectivity between machines or a problem in the IoTAManager. IoTAgent information in the IoTAManager will be out of
-date until this problem is solved.
+The IoT Agent could not contact the IoT Agent manager to update its information. This condition may indicate a lack of
+connectivity between machines or a problem in the IoT Agent Manager. The IoT Agent information in the IoT Agent Manager
+will be out-of-date until this problem is solved.
 
 ### KEYSTONE-001: Error retrieving token from Keystone: %s
 
@@ -68,7 +68,7 @@ This may also be caused by an invalid `refresh_token` used by the user.
 ### OAUTH2-003: Token missing in the response body
 
 The JSON response body returned by the OAuth2 provider does not include a field `access_token`.
-Check the OAuth2 logs and configuration. 
+Check the OAuth2 logs and configuration.
 
 ### ORION-001: Connection error creating inital entity in the Context Broker: %s
 
@@ -78,7 +78,7 @@ Check connectivity between the machines, the status of the remote Context Broker
 ### ORION-002: Connection error sending registrations to the Context Broker: %s
 
 There was a connectivity error accessing Context Broker to register the IoTA as a Context Provider (or the Context Broker was down).
-Check connectivity between the machines, the status of the remote Context Broker and the configuration of the IoTAgent.
+Check connectivity between the machines, the status of the remote Context Broker and the configuration of the IoT Agent.
 
 ### VALIDATION-FATAL-001: Validation Request templates not found
 

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -39,9 +39,11 @@ The stats library currently stores only the following values:
 
 More values will be added in the future to the library. The applications using the library can add values to the Stats Registry
 just by using the following function:
+
 ```
 iotagentLib.statsRegistry.add('statName', statIncrementalValue, callback)
 ```
+
 The first time this function is invoked, it will add the new stat to the registry. Subsequent calls will add the value
 to the specified stat both to the current and global measures. The stat will be cleared in each interval as usual.
 
@@ -82,12 +84,13 @@ Returns the current log level, in a json payload with a single attribute `level`
 
 
 ### Transactions
-The library implements a concept of transactions, in order to follow the execution flow the library follows when treating
-requests entering both from the North and the South ports of the IoT Agent.
+The library implements a concept of transactions, in order to follow the execution flow the library follows when
+treating requests entering both from the North and the South ports of the IoT Agent.
 
-To follow the transactions, a new Domain is created for each incoming request; in the case of Northbound requests, this
-domain is automatically created by a Express middleware, and no further action is needed from the user. For the case of
-Southbound requests, the user is responsible of creating an stopping the transaction, using the `ensureSouthboundDomain`
+To follow the transactions, a new Domain is created for each incoming request; in the case of requests received
+on the North Port of the IoT Agent, this domain is automatically created by a Express middleware, and no further
+action is needed from the user. For the case of requests received on the South Port of the IoT Agent, the user is
+responsible of creating an stopping the transaction, using the `ensureSouthboundDomain`
 and `finishSouthBoundTransaction`. In this case, the transaction will last from the invocation to the former to the
 invocation of the latter.
 
@@ -311,8 +314,8 @@ entity, and all the results will be combined into a single response.
 function setNotificationHandler(newHandler)
 ```
 ###### Description
-Sets the new handler for incoming notifications. The notifications are sent by the Context Broker based on the IOTA subscriptions created
-with the subscribe() function.
+Sets the new handler for incoming notifications. The notifications are sent by the Context Broker based on
+the IoT Agent subscriptions created with the `subscribe()` function.
 
 The handler must adhere to the following signature:
 
@@ -326,7 +329,7 @@ The handler will be called once for each one of those entities.
 The `data` parameter is an array with all the attributes that were requested in the subscription and its respective
 values.
 
-The handler is expected to call its callback once with no parameters (failing to do so may cause unexpected behaviors in the IOTA).
+The handler is expected to call its callback once with no parameters (failing to do so may cause unexpected behaviors in the IoT Agent).
 
 
 ##### iotagentLib.setConfigurationHandler()
@@ -345,7 +348,7 @@ The handler must adhere to the following signature:
 function(newConfiguration, callback)
 ```
 The `newConfiguration` parameter will contain the newly created configuration. The handler is expected to call its
-callback with no parameters (this handler should only be used for reconfiguration purposes of the IOT Agent).
+callback with no parameters (this handler should only be used for reconfiguration purposes of the IoT Agent).
 
 For the cases of multiple updates (a single Device Configuration POST that will create several device groups), the
 handler will be called once for each of the configurations (both in the case of the creations and the updates).

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -521,10 +521,11 @@ function finishSouthboundTransaction(callback)
 Terminates the current transaction, if there is any, cleaning its context.
 
 #### Generic middlewares
-This collection of utility middlewares is aimed to be used in the northbound of the IoTAgent Library, as well as in other
-HTTP-based APIs of the IoTAs. All the middlewares follow the Express convention of (req, res, next) objects, so this
-information will not be repeated in the descriptions for the middleware functions. All the middlewares can be added
-to the servers using the standard Express mechanisms.
+
+This collection of utility middlewares is aimed to be used to north of the IoT Agent Library, as well as in other
+HTTP-based APIs of the IoT Agents. All the middlewares follow the Express convention of `(req, res, next)` objects,
+so this information will not be repeated in the descriptions for the middleware functions. All the middlewares
+can be added to the servers using the standard Express mechanisms.
 
 ##### iotagentLib.middlewares.handleError()
 ###### Signature

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -83,7 +83,7 @@ Returns the current log level, in a json payload with a single attribute `level`
 
 ### Transactions
 The library implements a concept of transactions, in order to follow the execution flow the library follows when treating
-requests entering both from the Northbound and the Southbound.
+requests entering both from the North and the South ports of the IoT Agent.
 
 To follow the transactions, a new Domain is created for each incoming request; in the case of Northbound requests, this
 domain is automatically created by a Express middleware, and no further action is needed from the user. For the case of
@@ -609,7 +609,7 @@ The project is managed using Grunt Task Runner.
 
 For a list of available task, type
 
-```console
+```bash
 grunt --help
 ```
 
@@ -625,14 +625,14 @@ Module mocking during testing can be done with [proxyquire](https://github.com/t
 
 To run tests, type
 
-```console
+```bash
 grunt test
 ```
 
 Tests reports can be used together with Jenkins to monitor project quality metrics by means of TAP or XUnit plugins.
 To generate TAP report in `report/test/unit_tests.tap`, type
 
-```console
+```bash
 grunt test-report
 ```
 
@@ -643,7 +643,7 @@ Uses provided .jshintrc and .gjslintrc flag files. The latter requires Python an
 while creating the project skeleton with grunt-init.
 To check source code style, type
 
-```console
+```bash
 grunt lint
 ```
 
@@ -651,7 +651,7 @@ Checkstyle reports can be used together with Jenkins to monitor project quality 
 and Violations plugins.
 To generate Checkstyle and JSLint reports under `report/lint/`, type
 
-```console
+```bash
 grunt lint-report
 ```
 
@@ -661,7 +661,7 @@ grunt lint-report
 Support for continuous testing by modifying a src file or a test.
 For continuous testing, type
 
-```console
+```bash
 grunt watch
 ```
 
@@ -672,7 +672,7 @@ dox-foundation
 Generates HTML documentation under `site/doc/`. It can be used together with jenkins by means of DocLinks plugin.
 For compiling source code documentation, type
 
-```console
+```bash
 grunt doc
 ```
 
@@ -684,7 +684,7 @@ Analizes the code coverage of your tests.
 
 To generate an HTML coverage report under `site/coverage/` and to print out a summary, type
 
-```console
+```bash
 # Use git-bash on Windows
 grunt coverage
 ```
@@ -692,7 +692,7 @@ grunt coverage
 To generate a Cobertura report in `report/coverage/cobertura-coverage.xml` that can be used together with Jenkins to
 monitor project quality metrics by means of Cobertura plugin, type
 
-```console
+```bash
 # Use git-bash on Windows
 grunt coverage-report
 ```
@@ -705,7 +705,7 @@ Analizes code complexity using Plato and stores the report under `site/report/`.
 by means of DocLinks plugin.
 For complexity report, type
 
-```console
+```bash
 grunt complexity
 ```
 
@@ -713,7 +713,7 @@ grunt complexity
 
 Update the contributors for the project
 
-```console
+```bash
 grunt contributors
 ```
 
@@ -722,7 +722,7 @@ grunt contributors
 
 Initialize your environment with git hooks.
 
-```console
+```bash
 grunt init-dev-env
 ```
 
@@ -744,7 +744,7 @@ There is a grunt task to generate the GitHub pages of the project, publishing al
 In order to initialize the GitHub pages, use:
 
 
-```console
+```bash
 grunt init-pages
 ```
 
@@ -753,7 +753,7 @@ history, and associated to the gh-pages branch, created for publishing. This ini
 once in the project history. Once the site has been initialized, publish with the following command:
 
 
-```console
+```bash
 grunt site
 ```
 


### PR DESCRIPTION
After discussion with @dcalvoalonso 

With standard English usage, the “bound”  suffix in implies a direction e.g “Homeward bound" means "going **towards** my home”, therefore “Southbound” means "going **towards** the South”
In contrast, the phrase "to the North of” does not imply direction, it implies relative location — you can be to the North of a town, but travelling Southbound - i.e. towards the city.
The main common usage of Northbound/Southbound is found with motorway traffic reports e.g. “the Northbound carriageway is blocked"

Therefore the following usage is correct common English, and the existing documents should be corrected to use it: 

* Traffic **to the South of** the IoT Agent refers to the exchange of information and commands between a device and an IoT Agent (Native protocols)
Traffic **to the North of** the IoT Agent traffic considers the link between the IoT Agent  and the CB.  (NGSI)
* **Southbound** traffic refers to the commands sent from the CB down to the device
* **Northbound** traffic refers to the measurements sent up from the IoT device to the CB
* **Northbound** traffic also refers to the results of commands  sent up from the IoT device to the CB

I have updated the documents  and removed `<a>`  tags and added code highlights for ReadTheDocs whilst updating. (RTD doesn't support `console`)