### PR TITLE
Add missing issue number in CHANGES_NEXT_RELEASE

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-Add Null check within executeWithSecurity() to avoid crash 
+Add Null check within executeWithSecurity() to avoid crash (#829)


### PR DESCRIPTION
For traceability, we add the corresponding issue nunber in CHANGEX_NEXT_RELEASE whenever is possible. I missed this in the PR #833 review.

CC: @jason-fox 