### PR TITLE
Add missing ENV parameters

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@ Fix: user provider timestamp correctly propagated to mapped entities when multie
 Add: new functions to set callbacks for removal of devices and groups (#735)
 Fix: add ?type parameter in CB request updates to avoid potential entity ambiguities (#733)
 Upgrade from node-uuid ~1.4.1 to uuid ~3.3.2.
+Add: IOTA_AUTH_URL, IOTA_AUTH_CLIENT_ID, IOTA_AUTH_CLIENT_SECRET and IOTA_AUTH_TOKEN_PATH env vars

--- a/doc/installationguide.md
+++ b/doc/installationguide.md
@@ -24,7 +24,7 @@ These are the parameters that can be configured in the global section:
     port: '1026',
     ngsiVersion: 'v2'
   }
-``` 
+```
 
 * **server**: configuration used to create the Context Server (port where the IoT Agent will be listening as a Context Provider and base root to prefix all the paths). The `port` attribute is required. If no `baseRoot` attribute is used, '/' is used by default. E.g.:
 
@@ -42,8 +42,8 @@ These are the parameters that can be configured in the global section:
         interval: 100
     }
 ```
-* **authentication**: authentication data, for use in retrieving tokens for devices with a trust token (required in scenarios with security enabled in the Context Broker side). 
-  Currently, two authentication provider are supported: `keystone` and `oauth2`. Authentication need to be enabled by setting the field `enabled` to `true`. 
+* **authentication**: authentication data, for use in retrieving tokens for devices with a trust token (required in scenarios with security enabled in the Context Broker side).
+  Currently, two authentication provider are supported: `keystone` and `oauth2`. Authentication need to be enabled by setting the field `enabled` to `true`.
   In `keystone` based authentication, the `trust` associated to the `device` or `deviceGroup` is a token representing a specific user and his rights on a given domain (i.e.
   combination of `fiware-service` and `fiware-servicepath`). The authentication process use the trust delegation workflow to check if the trust provided is valid, in which
   case return a `x-subject-token` that can be used to authenticate the request to the Context Broker. Required parameters are: the `url` of the keystone to be used
@@ -60,7 +60,7 @@ These are the parameters that can be configured in the global section:
           password: 'iotagent'
     }
 ```
