### PR TITLE
Remove `##Index` from ToC since it is not required - fixes #648

### DIFF
--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -1,7 +1,5 @@
 # Measurement Transformation Expression Language
 
-## Index
-
 * [Overview](#overview)
 * [Measurement transformation](#measurement-transformation)
   + [Expression definition](#expression-definition)
@@ -215,7 +213,7 @@ The following table shows expressions and their expected outcomes for a measure 
 
 ## NGSIv2 support
 
-As it is explained in previous sections, expressions can have two return types: String or Number, being the former one the default. Whenever an expression is executed without error, its result will be cast to the configured type. 
+As it is explained in previous sections, expressions can have two return types: String or Number, being the former one the default. Whenever an expression is executed without error, its result will be cast to the configured type.
 
 On one hand, in NGSIv1 since all attributes' values are of type String, in the expression parser the expression type is set always to String and the transformation of the information coming from the SouthBound is done using replace instruction. Therefore, values sent to the CB will always be Strings. This can be seen in previous examples.
 

--- a/doc/howto.md
+++ b/doc/howto.md
@@ -1,7 +1,5 @@
 # How to develop a new IOTAgent
 
-## Index
-
 * [Overview](#overview)
   + [Protocol](#protocol)
   + [Requirements](#requirements)

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -1,7 +1,5 @@
 # Traffic North of the IoT Agent -  NGSI Interactions
 
-## Index
-
 * [Overview](#overview)
 * [Requirements](#requirements)
 * [Theory](#theory)

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -1,5 +1,4 @@
 # Operations Manual: logs and alarms
-## Index
 
 * [Overview](#overview)
 * [Logs](#logs)

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -1,8 +1,5 @@
 # User & Programmers Manual
 
-## Index
-
-
 * [Usage](#usage)
   + [Stats Registry](#stats-registry)
   + [Alarm module](#alarm-module)


### PR DESCRIPTION
* The ToC is suppressed with the ReadtheDocs CSS
* The ToC Header cannot be suppressed without CSS3

Therefore the title of the ToC should be removed to avoid confusion