### PR TITLE
Add NGSIv2 metadata support to attributeAlias plugin

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@ Refresh Documentation
 Add NGSIv2 metadata support to device provisioned attributes
 Fix: Error message when sending measures with unknown/undefined attribute
 Add Null check within executeWithSecurity() to avoid crash (#829)
+Add NGSIv2 metadata support to attributeAlias plugin.

--- a/lib/plugins/attributeAlias.js
+++ b/lib/plugins/attributeAlias.js
@@ -37,9 +37,9 @@ var config = require('../commonConfig'),
 
 function extractSingleMapping(previous, current) {
     /* jshint camelcase: false */
-
     previous.direct[current.object_id] = current.name;
     previous.types[current.object_id] = current.type;
+    previous.metadata[current.object_id] = current.metadata;
     previous.inverse[current.name] = current.object_id; // collision using multientity
     return previous;
 }
@@ -51,7 +51,7 @@ function extractSingleMapping(previous, current) {
  * @return {{direct: {}, inverse: {}}}      Object containing the direct and reverse name mappings.
  */
 function extractAllMappings(typeInformation) {
-    var mappings = { direct: {}, inverse: {}, types: {}};
+    var mappings = { direct: {}, inverse: {}, types: {}, metadata: {}};
 
     if (typeInformation.active) {
         mappings = typeInformation.active.reduce(extractSingleMapping, mappings);
@@ -64,7 +64,6 @@ function extractAllMappings(typeInformation) {
     if (typeInformation.commands) {
         mappings = typeInformation.commands.reduce(extractSingleMapping, mappings);
     }
-
     return mappings;
 }
 
@@ -81,10 +80,10 @@ function applyAlias(mappings) {
                 /*jshint camelcase: false */
                 attribute.object_id = attribute.name; // inverse not usefull due to collision
             }
+            attribute.metadata = mappings.metadata[attribute.name];
             attribute.type = mappings.types[attribute.name];
             attribute.name = mappings.direct[attribute.name];
         }
-
         return attribute;
     };
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin1.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin1.json
@@ -1,19 +1,18 @@
 {
-	"temperature": {
-		"type":"Number",
-		"value":52,
-		"metadata": {
-			"type":"Property",
-			"value":"CEL"
-		}
-	},
-	"pressure": {
-		"type":"Number",
-		"value":20071103,
-		"metadata": {
-			"type":"Property",
-			"value":"Hgmm"
-		}
-	}
+  "temperature": {
+    "type":"Number",
+    "value":52,
+    "metadata": {
+      "type":"Property",
+      "value":"CEL"
+    }
+  },
+  "pressure": {
+    "type":"Number",
+    "value":20071103,
+    "metadata": {
+      "type":"Property",
+      "value":"Hgmm"
+    }
+  }
 }
-

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin1.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin1.json
@@ -1,10 +1,19 @@
 {
-  "temperature": {
-    "type": "centigrades",
-    "value": "52"
-  },
-  "pressure": {
-    "type": "Hgmm",
-    "value": "20071103T131805"
-  }
+	"temperature": {
+		"type":"Number",
+		"value":52,
+		"metadata": {
+			"type":"Property",
+			"value":"CEL"
+		}
+	},
+	"pressure": {
+		"type":"Number",
+		"value":20071103,
+		"metadata": {
+			"type":"Property",
+			"value":"Hgmm"
+		}
+	}
 }
+

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin2.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin2.json
@@ -3,8 +3,8 @@
     "type": "Number",
     "value": 9,
     "metadata": {
-		"type":"Property",
-		"value":"CAL"
-	}
+      "type":"Property",
+      "value":"CAL"
+    }
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin2.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextAliasPlugin2.json
@@ -1,6 +1,10 @@
 {
   "luminance": {
-    "type": "lumens",
-    "value": "9"
+    "type": "Number",
+    "value": 9,
+    "metadata": {
+		"type":"Property",
+		"value":"CAL"
+	}
   }
 }

--- a/test/unit/ngsiv2/plugins/alias-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/alias-plugin_test.js
@@ -50,19 +50,25 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
                     {
                         object_id: 't',
                         name: 'temperature',
-                        type: 'centigrades'
+                        type: 'Number',
+                        metadata: { type: 'Property', value:'CEL'}
+
                     }
                 ],
                 active: [
                     {
                         object_id: 'p',
                         name: 'pressure',
-                        type: 'Hgmm'
+                        type: 'Number',
+                        metadata: { type: 'Property', value:'Hgmm'}
+
                     },
                     {
                         object_id: 'l',
                         name: 'luminance',
-                        type: 'lumens'
+                        type: 'Number',
+                        metadata: { type: 'Property', value:'CAL'}
+
                     },
                     {
                         object_id: 'ut',


### PR DESCRIPTION
Amend the `aliasAttribute` plugin to do the following:

- copy over `metadata` if found in provisioning data
- update two tests to use `metadata` in provisioning.

The other eight `aliasAttribute` test cases have not been updated, so that the negative case - alias without `metadata` - is still covered.
