### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/telefonicaid/iotagent-node-lib.git
 site_description: IoT Agent Library Documentation
 docs_dir: doc
 site_dir: html
+edit_uri: edit/master/doc/
 markdown_extensions: [toc,fenced_code]
 use_directory_urls: false
 theme: readthedocs


### PR DESCRIPTION
Adding the right config parameter, according to mkdocs instructions will fix documentation broken links:
https://www.mkdocs.org/user-guide/configuration/#edit_uri
The same fix has been applied successfully in other similar repositories:
telefonicaid/fiware-orion#3491