### PR TITLE
add replicaSet in uri

### DIFF
--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -85,6 +85,10 @@ function init(host, db, port, username, password, options, callback) {
 
     url = 'mongodb://' + credentials + hosts + '/' + db;
 
+    if (options.replicaSet) {
+        url += '?replicaSet=' + options.replicaSet.rs_name;
+    }
+
     function createConnectionHandler(error, results) {
         if (defaultDb) {
             logger.info(context, 'Successfully connected to MongoDB.');

--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -191,7 +191,7 @@ function configureDb(callback) {
             }
 
             init(config.getConfig().mongodb.host, dbName, port,
-                currentConfig.username, currentConfig.password, {}, callback);
+                currentConfig.username, currentConfig.password, options, callback);
         }
     } else {
         callback();


### PR DESCRIPTION
fix https://github.com/telefonicaid/iotagent-node-lib/pull/684#issuecomment-435838531

According with 
https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
example:
```
mongodb://db1.example.net:27017,db2.example.net:2500/?replicaSet=test&connectTimeoutMS=300000
```