-  In `oauth2` based authentication, two types of tokens can be used depending on the availability in the IDM to be used. On one hand, the `trust` associated to the `device` or `deviceGroup` is a `refresh_token` issued by a specific user for the Context Broker client. 
+  In `oauth2` based authentication, two types of tokens can be used depending on the availability in the IDM to be used. On one hand, the `trust` associated to the `device` or `deviceGroup` is a `refresh_token` issued by a specific user for the Context Broker client.
   The authentication process uses the [`refresh_token` grant type](https://tools.ietf.org/html/rfc6749#section-1.5) to obtain an `access_token`
   that can be used to authenticate the request to the Context Broker.
   At the time being the assumption is that the `refresh_token` is a not expiring `offline_token` (we believe this is the best solution in the case of IoT Devices,
@@ -176,10 +176,14 @@ The following table shows the accepted environment variables, as well as the con
 | IOTA_AUTH_ENABLED         | authentication.enabled              |
 | IOTA_AUTH_TYPE            | authentication.type                 |
 | IOTA_AUTH_HEADER          | authentication.header               |
+| IOTA_AUTH_URL             | authentication.url                  |
 | IOTA_AUTH_HOST            | authentication.host                 |
 | IOTA_AUTH_PORT            | authentication.port                 |
 | IOTA_AUTH_USER            | authentication.user                 |
 | IOTA_AUTH_PASSWORD        | authentication.password             |
+| IOTA_AUTH_CLIENT_ID       | authentication.clientId             |
+| IOTA_AUTH_CLIENT_SECRET   | authentication.clientSecret         |
+| IOTA_AUTH_TOKEN_PATH      | authentication.tokenPath            |
 | IOTA_AUTH_PERMANENT_TOKEN | authentication.permanentToken       |
 | IOTA_REGISTRY_TYPE        | deviceRegistry.type                 |
 | IOTA_LOG_LEVEL            | logLevel                            |

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -61,10 +61,14 @@ function processEnvironmentVariables() {
              'IOTA_AUTH_ENABLED',
              'IOTA_AUTH_TYPE',
              'IOTA_AUTH_HEADER',
+             'IOTA_AUTH_URL',
              'IOTA_AUTH_HOST',
              'IOTA_AUTH_PORT',
              'IOTA_AUTH_USER',
              'IOTA_AUTH_PASSWORD',
+             'IOTA_AUTH_CLIENT_ID',
+             'IOTA_AUTH_CLIENT_SECRET',
+             'IOTA_AUTH_TOKEN_PATH',
              'IOTA_AUTH_PERMANENT_TOKEN',
              'IOTA_REGISTRY_TYPE',
              'IOTA_LOG_LEVEL',
@@ -112,6 +116,7 @@ function processEnvironmentVariables() {
         }
     }
 
+    // Context Broker Configuration
     if (process.env.IOTA_CB_URL) {
         config.contextBroker.url = process.env.IOTA_CB_URL;
     } else if (process.env.IOTA_CB_HOST) {
@@ -124,14 +129,20 @@ function processEnvironmentVariables() {
         }
     }
 
+    if (process.env.IOTA_CB_HOST) {
+        config.contextBroker.host = process.env.IOTA_CB_HOST;
+    }
+    if (process.env.IOTA_CB_PORT) {
+        config.contextBroker.port = process.env.IOTA_CB_PORT;
+    }
     if (process.env.IOTA_CB_NGSI_VERSION) {
         config.contextBroker.ngsiVersion = process.env.IOTA_CB_NGSI_VERSION;
     }
 
+    // North Port Configuration
     if (process.env.IOTA_NORTH_HOST) {
         config.server.host = process.env.IOTA_NORTH_HOST;
     }
-
     if (process.env.IOTA_NORTH_PORT) {
         config.server.port = process.env.IOTA_NORTH_PORT;
     }
@@ -140,6 +151,7 @@ function processEnvironmentVariables() {
         config.providerUrl = process.env.IOTA_PROVIDER_URL;
     }
 
+    // Authentication Parameters - General
     if (process.env.IOTA_AUTH_ENABLED) {
         config.authentication = {};
         config.authentication.enabled = process.env.IOTA_AUTH_ENABLED === 'true';
@@ -150,39 +162,68 @@ function processEnvironmentVariables() {
     if (process.env.IOTA_AUTH_HEADER) {
         config.authentication.header = process.env.IOTA_AUTH_HEADER;
     }
+    if (process.env.IOTA_AUTH_URL) {
+        config.authentication.url = process.env.IOTA_AUTH_URL;
+    } else if (process.env.IOTA_AUTH_HOST) {
+        config.authentication.host = process.env.IOTA_AUTH_HOST;
+        config.authentication.url = 'http://' + process.env.IOTA_AUTH_HOST;
+        if (process.env.IOTA_AUTH_PORT) {
+            config.authentication.url += ':' + process.env.IOTA_AUTH_PORT;
+        } else {
+            config.authentication.url += ':' + config.authentication.port;
+        }
+    }
     if (process.env.IOTA_AUTH_HOST) {
         config.authentication.host = process.env.IOTA_AUTH_HOST;
     }
     if (process.env.IOTA_AUTH_PORT) {
         config.authentication.port = process.env.IOTA_AUTH_PORT;
     }
+    // Authentication Parameters - Oauth + Keyrock
+    if (process.env.IOTA_AUTH_CLIENT_ID) {
+        config.authentication.clientId = process.env.IOTA_AUTH_CLIENT_ID;
+    }
+    if (process.env.IOTA_AUTH_CLIENT_SECRET) {
+        config.authentication.clientSecret = process.env.IOTA_AUTH_CLIENT_SECRET;
+    }
+    if (process.env.IOTA_AUTH_TOKEN_PATH) {
+        config.authentication.tokenPath = process.env.IOTA_AUTH_TOKEN_PATH;
+    }
+    // Authentication Parameters - Keyrock only
+    if (process.env.IOTA_AUTH_PERMANENT_TOKEN) {
+        config.authentication.permanentToken = process.env.IOTA_AUTH_PERMANENT_TOKEN;
+    }
+    // Authentication Parameters - Keystone only
     if (process.env.IOTA_AUTH_USER) {
         config.authentication.user = process.env.IOTA_AUTH_USER;
     }
     if (process.env.IOTA_AUTH_PASSWORD) {
         config.authentication.password = process.env.IOTA_AUTH_PASSWORD;
     }
-    if (process.env.IOTA_AUTH_PERMANENT_TOKEN) {
-        config.authentication.permanentToken = process.env.IOTA_AUTH_PERMANENT_TOKEN;
-    }
+
+    // Registry configuration (memory or database)
     if (process.env.IOTA_REGISTRY_TYPE) {
         config.deviceRegistry = {};
         config.deviceRegistry.type = process.env.IOTA_REGISTRY_TYPE;
     }
 
+    // Log Level configuration
     if (process.env.IOTA_LOG_LEVEL) {
         config.logLevel = process.env.IOTA_LOG_LEVEL;
         logger.setLevel(process.env.IOTA_LOG_LEVEL);
     }
 
+    // Whether to include timestamps
     if (process.env.IOTA_TIMESTAMP) {
         config.timestamp = process.env.IOTA_TIMESTAMP === 'true';
     }
 
+    // Default resource
     if (process.env.IOTA_DEFAULT_RESOURCE) {
         config.defaultResource = process.env.IOTA_DEFAULT_RESOURCE;
     }
 
+    // IoT Manager Configuration
     if (anyIsSet(iotamVariables)) {
         config.iotManager = {};
     }
@@ -214,6 +255,7 @@ function processEnvironmentVariables() {
         config.iotManager.agentPath = process.env.IOTA_IOTAM_AGENTPATH;
     }
 
+    // Mongo DB configuration
     if (anyIsSet(mongoVariables)) {
         config.mongodb = {};
     }
@@ -242,6 +284,7 @@ function processEnvironmentVariables() {
         config.mongodb.retryTime = process.env.IOTA_MONGO_RETRY_TIME;
     }
 
+    // Other configuration properties
     if (process.env.IOTA_SINGLE_MODE) {
         config.singleConfigurationMode = process.env.IOTA_SINGLE_MODE === 'true';
     }


### PR DESCRIPTION
Related: https://github.com/telefonicaid/iotagent-ul/pull/339#issuecomment-476255597

This PR adds Docker `ENV` parameters for the following parts of the config:

| Environment variable      | Configuration attribute             |
|:------------------------- |:----------------------------------- |
| IOTA_AUTH_URL             | authentication.url                  |
| IOTA_AUTH_CLIENT_ID       | authentication.clientId             |
| IOTA_AUTH_CLIENT_SECRET   | authentication.clientSecret         |
| IOTA_AUTH_TOKEN_PATH      | authentication.tokenPath            |

Furthermore `IOTA_CB_HOST` and `IOTA_CB_PORT` should always update their relevant part of the config regardless of whether `IOTA_CB_URL` is set, as the debug statements regarding the initialization (e.g. _overriding_ `CB_HOST`) will not match the actual state output thereafter since the host port won't be updated.

