### PR TITLE
Fix #829 - Add null check

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+Add Null check within executeWithSecurity() to avoid crash 

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -299,7 +299,8 @@ function executeWithSecurity(requestOptions, deviceData, callback) {
                         }
                     });
                 } else {
-                    callback(new errors.SecurityInformationMissing(typeInformation ? typeInformation.type : deviceData.type));
+                    callback(new errors.SecurityInformationMissing( 
+                        typeInformation ? typeInformation.type : deviceData.type));
                 }
             } else {
                 request(requestOptions, callback);

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -299,7 +299,7 @@ function executeWithSecurity(requestOptions, deviceData, callback) {
                         }
                     });
                 } else {
-                    callback(new errors.SecurityInformationMissing(typeInformation.type));
+                    callback(new errors.SecurityInformationMissing(typeInformation ? typeInformation.type : deviceData.type));
                 }
             } else {
                 request(requestOptions, callback);


### PR DESCRIPTION
The function `executeWithSecurity()` has the following logic:

```javascript
 var typeInformation;
 if (deviceGroup) {
       typeInformation = deviceGroup;
 } else {
    typeInformation = config.getConfig().types[deviceData.type];
 }

 if (config.getConfig().authentication && config.getConfig().authentication.enabled) {
    var security = config.getSecurityService();
    if (typeInformation && typeInformation.trust) {
         ///  ...etc
    } else {
        callback(new errors.SecurityInformationMissing(typeInformation.type));
   }
// etc ...
```

If security is properly configured and  a device is provisioned which does not belong to an existing group (neither in the config, nor in a previsioned group) then:

```javascript
 typeInformation = config.getConfig().types[deviceData.type] = null;
```

and the error call back will null pointer against `typeInformation.type`.

The PR just substitutes `device.type` if type is not provisioned.
