### PR TITLE
[WIP] keep default id and type for a autoprovisioned device

### DIFF
--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -463,8 +463,8 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                         entities: result
                     };
                 } else {
-                    delete result.id;
-                    delete result.type;
+                    // delete result.id; // ?
+                    // delete result.type; // ?
                     options.json = result;
 
                     if (config.getConfig().timestamp && !utils.isTimestampedNgsi2(options.json)) {
@@ -472,8 +472,8 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     }
                 }
             } else {
-                delete payload.id;
-                delete payload.type;
+                // delete payload.id;  // ?
+                // delete payload.type; // ?
                 options.json = payload;
             }
 


### PR DESCRIPTION
autoprovisioned devices has not the same id and type values using NGSIv1 and NGSIv2