### PR TITLE
Implements missing aspects of use of group's cbhost

### DIFF
--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -318,8 +318,14 @@ function createInitialEntityNgsi2(deviceData, newDevice, callback) {
  * @param {Object} newDevice        Device object that will be stored in the database.
  */
 function createInitialEntityNgsi1(deviceData, newDevice, callback) {
+    var cbHost = config.getConfig().contextBroker.url;
+    if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
+        cbHost = deviceData.cbHost;
+    } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
+        cbHost = 'http://' + deviceData.cbHost;
+    }
     var options = {
-            url: config.getConfig().contextBroker.url + '/v1/updateContext',
+            url: cbHost + '/v1/updateContext',
             method: 'POST',
             json: {
                 contextElements: [
@@ -544,6 +550,10 @@ function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuratio
         } else if (!deviceData[fields[i]] && (!configuration || !configuration[confField])) {
             deviceData[fields[i]] = defaults[i];
         }
+    }
+
+    if (configuration && configuration.cbHost) {
+        deviceData.cbHost = configuration.cbHost;
     }
     logger.debug(context, 'deviceData2: %j', deviceData);
     callback(null, deviceData);

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -130,8 +130,15 @@ function createRegistrationHandlerNgsi2(unregister, deviceData, callback) {
  * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
  */
 function sendRegistrationsNgsi1(unregister, deviceData, callback) {
+    var cbHost = config.getConfig().contextBroker.url;
+    if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
+        cbHost = deviceData.cbHost;
+    } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
+        cbHost = 'http://' + deviceData.cbHost;
+    }
+
     var options = {
-        url: config.getConfig().contextBroker.url + '/NGSI9/registerContext',
+        url: cbHost + '/NGSI9/registerContext',
         method: 'POST',
         json: {
             contextRegistrations: [
@@ -206,8 +213,14 @@ function sendRegistrationsNgsi1(unregister, deviceData, callback) {
  * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
  */
 function sendUnregistrationsNgsi2(deviceData, callback) {
+    var cbHost = config.getConfig().contextBroker.url;
+    if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
+        cbHost = deviceData.cbHost;
+    } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
+        cbHost = 'http://' + deviceData.cbHost;
+    }
     var options = {
-        url: config.getConfig().contextBroker.url + '/v2/registrations/' + deviceData.registrationId,
+        url: cbHost + '/v2/registrations/' + deviceData.registrationId,
         method: 'DELETE',
         json: true,
         headers: {
@@ -240,8 +253,14 @@ function sendUnregistrationsNgsi2(deviceData, callback) {
  * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
  */
 function sendRegistrationsNgsi2(unregister, deviceData, callback) {
+    var cbHost = config.getConfig().contextBroker.url;
+    if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
+        cbHost = deviceData.cbHost;
+    } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
+        cbHost = 'http://' + deviceData.cbHost;
+    }
     var options = {
-        url: config.getConfig().contextBroker.url + '/v2/registrations',
+        url: cbHost + '/v2/registrations',
         method: 'POST',
         json: {
             dataProvided: {

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -793,9 +793,14 @@ function executeWithDeviceInformation(operationFunction) {
                 }
             } else {
                 typeInformation = deviceInformation;
-                if (deviceGroup && deviceGroup.trust && deviceGroup.cbHost) {
-                    typeInformation.trust = deviceGroup.trust;
-                    typeInformation.cbHost = deviceGroup.cbHost;
+                if (deviceGroup) {
+                    if (deviceGroup.trust) {
+                        typeInformation.trust = deviceGroup.trust;
+                    }
+
+                    if (deviceGroup.cbHost) {
+                        typeInformation.cbHost = deviceGroup.cbHost;
+                    }
                 }
             }
 

--- a/test/unit/general/deviceService-test.js
+++ b/test/unit/general/deviceService-test.js
@@ -190,7 +190,7 @@ describe('Device Service: utils', function() {
 
     describe('When an existing device tries to be retrieved with retrieveOrCreate()', function() {
         beforeEach(function(done) {
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/NGSI9/registerContext')
@@ -225,7 +225,7 @@ describe('Device Service: utils', function() {
 
     describe('When an unexisting device tries to be retrieved for an existing APIKey', function() {
         beforeEach(function(done) {
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/NGSI9/registerContext')

--- a/test/unit/ngsiv2/general/deviceService-test.js
+++ b/test/unit/ngsiv2/general/deviceService-test.js
@@ -197,7 +197,7 @@ describe('Device Service: utils', function() {
             // This mock does not check the payload since the aim of the test is not to verify
             // device provisioning functionality. Appropriate verification is done in tests under
             // provisioning folder
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistenthost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/v2/entities?options=upsert')
@@ -228,7 +228,7 @@ describe('Device Service: utils', function() {
             // This mock does not check the payload since the aim of the test is not to verify
             // device provisioning functionality. Appropriate verification is done in tests under
             // provisioning folder
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistenthost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/v2/entities?options=upsert')

--- a/test/unit/ngsiv2/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/multientity-plugin_test.js
@@ -192,7 +192,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 describe('Multi-entity plugin', function() {
     beforeEach(function(done) {
-        logger.setLevel('DEBUG');
+        logger.setLevel('FATAL');
 
         iotAgentLib.activate(iotAgentConfig, function() {
             iotAgentLib.clearAll(function() {

--- a/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
+++ b/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
@@ -126,7 +126,7 @@ describe('Provisioning API: Single service mode', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/v2/registrations')
@@ -242,7 +242,7 @@ describe('Provisioning API: Single service mode', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/v2/registrations')
@@ -283,7 +283,7 @@ describe('Provisioning API: Single service mode', function() {
     describe('When a device is provisioned for a configuration', function() {
         beforeEach(function(done) {
             nock.cleanAll();
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/v2/registrations', function(body) {

--- a/test/unit/provisioning/singleConfigurationMode-test.js
+++ b/test/unit/provisioning/singleConfigurationMode-test.js
@@ -122,7 +122,7 @@ describe('Provisioning API: Single service mode', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/NGSI9/registerContext')
@@ -235,7 +235,7 @@ describe('Provisioning API: Single service mode', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/NGSI9/registerContext')
@@ -276,7 +276,7 @@ describe('Provisioning API: Single service mode', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
+            contextBrokerMock = nock('http://unexistentHost:1026')
                 .matchHeader('fiware-service', 'TestService')
                 .matchHeader('fiware-servicepath', '/testingPath')
                 .post('/NGSI9/registerContext', utils.readExampleFile(


### PR DESCRIPTION
As it is explained in https://github.com/telefonicaid/iotagent-json/pull/353#issuecomment-442858364, there is an inconsistent use of the field `cbhost` of groups. Although thanks to https://github.com/telefonicaid/iotagent-node-lib/pull/697/files, it is used to create the initial entity in the CB using NGSIv2, to update entities and to send unregistration requests, it was not used to send the subscription request using NGSIv2, nor some of the previously mentioned operations using NSGSIv1.

This PR implements these missing aspects and modified the corresponding unit tests.