### PR TITLE
Allow blank as an override for defaultResource

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Add autoprovision (appendMode) in device and group provosion (#805)
+- Allow blank as an override for defaultResource 

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -219,7 +219,7 @@ function processEnvironmentVariables() {
     }
 
     // Default resource
-    if (process.env.IOTA_DEFAULT_RESOURCE) {
+    if (process.env.IOTA_DEFAULT_RESOURCE !== undefined) {
         config.defaultResource = process.env.IOTA_DEFAULT_RESOURCE;
     }
 

--- a/lib/services/common/iotManagerService.js
+++ b/lib/services/common/iotManagerService.js
@@ -76,7 +76,7 @@ function register(callback) {
                 protocol: config.getConfig().iotManager.protocol,
                 description: config.getConfig().iotManager.description,
                 iotagent: config.getConfig().providerUrl + (config.getConfig().iotManager.agentPath || ''),
-                resource: config.getConfig().defaultResource || constants.DEFAULT_RESOURCE,
+                resource: (config.getConfig().defaultResource !== undefined ? config.getConfig().defaultResource : constants.DEFAULT_RESOURCE),
                 services: services
             }
         };

--- a/lib/services/common/iotManagerService.js
+++ b/lib/services/common/iotManagerService.js
@@ -70,6 +70,11 @@ function register(callback) {
     }
 
     function sendRegistration(services, callback) {
+        var resource = constants.DEFAULT_RESOURCE;
+        // Use an Undefined check since defaultResource override could be blank.
+        if (config.getConfig().defaultResource !== undefined){
+            resource = config.getConfig().defaultResource;
+        }
         var options = {
             url: config.getConfig().iotManager.url + config.getConfig().iotManager.path,
             method: 'POST',
@@ -77,7 +82,7 @@ function register(callback) {
                 protocol: config.getConfig().iotManager.protocol,
                 description: config.getConfig().iotManager.description,
                 iotagent: config.getConfig().providerUrl + (config.getConfig().iotManager.agentPath || ''),
-                resource: (config.getConfig().defaultResource !== undefined ? config.getConfig().defaultResource : constants.DEFAULT_RESOURCE),
+                resource: resource,
                 services: services
             }
         };


### PR DESCRIPTION
Potential fix/workaround for https://github.com/telefonicaid/iotagent-ul/issues/320

When checking to see if `IOTA_DEFAULT_RESOURCE` is set, deliberately check for `undefined` rather than general truthiness, since a zero-length string is also `false` This allows docker-compose users to set the default resource to blank `''` using an `ENV` as shown:

```yaml
  iot-agent:
    image: iot-agent
    depends_on:
      - mongo-db
      - mosquitto
    networks:
      - default
    expose:
      - "4041"
    ports:
      - "4041:4041"
    environment:
...etc
      - IOTA_MQTT_HOST=mosquitto # The host name of the MQTT Broker
      - IOTA_MQTT_PORT=1883 # The port the MQTT Broker is listening on to receive topics
      - IOTA_DEFAULT_RESOURCE= # Default is blank. I'm using MQTT so I don't need a resource
```

This means that an MQTT device can be successfully provisioned without setting a dummy resource

```console
curl -X POST \
  http://localhost:4041/iot/services \
  -H 'Content-Type: application/json' \
  -H 'fiware-service: openiot' \
  -H 'fiware-servicepath: /' \
  -d '{
 "services": [
   {
     "apikey":      "4jggokgpepnvsb2uv4s40d59ov",
     "cbroker":     "http://orion:1026",
     "entity_type": "Thing",
     "resource":    ""
   }
 ]
}'

curl -X POST \
  http://localhost:4041/iot/devices \
  -H 'Content-Type: application/json' \
  -H 'fiware-service: openiot' \
  -H 'fiware-servicepath: /' \
  -d '{
 "devices": [
   {
     "device_id":   "motion001",
     "entity_name": "urn:ngsd-ld:Motion:001",
     "entity_type": "Motion",
     "protocol":    "PDI-IoTA-UltraLight",
     "transport":   "MQTT",
     "timezone":    "Europe/Berlin",
     "attributes": [
       { "object_id": "c", "name":"count", "type":"Integer"}
      ],
      "static_attributes": [
         {"name":"refStore", "type": "Relationship","value": "urn:ngsi-ld:Store:001"}
      ]
   }
 ]
}
'
```

When a topic is sent to Mosquitto the  default resource of `''` is used.

This PR would mean that the `docker-compose` for the MQTT tutorial could be updated to work with the latest Ultralight IoT Agent and the issue https://github.com/FIWARE/tutorials.IoT-over-MQTT/issues/8 can be closed thereafter

My opinion on the existing bug can be found here: https://github.com/telefonicaid/iotagent-ul/issues/320#issuecomment-454869041 - in summary both the Agent and the Tutorial should be updated somehow. I think this is a better _reasonable workaround_ for the existing situation, as forcing users to set a resource unnecessarily seems weird.