### PR TITLE
remove apikey from device model

### DIFF
--- a/lib/model/Device.js
+++ b/lib/model/Device.js
@@ -32,7 +32,6 @@ var Device = new Schema({
     lazy: Array,
     active: Array,
     commands: Array,
-    apikey: String,
     endpoint: String,
     resource: String,
     protocol: String,


### PR DESCRIPTION
According with doc apikey is not part of device model
https://github.com/telefonicaid/iotagent-node-lib#device-model

related with https://github.com/telefonicaid/iotagent-node-lib/pull/796