### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Fiware-iotagent-node-lib
 site_url: https://fiware-iotagent-node-lib.readthedocs.org
-repo_url: https://github.com/telefonicaid/iotagent-node-lib.git
+repo_url: https://github.com/telefonicaid/iotagent-node-lib
 site_description: IoT Agent Library Documentation
 docs_dir: doc
 site_dir: html


### PR DESCRIPTION
I'm sorry, in order to fix links to GitHub, this must be changed also
Repo URL must be:
repo_url: https://github.com/telefonicaid/iotagent-node-lib
Instead of
repo_url: https://github.com/telefonicaid/iotagent-node-lib.git