### PR TITLE
[WIP] Fix reconnection problems with single mongo db instances

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -7,4 +7,4 @@ Upgrade from node-uuid ~1.4.1 to uuid ~3.3.2.
 Add: IOTA_AUTH_URL, IOTA_AUTH_CLIENT_ID, IOTA_AUTH_CLIENT_SECRET and IOTA_AUTH_TOKEN_PATH env vars
 Fix: incomplete HTTPS support for NGSI subscriptions (#593)
 Add: support for authentication to NGSI subscription requests (#592) 
-
+Fix: process dies if reconnection to DB fails instead of remain in a zombie state (#772)

--- a/doc/operations.md
+++ b/doc/operations.md
@@ -31,6 +31,14 @@ of the IoTA Manager. Check the conectivity, the state of the MongoDB cluster and
 This error will thrown if MongoDB is selected as the configured repository for data but some information is missing
 in the configuration file. Check the configuration file and add all the required information.
 
+### MONGODB-004: MongoDB connection was lost.
+
+Indicates that it was impossible to reestablish the connection with the MongoDB server after retrying N times. This could be caused
+by a connectivity problem with the MongoDB machine or by changes on the configuration of the MongoDB server done while the IoT Agent
+was running. This error is only thrown when using a single MongoDB instance or when using sharding but just a single mongos proxy.
+When using MongoDB instances using replica sets or multiple mongos servers, the IoT Agent will retry connecting forever alternating
+between the different nodes.
+
 ### IOTAM-001: Error updating information in the IOTAM. Status Code [%d]
 
 The IoT Agent could not contact the IoT Agent manager to update its information. This condition may indicate a lack of

--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -135,7 +135,7 @@ function init(host, db, port, username, password, options, callback) {
                 });
                 defaultDb.on('reconnectFailed', function() {
                     logger.error(context, 'MONGODB-004: MongoDB connection was lost');
-                    process.exit();
+                    process.exit(1);
                 });
                 defaultDb.on('disconnecting', function() {
                     logger.debug(context, 'Mongo Driver disconnecting');

--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -133,6 +133,10 @@ function init(host, db, port, username, password, options, callback) {
                 defaultDb.on('disconnected', function() {
                     logger.debug(context, 'Mongo Driver disconnected');
                 });
+                defaultDb.on('reconnectFailed', function() {
+                    logger.error(context, 'MONGODB-004: MongoDB connection was lost');
+                    process.exit();
+                });
                 defaultDb.on('disconnecting', function() {
                     logger.debug(context, 'Mongo Driver disconnecting');
                 });


### PR DESCRIPTION
This PR should fix reconnection with MongoDBs when using single MongoDBs instances (e.g. for basic or demo installations). In this scenario, if the connection to the MongoDB server is lost and the IoTAgent is not able to reconnect again in a short period of time, the IoTAgent node lib will never reconnect again to MongoDB leaving the IoTAgent in a zombi status. 

This can be easily reproduced by shutting down the MongoDB server while the IoTAgent is running, leaving the MongoDB server down enough time and starting it again.

This happens because the IoTAgent node libe is not listening to the `reconnectFailed` event. Mongoose will try to reconnect every `reconnectInterval` milliseconds for `reconnectTries` times before raising the `reconnectFailed` event (See [mongoose's documentation](https://mongoosejs.com/docs/4.x/docs/connections.html#options) for more details). In my opinion, the best option here is to make the IoTAgent process to quit as soon as this scenario is detected. Another option would be adding extra reconnection stuff, but I think it is not worth it due the fact that IoTAgent are usually executed using docker so you can configure a restart policy (in fact, the pm2 component currently installed on the docker images is doing the same and can be used outside the docker image).

This problem does not happen when using replica sets or sharding, as in those scenarios Mongoose will try to reconnect forever. 