### PR TITLE
Add NGSIv2 metadata support to device provisioned attributes

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
+Add NGSIv2 metadata support to device provisioned attributes
 Fix: Error message when sending measures with unknown/undefined attribute
 Add Null check within executeWithSecurity() to avoid crash 

--- a/lib/plugins/pluginUtils.js
+++ b/lib/plugins/pluginUtils.js
@@ -106,7 +106,9 @@ function createProcessAttribute(fn, attributeType) {
         }
 
         if (config.checkNgsi2()) {
-
+            // This code is backwards compatible to process metadata in the older NGSIv1-style (array) 
+            // as well as supporting the newer NGSIv2-style (object). The redundant Array Check can be 
+            // therefore be removed if/when NGSIv1 support is removed from the library.
             if (Array.isArray (attribute.metadata)){
                 attribute.metadata = attribute.metadata.map(createProcessAttribute(fn, attributeType));
             } else if (attribute.metadata) {

--- a/lib/plugins/pluginUtils.js
+++ b/lib/plugins/pluginUtils.js
@@ -106,8 +106,14 @@ function createProcessAttribute(fn, attributeType) {
         }
 
         if (config.checkNgsi2()) {
-            if (attribute.metadata) {
+
+            if (Array.isArray (attribute.metadata)){
                 attribute.metadata = attribute.metadata.map(createProcessAttribute(fn, attributeType));
+            } else if (attribute.metadata) {
+                Object.keys(attribute.metadata).forEach(function(key) {
+                    var entry = attribute.metadata[key];
+                    entry.value = fn(entry.value);
+                });
             }
         } else {
             if (attribute.metadatas) {

--- a/lib/plugins/timestampProcessPlugin.js
+++ b/lib/plugins/timestampProcessPlugin.js
@@ -45,7 +45,7 @@ function updatePluginNgsi2(entity, entityType, callback) {
     function insertMetadata(element) {
 
         if (element.name !== constants.TIMESTAMP_ATTRIBUTE) {
-            var metadata = {};
+            var metadata = element.metadata || {};
             metadata[constants.TIMESTAMP_ATTRIBUTE] = {
                 type: constants.TIMESTAMP_TYPE_NGSI2,
                 value: timestamp.value

--- a/lib/services/commands/commandRegistryMongoDB.js
+++ b/lib/services/commands/commandRegistryMongoDB.js
@@ -56,8 +56,7 @@ function findCommand(service, subservice, deviceId, name, callback) {
             callback(null, data);
         } else {
             logger.debug(context, 'Command for DeviceID [%j] with name [%j] not found', deviceId, name);
-
-            callback(new errors.CommandNotFound());
+            callback(new errors.CommandNotFound(name));
         }
     });
 }

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -218,19 +218,21 @@ function formatAttributesNgsi2(originalVector, staticAtts) {
             // (#628) check if attribute has entity_name:
             // In that case attribute should not be appear in current entity
             /*jshint camelcase: false */
+
             if (!originalVector[i].entity_name) {
                 attributeList[originalVector[i].name] = {
                     type: originalVector[i].type,
                     value: getInitialValueForType(originalVector[i].type)
                 };
-
                 if (staticAtts) {
                     attributeList[originalVector[i].name].value = originalVector[i].value;
                 } else {
                     attributeList[originalVector[i].name].value = getInitialValueForType(originalVector[i].type);
                 }
+                if (originalVector[i].metadata ){
+                    attributeList[originalVector[i].name].metadata = originalVector[i].metadata;
+                }
             }
-
         }
     }
 

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -82,7 +82,7 @@ function generateNGSIOperationHandler(operationName, entityName, typeInformation
                 logger.error(context,
                     'Operation ' + operationName + ' error connecting to the Context Broker: %j', errorField);
 
-                if (errorField.code && errorField.code === '404' && 
+                if (errorField.code && errorField.code === '404' &&
                     errorField.details.includes(typeInformation.type) ){
                     callback(new errors.DeviceNotFound(entityName));
                 }
@@ -168,9 +168,9 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
 
             logger.error(context,
                 'Operation ' + operationName + ' error connecting to the Context Broker: %j', body);
-            
+
             var errorField = ngsiParser.getErrorField(body);
-            if (response.statusCode && response.statusCode === 404 && 
+            if (response.statusCode && response.statusCode === 404 &&
                 errorField.details.includes(typeInformation.type) ) {
                 callback(new errors.DeviceNotFound(entityName));
             }
@@ -275,7 +275,7 @@ function addTimestamp(payload, timezone) {
     if (!timezone) {
         timestamp.value = (new Date()).toISOString();
     } else {
-        timestamp.value = moment().tz(timezone).format('YYYY-MM-DD[T]HH:mm:ss.SSSZ');      
+        timestamp.value = moment().tz(timezone).format('YYYY-MM-DD[T]HH:mm:ss.SSSZ');
     }
 
     function addMetadata(attribute) {
@@ -317,7 +317,7 @@ function addTimestampNgsi2(payload, timezone) {
         if (!timezone) {
             timestamp.value = (new Date()).toISOString();
         } else {
-            timestamp.value = moment().tz(timezone).format('YYYY-MM-DD[T]HH:mm:ss.SSSZ');      
+            timestamp.value = moment().tz(timezone).format('YYYY-MM-DD[T]HH:mm:ss.SSSZ');
         }
 
         function addMetadata(attribute) {
@@ -372,6 +372,31 @@ function addTimestampNgsi2(payload, timezone) {
     }
 
 }
+
+function getMetaData(typeInformation, name, metadata){
+    if(metadata){
+        return metadata;
+    }
+
+    var i;
+    if(typeInformation.active){
+        for (i = 0; i < typeInformation.active.length; i++) {
+            /* jshint camelcase: false */
+            if (name === typeInformation.active[i].object_id){
+              return typeInformation.active[i].metadata;
+            }
+        }
+    }
+    if(typeInformation.staticAttributes){
+        for (i = 0; i < typeInformation.staticAttributes.length; i++) {
+            if (name === typeInformation.staticAttributes[i].name){
+              return typeInformation.staticAttributes[i].metadata;
+            }
+        }
+    }
+    return undefined;
+}
+
 
 /**
  * It casts attribute values which are reported using JSON native types
@@ -436,15 +461,15 @@ function castJsonNativeAttributes(payload) {
 function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, callback) {
 
     var payload = {};
-    
+
     var url = '/v2/entities/' + entityName + '/attrs';
-    
+
     if (typeInformation.type) {
        url += '?type=' + typeInformation.type;
-    } 
-    
+    }
+
     var options = createRequestObject(url, typeInformation, token);
-    
+
 
     if (typeInformation && typeInformation.staticAttributes) {
         attributes = attributes.concat(typeInformation.staticAttributes);
@@ -462,14 +487,18 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
         if (attributes[i].name && attributes[i].type) {
             payload[attributes[i].name] = {
                 'value' : attributes[i].value,
-                'type' : attributes[i].type,
-                'metadata' : attributes[i].metadata
+                'type' : attributes[i].type
             };
+            var metadata = getMetaData(typeInformation, attributes[i].name, attributes[i].metadata);
+            if (metadata){
+                payload[attributes[i].name].metadata = metadata;
+            }
         } else {
             callback(new errors.BadRequest(null, entityName));
             return;
         }
     }
+
     payload = castJsonNativeAttributes(payload);
     async.waterfall([
         apply(statsService.add, 'measureRequests', 1),
@@ -624,7 +653,7 @@ function sendUpdateValueNgsi1(entityName, attributes, typeInformation, token, ca
                     callback(new errors.BadTimestamp(options.json));
                     return;
                 }
-                
+
             }
 
             logger.debug(context, 'Updating device value in the Context Broker at [%s]', options.url);
@@ -682,7 +711,7 @@ function sendQueryValueNgsi2(entityName, attributes, typeInformation, token, cal
         if (attributes && attributes.length > 0) {
             url += '&type=' + typeInformation.type;
         } else {
-            url += '?type=' + typeInformation.type;            
+            url += '?type=' + typeInformation.type;
         }
     }
 
@@ -891,6 +920,7 @@ function setCommandResult(entityName, resource, apikey, commandName,
                 }
             ];
 
+
         if (!callback) {
             callback = deviceInformation;
 
@@ -920,6 +950,10 @@ function setCommandResult(entityName, resource, apikey, commandName,
         }
 
         commandInfo = _.where(typeInformation.commands, {name: commandName});
+
+        if(deviceGroup && commandInfo.length !== 1){
+            commandInfo = _.where(deviceGroup.commands, {name: commandName});
+        }
 
         if (commandInfo.length === 1) {
             exports.update(

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextCompressTimestamp2.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextCompressTimestamp2.json
@@ -2,15 +2,14 @@
   "state": {
     "type": "Boolean",
     "value": true,
-    "metadata": [
-      {
-        "name": "TimeInstant",
+    "metadata": {
+      "TimeInstant": {
         "type": "DateTime",
         "value": "+002007-11-03T13:18:05"
       }
-    ]
+    }
   },
-  "TheTargetValue":{
+  "TheTargetValue": {
     "type": "DateTime",
     "value": "+002007-11-03T13:18:05"
   }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextMultientityPlugin8.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextMultientityPlugin8.json
@@ -1,0 +1,31 @@
+{
+  "actionType": "append",
+  "entities": [
+    {
+      "id": "ws7",
+      "type": "WeatherStation"
+    },
+    {
+      "pressure": {
+        "type": "Hgmm",
+        "value": "17",
+        "metadata": {
+          "unitCode": {
+            "type": "Text",
+            "value": "Hgmm"
+          }
+        }
+      },
+      "type": "Higrometer",
+      "id": "Higro2002"
+    },
+    {
+      "pressure": {
+        "type": "Hgmm",
+        "value": "16"
+      },
+      "type": "Higrometer",
+      "id": "Higro2000"
+    }
+  ]
+}

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributesMetadata.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributesMetadata.json
@@ -1,0 +1,16 @@
+{
+  "luminosity": {
+    "value": "100",
+    "type": "text"
+  },
+  "controlledProperty": {
+    "value": "StaticValue",
+    "type": "text",
+    "metadata": {
+      "includes": {
+        "type": "Text",
+        "value": "bell"
+      }
+    }
+  }
+}

--- a/test/unit/ngsiv2/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiv2/ngsiService/active-devices-test.js
@@ -113,6 +113,30 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                         type: 'percentage'
                     }
                 ]
+            },
+            'Lamp': {
+                type: 'Lamp',
+                commands: [],
+                lazy: [],
+                staticAttributes: [
+                    {
+                        'name': 'controlledProperty',
+                        'type': 'text',
+                        'value': 'StaticValue',
+                        'metadata':{
+                            'includes':{'type': 'Text', 'value' :'bell'}
+                        }
+                    }
+                ],
+                active: [
+                    {
+                        name: 'luminosity',
+                        type: 'text',
+                        metadata:{
+                            unitCode:{type: 'Text', value :'CAL'}
+                        }
+                    }
+                ]
             }
         },
         service: 'smartGondor',
@@ -618,6 +642,38 @@ describe('Active attributes test', function() {
         });
         it('should decorate the entity with the static attributes', function(done) {
             iotAgentLib.update('motion1', 'Motion', '', newValues, function(error) {
+                should.not.exist(error);
+                contextBrokerMock.done();
+                done();
+            });
+        });
+    });
+
+
+     xdescribe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
+        var newValues = [
+            {
+                name: 'luminosity',
+                type: 'text',
+                value: '100'
+            }
+        ];
+
+        beforeEach(function(done) {
+            nock.cleanAll();
+
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', 'gardens')
+                .post('/v2/entities/lamp1/attrs',
+                utils.readExampleFile('./test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributes.json'))
+                .query({type: 'Lamp'})
+                .reply(204);
+
+            iotAgentLib.activate(iotAgentConfig, done);
+        });
+        it('should decorate the entity with the static attributes', function(done) {
+            iotAgentLib.update('lamp1', 'Lamp', '', newValues, function(error) {
                 should.not.exist(error);
                 contextBrokerMock.done();
                 done();

--- a/test/unit/ngsiv2/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiv2/ngsiService/active-devices-test.js
@@ -650,7 +650,7 @@ describe('Active attributes test', function() {
     });
 
 
-     xdescribe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
+    describe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
         var newValues = [
             {
                 name: 'luminosity',
@@ -666,7 +666,7 @@ describe('Active attributes test', function() {
                 .matchHeader('fiware-service', 'smartGondor')
                 .matchHeader('fiware-servicepath', 'gardens')
                 .post('/v2/entities/lamp1/attrs',
-                utils.readExampleFile('./test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributes.json'))
+                utils.readExampleFile('./test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributesMetadata.json'))
                 .query({type: 'Lamp'})
                 .reply(204);
 

--- a/test/unit/ngsiv2/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiv2/ngsiService/active-devices-test.js
@@ -662,6 +662,7 @@ describe('Active attributes test', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
+            /* jshint maxlen: 200 */
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
                 .matchHeader('fiware-servicepath', 'gardens')

--- a/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
@@ -122,7 +122,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 describe('Timestamp compression plugin', function() {
     beforeEach(function(done) {
-        logger.setLevel('FATAL');
+        logger.setLevel('DEBUG');
         iotAgentLib.activate(iotAgentConfig, function() {
             iotAgentLib.clearAll(function() {
                 iotAgentLib.addUpdateMiddleware(iotAgentLib.dataPlugins.compressTimestamp.updateNgsi2);
@@ -172,19 +172,19 @@ describe('Timestamp compression plugin', function() {
         });
     });
 
-    describe('When an update comes with a timestamp through the plugin with metadata', function() {
+    describe('When an update comes with a timestamp through the plugin with metadata.', function() {
         var values = [
             {
                 name: 'state',
                 type: 'Boolean',
                 value: true,
-                metadata: [
-                    {
-                        name: 'TimeInstant',
+                metadata: {
+                     TimeInstant: {
                         type: 'DateTime',
                         value: '20071103T131805'
                     }
-                ]
+                }
+                
             },
             {
                 name: 'TheTargetValue',

--- a/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
@@ -122,7 +122,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 describe('Timestamp compression plugin', function() {
     beforeEach(function(done) {
-        logger.setLevel('DEBUG');
+        logger.setLevel('FATAL');
         iotAgentLib.activate(iotAgentConfig, function() {
             iotAgentLib.clearAll(function() {
                 iotAgentLib.addUpdateMiddleware(iotAgentLib.dataPlugins.compressTimestamp.updateNgsi2);

--- a/test/unit/ngsiv2/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/multientity-plugin_test.js
@@ -340,6 +340,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
+    /* jshint maxlen: 200 */
     describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
         var values = [
             {

--- a/test/unit/ngsiv2/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/multientity-plugin_test.js
@@ -139,6 +139,30 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     }
                 ]
             },
+            'WeatherStation7': {
+                commands: [],
+                type: 'WeatherStation',
+                lazy: [],
+                active: [
+                    {
+                        object_id: 'p',
+                        name: 'pressure',
+                        type: 'Hgmm',
+                        metadata: {
+                            unitCode:{type: 'Text', value :'Hgmm'}
+                        },
+                        entity_name: 'Higro2002',
+                        entity_type: 'Higrometer'
+                    },
+                    {
+                        object_id: 'h',
+                        name: 'pressure',
+                        type: 'Hgmm',
+                        entity_name: 'Higro2000',
+                        entity_type: 'Higrometer'
+                    }
+                ]
+            },
             'Sensor001': {
                 commands: [],
                 type: 'Sensor',
@@ -309,6 +333,40 @@ describe('Multi-entity plugin', function() {
 
         it('should send context elements', function(done) {
             iotAgentLib.update('ws6', 'WeatherStation6', '', values, function(error) {
+                should.not.exist(error);
+                contextBrokerMock.done();
+                done();
+            });
+        });
+    });
+
+    describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
+        var values = [
+            {
+                name: 'h',
+                type: 'Hgmm',
+                value: '16'
+            },
+            {
+                name: 'p',
+                type: 'Hgmm',
+                value: '17'
+            }
+        ];
+
+        beforeEach(function() {
+            nock.cleanAll();
+
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .matchHeader('fiware-servicepath', 'gardens')
+                .post('/v2/op/update', utils.readExampleFile(
+                    './test/unit/ngsiv2/examples/contextRequests/updateContextMultientityPlugin8.json'))
+                .reply(204);
+        });
+
+        it('should send context elements', function(done) {
+            iotAgentLib.update('ws7', 'WeatherStation7', '', values, function(error) {
                 should.not.exist(error);
                 contextBrokerMock.done();
                 done();


### PR DESCRIPTION
I want to be able to add metadata when provisioning an IoT Agent, so that the units of measurement can be placed into the resultant entity.

e.g.:

```json
{
     "entity_type": "Lamp",
     "resource":    "/iot/d",
     "protocol":    "PDI-IoTA-UltraLight",
..etc
     "commands": [ 
        {"name": "on","type": "command"},
        {"name": "off","type": "command"}
     ],
     "attributes": [
        {"object_id": "s", "name": "state", "type":"Text"},
        {"object_id": "l", "name": "luminosity", "type":"Integer",
          "metadata":{
              "unitCode":{"type": "Text", "value" :"CAL"}
          }
        }
     ],
     "static_attributes": [
          {"name": "category", "type":"Text", "value": ["actuator","sensor"]},
          {"name": "controlledProperty", "type": "Text", "value": ["light"],
            "metadata":{
              "includes":{"type": "Text", "value" :["state", "luminosity"]},
              "alias":{"type": "Text", "value" :"lamp"}
            }
          },
     ]
   }
```


Currently `metadata` placed into the provisioning request is **valid**, but the `metadata` is not **processed** when exchanging requests with the Context Broker.  Only `metadata` coming directly from a **Measure** is  exchanged.

Furthermore, typical NGSI v2 `metadata` is in the form of key-value pairs - a.k.a _properties-of-properties_. These values should also be processed properly along with NGSI v1 style metadata-as-an- array.

This PR does the following:

- Ensure static attribute and active attributes can hold metadata
- Process metadata objects as well as arrays.
- Ensures that Generated Timestamps do not obliterate other metadata elements.
- Create Tests