### PR TITLE
Prepend NGSI-v1 to the v1 tests, NGSI-v2 to the v2 tests

### DIFF
--- a/test/unit/expressions/expressionBasedTransformations-test.js
+++ b/test/unit/expressions/expressionBasedTransformations-test.js
@@ -118,7 +118,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Expression-based transformations plugin', function() {
+describe('NGSI-v1 - Expression-based transformations plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/general/contextBrokerKeystoneSecurityAccess-test.js
+++ b/test/unit/general/contextBrokerKeystoneSecurityAccess-test.js
@@ -87,7 +87,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Secured access to the Context Broker with Keystone', function() {
+describe('NGSI-v1 - Secured access to the Context Broker with Keystone', function() {
     var values = [
         {
             name: 'state',

--- a/test/unit/general/contextBrokerOAuthSecurityAccess-test.js
+++ b/test/unit/general/contextBrokerOAuthSecurityAccess-test.js
@@ -88,7 +88,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Secured access to the Context Broker with OAuth2 provider', function() {
+describe('NGSI-v1 - Secured access to the Context Broker with OAuth2 provider', function() {
     var values = [
         {
             name: 'state',

--- a/test/unit/general/deviceService-test.js
+++ b/test/unit/general/deviceService-test.js
@@ -168,7 +168,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
 
 
 /* jshint camelcase: false */
-describe('Device Service: utils', function() {
+describe('NGSI-v1 - Device Service: utils', function() {
     beforeEach(function(done) {
         nock.cleanAll();
         logger.setLevel('FATAL');

--- a/test/unit/general/https-support-test.js
+++ b/test/unit/general/https-support-test.js
@@ -122,7 +122,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
     iotamMock;
 
 
-describe('HTTPS support tests IOTAM', function() {
+describe('NGSI-v1 - HTTPS support tests IOTAM', function() {
 
     describe('When the IoT Agents is started with https "iotManager" config', function() {
         beforeEach(function(done) {
@@ -154,7 +154,7 @@ describe('HTTPS support tests IOTAM', function() {
     });
 });
 
-describe('HTTPS support tests', function() {
+describe('NGSI-v1 - HTTPS support tests', function() {
 
     describe('When subscription is sent to HTTPS context broker', function() {
         beforeEach(function(done) {

--- a/test/unit/general/iotam-autoregistration-test.js
+++ b/test/unit/general/iotam-autoregistration-test.js
@@ -186,7 +186,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
     },
     iotamMock;
 
-describe('IoT Manager autoregistration', function() {
+describe('NGSI-v1 - IoT Manager autoregistration', function() {
     describe('When the IoT Agent is started without a "iotManager" config parameter and empty services', function() {
         beforeEach(function() {
             nock.cleanAll();

--- a/test/unit/general/startup-test.js
+++ b/test/unit/general/startup-test.js
@@ -62,7 +62,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
     iotAgentConfigNoTypes = _.clone(iotAgentConfig),
     iotamMock;
 
-describe('Startup tests', function() {
+describe('NGSI-v1 - Startup tests', function() {
     describe('When the IoT Agent is started without a "providerUrl" config parameter', function() {
         beforeEach(function() {
             delete iotAgentConfigNoUrl.providerUrl;

--- a/test/unit/lazyAndCommands/active-devices-attribute-update-test.js
+++ b/test/unit/lazyAndCommands/active-devices-attribute-update-test.js
@@ -62,7 +62,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('Update attribute functionalities', function() {
+describe('NGSI-v1 - Update attribute functionalities', function() {
 
     beforeEach(function(done) {
         logger.setLevel('FATAL');

--- a/test/unit/lazyAndCommands/command-test.js
+++ b/test/unit/lazyAndCommands/command-test.js
@@ -107,7 +107,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('Command functionalities', function() {
+describe('NGSI-v1 - Command functionalities', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/lazyAndCommands/lazy-devices-test.js
+++ b/test/unit/lazyAndCommands/lazy-devices-test.js
@@ -138,7 +138,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         }
     };
 
-describe('IoT Agent Lazy Devices', function() {
+describe('NGSI-v1 - IoT Agent Lazy Devices', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
         mongoUtils.cleanDbs(done);

--- a/test/unit/lazyAndCommands/polling-commands-test.js
+++ b/test/unit/lazyAndCommands/polling-commands-test.js
@@ -119,7 +119,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         polling: true
     };
 
-describe('Polling commands', function() {
+describe('NGSI-v1 - Polling commands', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiService/active-devices-test.js
@@ -118,7 +118,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Active attributes test', function() {
+describe('NGSI-v1 - Active attributes test', function() {
     var values = [
         {
             name: 'state',

--- a/test/unit/ngsiService/staticAttributes-test.js
+++ b/test/unit/ngsiService/staticAttributes-test.js
@@ -81,7 +81,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
     };
 
 
-describe('Static attributes test', function() {
+describe('NGSI-v1 - Static attributes test', function() {
     var values = [
         {
             name: 'state',

--- a/test/unit/ngsiService/subscriptions-test.js
+++ b/test/unit/ngsiService/subscriptions-test.js
@@ -44,7 +44,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Subscription tests', function() {
+describe('NGSI-v1 - Subscription tests', function() {
     beforeEach(function(done) {
         var optionsProvision = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',

--- a/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
@@ -213,7 +213,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for expressions with syntax errors', function() {
+    describe('When an update comes for expressions with syntax errors', function() {
         // Case: Update for an attribute with bad expression
         var values = [
             {
@@ -233,7 +233,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When there are expression attributes that are just calculated (not sent by the device)', function() {
+    describe('When there are expression attributes that are just calculated (not sent by the device)', function() {
         // Case: Expression which results is sent as a new attribute
         var values = [
             {
@@ -269,7 +269,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an expression with multiple variables with numbers arrive', function() {
+    describe('When an expression with multiple variables with numbers arrive', function() {
         // Case: Update for integer and string attributes with expression
 
         var values = [
@@ -306,7 +306,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and type integer', function() {
+    describe('When an update comes for attributes without expressions and type integer', function() {
         // Case: Update for an integer attribute without expression
         var values = [
             {
@@ -337,7 +337,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with numeric expressions and type integer', function() {
+    describe('When an update comes for attributes with numeric expressions and type integer', function() {
         // Case: Update for an integer attribute with arithmetic expression
         var values = [
             {
@@ -368,7 +368,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with string expression and type integer', function() {
+    describe('When an update comes for attributes with string expression and type integer', function() {
         // Case: Update for an integer attribute with string expression
         var values = [
             {
@@ -399,7 +399,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and type float', function() {
+    describe('When an update comes for attributes without expressions and type float', function() {
         // Case: Update for a Float attribute without expressions
 
         var values = [
@@ -431,7 +431,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with numeric expressions and type float', function() {
+    describe('When an update comes for attributes with numeric expressions and type float', function() {
         // Case: Update for a Float attribute with arithmetic expression
 
         var values = [
@@ -463,7 +463,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with string expressions and type float', function() {
+    describe('When an update comes for attributes with string expressions and type float', function() {
         // Case: Update for a Float attribute with string expression
 
         var values = [
@@ -495,7 +495,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and NULL type', function() {
+    describe('When an update comes for attributes without expressions and NULL type', function() {
         // Case: Update for a Null attribute without expression
 
         var values = [
@@ -527,7 +527,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with numeric expressions and NULL type', function() {
+    describe('When an update comes for attributes with numeric expressions and NULL type', function() {
         // Case: Update for a Null attribute with arithmetic expression
 
         var values = [
@@ -559,7 +559,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with string expressions and NULL type', function() {
+    describe('When an update comes for attributes with string expressions and NULL type', function() {
         // Case: Update for a Null attribute with string expression
 
         var values = [
@@ -591,7 +591,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and Boolean type', function() {
+    describe('When an update comes for attributes without expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute without expression
 
         var values = [
@@ -623,7 +623,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with numeric expressions and Boolean type', function() {
+    describe('When an update comes for attributes with numeric expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute with arithmetic expression
 
         var values = [
@@ -655,7 +655,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with string expressions and Boolean type', function() {
+    describe('When an update comes for attributes with string expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute with string expression
         var values = [
             {
@@ -686,7 +686,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and Object type', function() {
+    describe('When an update comes for attributes without expressions and Object type', function() {
         // Case: Update for a JSON document attribute without expression
         var values = [
             {
@@ -717,7 +717,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes without expressions and Object type', function() {
+    describe('When an update comes for attributes without expressions and Object type', function() {
         // Case: Update for a JSON array attribute without expression
 
         var values = [
@@ -749,7 +749,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When there are expressions including other attributes and they are not updated', function() {
+    describe('When there are expressions including other attributes and they are not updated', function() {
 
         var values = [
             {
@@ -780,7 +780,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When there are expressions including other attributes and they are updated', function() {
+    describe('When there are expressions including other attributes and they are updated', function() {
 
         var values = [
             {
@@ -811,7 +811,7 @@ describe('NGSI-v2 - Expression-based transformations plugin', function() {
         });
     });
 
-   describe('When there are expressions including other attributes and they are updated' +
+    describe('When there are expressions including other attributes and they are updated' +
         '(overriding situation)', function() {
 
         var values = [

--- a/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/expressionBasedTransformations-test.js
@@ -193,7 +193,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Expression-based transformations plugin', function() {
+describe('NGSI-v2 - Expression-based transformations plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -213,7 +213,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for expressions with syntax errors', function() {
+   describe('When an update comes for expressions with syntax errors', function() {
         // Case: Update for an attribute with bad expression
         var values = [
             {
@@ -233,7 +233,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When there are expression attributes that are just calculated (not sent by the device)', function() {
+   describe('When there are expression attributes that are just calculated (not sent by the device)', function() {
         // Case: Expression which results is sent as a new attribute
         var values = [
             {
@@ -269,7 +269,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an expression with multiple variables with numbers arrive', function() {
+   describe('When an expression with multiple variables with numbers arrive', function() {
         // Case: Update for integer and string attributes with expression
 
         var values = [
@@ -306,7 +306,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and type integer', function() {
+   describe('When an update comes for attributes without expressions and type integer', function() {
         // Case: Update for an integer attribute without expression
         var values = [
             {
@@ -337,7 +337,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with numeric expressions and type integer', function() {
+   describe('When an update comes for attributes with numeric expressions and type integer', function() {
         // Case: Update for an integer attribute with arithmetic expression
         var values = [
             {
@@ -368,7 +368,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with string expression and type integer', function() {
+   describe('When an update comes for attributes with string expression and type integer', function() {
         // Case: Update for an integer attribute with string expression
         var values = [
             {
@@ -399,7 +399,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and type float', function() {
+   describe('When an update comes for attributes without expressions and type float', function() {
         // Case: Update for a Float attribute without expressions
 
         var values = [
@@ -431,7 +431,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with numeric expressions and type float', function() {
+   describe('When an update comes for attributes with numeric expressions and type float', function() {
         // Case: Update for a Float attribute with arithmetic expression
 
         var values = [
@@ -463,7 +463,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with string expressions and type float', function() {
+   describe('When an update comes for attributes with string expressions and type float', function() {
         // Case: Update for a Float attribute with string expression
 
         var values = [
@@ -495,7 +495,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and NULL type', function() {
+   describe('When an update comes for attributes without expressions and NULL type', function() {
         // Case: Update for a Null attribute without expression
 
         var values = [
@@ -527,7 +527,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with numeric expressions and NULL type', function() {
+   describe('When an update comes for attributes with numeric expressions and NULL type', function() {
         // Case: Update for a Null attribute with arithmetic expression
 
         var values = [
@@ -559,7 +559,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with string expressions and NULL type', function() {
+   describe('When an update comes for attributes with string expressions and NULL type', function() {
         // Case: Update for a Null attribute with string expression
 
         var values = [
@@ -591,7 +591,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and Boolean type', function() {
+   describe('When an update comes for attributes without expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute without expression
 
         var values = [
@@ -623,7 +623,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with numeric expressions and Boolean type', function() {
+   describe('When an update comes for attributes with numeric expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute with arithmetic expression
 
         var values = [
@@ -655,7 +655,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with string expressions and Boolean type', function() {
+   describe('When an update comes for attributes with string expressions and Boolean type', function() {
         // Case: Update for a Boolean attribute with string expression
         var values = [
             {
@@ -686,7 +686,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and Object type', function() {
+   describe('When an update comes for attributes without expressions and Object type', function() {
         // Case: Update for a JSON document attribute without expression
         var values = [
             {
@@ -717,7 +717,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes without expressions and Object type', function() {
+   describe('When an update comes for attributes without expressions and Object type', function() {
         // Case: Update for a JSON array attribute without expression
 
         var values = [
@@ -749,7 +749,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When there are expressions including other attributes and they are not updated', function() {
+   describe('When there are expressions including other attributes and they are not updated', function() {
 
         var values = [
             {
@@ -780,7 +780,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When there are expressions including other attributes and they are updated', function() {
+   describe('When there are expressions including other attributes and they are updated', function() {
 
         var values = [
             {
@@ -811,7 +811,7 @@ describe('Expression-based transformations plugin', function() {
         });
     });
 
-    describe('When there are expressions including other attributes and they are updated' +
+   describe('When there are expressions including other attributes and they are updated' +
         '(overriding situation)', function() {
 
         var values = [

--- a/test/unit/ngsiv2/general/contextBrokerOAuthSecurityAccess-test.js
+++ b/test/unit/ngsiv2/general/contextBrokerOAuthSecurityAccess-test.js
@@ -112,7 +112,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', 
         nock.cleanAll();
     });
 
-   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -151,7 +151,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', 
             });
         });
     });
-   describe('When a measure is sent to the Context Broker and the access is forbidden', function() {
+    describe('When a measure is sent to the Context Broker and the access is forbidden', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -184,7 +184,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', 
             });
         });
     });
-   describe('When a measure is sent and the trust is rejected asking for the token', function() {
+    describe('When a measure is sent and the trust is rejected asking for the token', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -215,7 +215,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', 
         });
     });
 
-   describe('When the user requests information about a device in a protected CB', function() {
+    describe('When the user requests information about a device in a protected CB', function() {
         var attributes = [
             'state',
             'dimming'
@@ -251,7 +251,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', 
             });
         });
     });
-   describe('When subscriptions are used on a protected Context Broker', function() {
+    describe('When subscriptions are used on a protected Context Broker', function() {
           beforeEach(function(done) {
             var optionsProvision = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -368,7 +368,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         nock.cleanAll();
     });
 
-   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -409,7 +409,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         });
     });
 
-   describe('When the user requests information about a device in a protected CB', function() {
+    describe('When the user requests information about a device in a protected CB', function() {
         var attributes = [
             'state',
             'dimming'
@@ -446,7 +446,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         });
     });
 
-   describe('When a measure is sent and the refresh token is not valid', function() {
+    describe('When a measure is sent and the refresh token is not valid', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -469,7 +469,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         });
     });
 
-   describe('When a measure is sent to the Context Broker and the client credentials are invalid', function() {
+    describe('When a measure is sent to the Context Broker and the client credentials are invalid', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -493,7 +493,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         });
     });
 
-   describe('When a measure is sent to the Context Broker and the access is unauthorized', function() {
+    describe('When a measure is sent to the Context Broker and the access is unauthorized', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -556,7 +556,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         nock.cleanAll();
     });
 
-   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         var oauth2Mock2;
         var contextBrokerMock2;
         beforeEach(function(done) {
@@ -623,7 +623,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
     });
 
 
-   describe('When a device is provisioned for a configuration contains an OAuth2 trust token', function() {
+    describe('When a device is provisioned for a configuration contains an OAuth2 trust token', function() {
         var values = [
             {
                 name: 'status',
@@ -757,7 +757,7 @@ describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (F
         nock.cleanAll();
     });
 
-   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/contextBrokerOAuthSecurityAccess-test.js
+++ b/test/unit/ngsiv2/general/contextBrokerOAuthSecurityAccess-test.js
@@ -89,7 +89,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Secured access to the Context Broker with OAuth2 provider', function() {
+describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider', function() {
     var values = [
         {
             name: 'state',
@@ -112,7 +112,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
         nock.cleanAll();
     });
 
-    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -151,7 +151,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
             });
         });
     });
-    describe('When a measure is sent to the Context Broker and the access is forbidden', function() {
+   describe('When a measure is sent to the Context Broker and the access is forbidden', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -184,7 +184,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
             });
         });
     });
-    describe('When a measure is sent and the trust is rejected asking for the token', function() {
+   describe('When a measure is sent and the trust is rejected asking for the token', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -215,7 +215,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
         });
     });
 
-    describe('When the user requests information about a device in a protected CB', function() {
+   describe('When the user requests information about a device in a protected CB', function() {
         var attributes = [
             'state',
             'dimming'
@@ -251,7 +251,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
             });
         });
     });
-    describe('When subscriptions are used on a protected Context Broker', function() {
+   describe('When subscriptions are used on a protected Context Broker', function() {
           beforeEach(function(done) {
             var optionsProvision = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -344,7 +344,7 @@ describe('Secured access to the Context Broker with OAuth2 provider', function()
     });
 });
 
-describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)', function() {
+describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)', function() {
 
     var values = [
         {
@@ -368,7 +368,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         nock.cleanAll();
     });
 
-    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -409,7 +409,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         });
     });
 
-    describe('When the user requests information about a device in a protected CB', function() {
+   describe('When the user requests information about a device in a protected CB', function() {
         var attributes = [
             'state',
             'dimming'
@@ -446,7 +446,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         });
     });
 
-    describe('When a measure is sent and the refresh token is not valid', function() {
+   describe('When a measure is sent and the refresh token is not valid', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -469,7 +469,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         });
     });
 
-    describe('When a measure is sent to the Context Broker and the client credentials are invalid', function() {
+   describe('When a measure is sent to the Context Broker and the client credentials are invalid', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -493,7 +493,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         });
     });
 
-    describe('When a measure is sent to the Context Broker and the access is unauthorized', function() {
+   describe('When a measure is sent to the Context Broker and the access is unauthorized', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -527,7 +527,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
     });
 });
 
-describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)' +
+describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)' +
     'configured through group provisioning', function() {
     var groupCreation = {
         url: 'http://localhost:4041/iot/services',
@@ -556,7 +556,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         nock.cleanAll();
     });
 
-    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         var oauth2Mock2;
         var contextBrokerMock2;
         beforeEach(function(done) {
@@ -623,7 +623,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
     });
 
 
-    describe('When a device is provisioned for a configuration contains an OAuth2 trust token', function() {
+   describe('When a device is provisioned for a configuration contains an OAuth2 trust token', function() {
         var values = [
             {
                 name: 'status',
@@ -727,7 +727,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
     });
 });
 
-describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)' +
+describe('NGSI-v2 - Secured access to the Context Broker with OAuth2 provider (FIWARE Keyrock IDM)' +
     'configured through group provisioning. Permanent token', function() {
     var groupCreation = {
         url: 'http://localhost:4041/iot/services',
@@ -757,7 +757,7 @@ describe('Secured access to the Context Broker with OAuth2 provider (FIWARE Keyr
         nock.cleanAll();
     });
 
-    describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
+   describe('When a measure is sent to the Context Broker via an Update Context operation', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/deviceService-test.js
+++ b/test/unit/ngsiv2/general/deviceService-test.js
@@ -189,7 +189,7 @@ describe('NGSI-v2 - Device Service: utils', function() {
         ], done);
     });
 
-   describe('When an existing device tries to be retrieved with retrieveOrCreate()', function() {
+    describe('When an existing device tries to be retrieved with retrieveOrCreate()', function() {
         beforeEach(function(done) {
 
             // This mock does not check the payload since the aim of the test is not to verify
@@ -220,7 +220,7 @@ describe('NGSI-v2 - Device Service: utils', function() {
         });
     });
 
-   describe('When an unexisting device tries to be retrieved for an existing APIKey', function() {
+    describe('When an unexisting device tries to be retrieved for an existing APIKey', function() {
         beforeEach(function(done) {
 
             // This mock does not check the payload since the aim of the test is not to verify
@@ -253,7 +253,7 @@ describe('NGSI-v2 - Device Service: utils', function() {
         });
     });
 
-   describe('When an unexisting device tries to be retrieved for an unexisting APIKey', function() {
+    describe('When an unexisting device tries to be retrieved for an unexisting APIKey', function() {
         it('should raise an error', function(done) {
             iotAgentLib.retrieveDevice('UNEXISTENT_DEV_AND_GROUP', 'H2332Y909DSF3H346yh20JK092',
                 function(error, device) {

--- a/test/unit/ngsiv2/general/deviceService-test.js
+++ b/test/unit/ngsiv2/general/deviceService-test.js
@@ -170,7 +170,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 
 /* jshint camelcase: false */
-describe('Device Service: utils', function() {
+describe('NGSI-v2 - Device Service: utils', function() {
     beforeEach(function(done) {
         nock.cleanAll();
         logger.setLevel('FATAL');
@@ -189,7 +189,7 @@ describe('Device Service: utils', function() {
         ], done);
     });
 
-    describe('When an existing device tries to be retrieved with retrieveOrCreate()', function() {
+   describe('When an existing device tries to be retrieved with retrieveOrCreate()', function() {
         beforeEach(function(done) {
 
             // This mock does not check the payload since the aim of the test is not to verify
@@ -220,7 +220,7 @@ describe('Device Service: utils', function() {
         });
     });
 
-    describe('When an unexisting device tries to be retrieved for an existing APIKey', function() {
+   describe('When an unexisting device tries to be retrieved for an existing APIKey', function() {
         beforeEach(function(done) {
 
             // This mock does not check the payload since the aim of the test is not to verify
@@ -253,7 +253,7 @@ describe('Device Service: utils', function() {
         });
     });
 
-    describe('When an unexisting device tries to be retrieved for an unexisting APIKey', function() {
+   describe('When an unexisting device tries to be retrieved for an unexisting APIKey', function() {
         it('should raise an error', function(done) {
             iotAgentLib.retrieveDevice('UNEXISTENT_DEV_AND_GROUP', 'H2332Y909DSF3H346yh20JK092',
                 function(error, device) {

--- a/test/unit/ngsiv2/general/https-support-test.js
+++ b/test/unit/ngsiv2/general/https-support-test.js
@@ -124,7 +124,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 describe('NGSI-v2 - HTTPS support tests IOTAM', function() {
 
-   describe('When the IoT Agents is started with https "iotManager" config', function() {
+    describe('When the IoT Agents is started with https "iotManager" config', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -156,7 +156,7 @@ describe('NGSI-v2 - HTTPS support tests IOTAM', function() {
 
 describe('NGSI-v2 - HTTPS support tests', function() {
 
-   describe('When subscription is sent to HTTPS context broker', function() {
+    describe('When subscription is sent to HTTPS context broker', function() {
         beforeEach(function(done) {
             var optionsProvision = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -217,7 +217,7 @@ describe('NGSI-v2 - HTTPS support tests', function() {
         });
     });
 
-   describe('When a new device is connected to the IoT Agent', function() {
+    describe('When a new device is connected to the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/https-support-test.js
+++ b/test/unit/ngsiv2/general/https-support-test.js
@@ -122,9 +122,9 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
     iotamMock;
 
 
-describe('HTTPS support tests IOTAM', function() {
+describe('NGSI-v2 - HTTPS support tests IOTAM', function() {
 
-    describe('When the IoT Agents is started with https "iotManager" config', function() {
+   describe('When the IoT Agents is started with https "iotManager" config', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -154,9 +154,9 @@ describe('HTTPS support tests IOTAM', function() {
     });
 });
 
-describe('HTTPS support tests', function() {
+describe('NGSI-v2 - HTTPS support tests', function() {
 
-    describe('When subscription is sent to HTTPS context broker', function() {
+   describe('When subscription is sent to HTTPS context broker', function() {
         beforeEach(function(done) {
             var optionsProvision = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -217,7 +217,7 @@ describe('HTTPS support tests', function() {
         });
     });
 
-    describe('When a new device is connected to the IoT Agent', function() {
+   describe('When a new device is connected to the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/iotam-autoregistration-test.js
+++ b/test/unit/ngsiv2/general/iotam-autoregistration-test.js
@@ -186,8 +186,8 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
     },
     iotamMock;
 
-describe('IoT Manager autoregistration', function() {
-    describe('When the IoT Agent is started without a "iotManager" config parameter and empty services', function() {
+describe('NGSI-v2 - IoT Manager autoregistration', function() {
+   describe('When the IoT Agent is started without a "iotManager" config parameter and empty services', function() {
         beforeEach(function() {
             nock.cleanAll();
 
@@ -211,7 +211,7 @@ describe('IoT Manager autoregistration', function() {
         });
     });
 
-    describe('When the IoT Agents is started with "iotManager" config with missing attributes', function() {
+   describe('When the IoT Agents is started with "iotManager" config with missing attributes', function() {
         beforeEach(function() {
             nock.cleanAll();
 
@@ -237,7 +237,7 @@ describe('IoT Manager autoregistration', function() {
         });
     });
 
-    describe('When the IoT Agents is started with "iotManager" config and multiple services', function() {
+   describe('When the IoT Agents is started with "iotManager" config and multiple services', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -265,7 +265,7 @@ describe('IoT Manager autoregistration', function() {
         });
     });
 
-    describe('When a new service is created in the IoT Agent', function() {
+   describe('When a new service is created in the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -301,7 +301,7 @@ describe('IoT Manager autoregistration', function() {
         });
     });
 
-    describe('When a service is removed from the IoT Agent', function() {
+   describe('When a service is removed from the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -337,7 +337,7 @@ describe('IoT Manager autoregistration', function() {
         });
     });
 
-    describe('When a new service with static attributes is created in the IoT Agent', function() {
+   describe('When a new service with static attributes is created in the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/iotam-autoregistration-test.js
+++ b/test/unit/ngsiv2/general/iotam-autoregistration-test.js
@@ -187,7 +187,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
     iotamMock;
 
 describe('NGSI-v2 - IoT Manager autoregistration', function() {
-   describe('When the IoT Agent is started without a "iotManager" config parameter and empty services', function() {
+    describe('When the IoT Agent is started without a "iotManager" config parameter and empty services', function() {
         beforeEach(function() {
             nock.cleanAll();
 
@@ -211,7 +211,7 @@ describe('NGSI-v2 - IoT Manager autoregistration', function() {
         });
     });
 
-   describe('When the IoT Agents is started with "iotManager" config with missing attributes', function() {
+    describe('When the IoT Agents is started with "iotManager" config with missing attributes', function() {
         beforeEach(function() {
             nock.cleanAll();
 
@@ -237,7 +237,7 @@ describe('NGSI-v2 - IoT Manager autoregistration', function() {
         });
     });
 
-   describe('When the IoT Agents is started with "iotManager" config and multiple services', function() {
+    describe('When the IoT Agents is started with "iotManager" config and multiple services', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -265,7 +265,7 @@ describe('NGSI-v2 - IoT Manager autoregistration', function() {
         });
     });
 
-   describe('When a new service is created in the IoT Agent', function() {
+    describe('When a new service is created in the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -301,7 +301,7 @@ describe('NGSI-v2 - IoT Manager autoregistration', function() {
         });
     });
 
-   describe('When a service is removed from the IoT Agent', function() {
+    describe('When a service is removed from the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -337,7 +337,7 @@ describe('NGSI-v2 - IoT Manager autoregistration', function() {
         });
     });
 
-   describe('When a new service with static attributes is created in the IoT Agent', function() {
+    describe('When a new service with static attributes is created in the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/general/startup-test.js
+++ b/test/unit/ngsiv2/general/startup-test.js
@@ -61,7 +61,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
 
 describe('NGSI-v2 - Startup tests', function() {
 
-   describe('When the IoT Agent is started with environment variables', function() {
+    describe('When the IoT Agent is started with environment variables', function() {
         beforeEach(function() {
             process.env.IOTA_CB_HOST = 'cbhost';
             process.env.IOTA_CB_PORT = '1111';

--- a/test/unit/ngsiv2/general/startup-test.js
+++ b/test/unit/ngsiv2/general/startup-test.js
@@ -59,9 +59,9 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
     },
     iotamMock;
 
-describe('Startup tests', function() {
+describe('NGSI-v2 - Startup tests', function() {
 
-    describe('When the IoT Agent is started with environment variables', function() {
+   describe('When the IoT Agent is started with environment variables', function() {
         beforeEach(function() {
             process.env.IOTA_CB_HOST = 'cbhost';
             process.env.IOTA_CB_PORT = '1111';

--- a/test/unit/ngsiv2/lazyAndCommands/active-devices-attribute-update-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/active-devices-attribute-update-test.js
@@ -98,7 +98,7 @@ describe('NGSI-v2 - Update attribute functionalities', function() {
         });
     });
 
-   describe('When a attribute update arrives to the IoT Agent as Context Provider', function() {
+    describe('When a attribute update arrives to the IoT Agent as Context Provider', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',

--- a/test/unit/ngsiv2/lazyAndCommands/active-devices-attribute-update-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/active-devices-attribute-update-test.js
@@ -63,7 +63,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('Update attribute functionalities', function() {
+describe('NGSI-v2 - Update attribute functionalities', function() {
 
     beforeEach(function(done) {
         logger.setLevel('FATAL');
@@ -98,7 +98,7 @@ describe('Update attribute functionalities', function() {
         });
     });
 
-    describe('When a attribute update arrives to the IoT Agent as Context Provider', function() {
+   describe('When a attribute update arrives to the IoT Agent as Context Provider', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',

--- a/test/unit/ngsiv2/lazyAndCommands/command-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/command-test.js
@@ -149,7 +149,7 @@ describe('NGSI-v2 - Command functionalities', function() {
         });
     });
 
-   describe('When a device is preregistered with commands', function() {
+    describe('When a device is preregistered with commands', function() {
         it('should register as Context Provider of the commands', function(done) {
             iotAgentLib.register(device3, function(error) {
                 should.not.exist(error);
@@ -158,7 +158,7 @@ describe('NGSI-v2 - Command functionalities', function() {
             });
         });
     });
-   describe('When a command update arrives to the IoT Agent as Context Provider', function() {
+    describe('When a command update arrives to the IoT Agent as Context Provider', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -260,7 +260,7 @@ describe('NGSI-v2 - Command functionalities', function() {
             });
         });
     });
-   describe('When an update arrives from the south bound for a registered command', function() {
+    describe('When an update arrives from the south bound for a registered command', function() {
         beforeEach(function(done) {
             statusAttributeMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
@@ -283,7 +283,7 @@ describe('NGSI-v2 - Command functionalities', function() {
                 });
         });
     });
-   describe('When an error command arrives from the south bound for a registered command', function() {
+    describe('When an error command arrives from the south bound for a registered command', function() {
         beforeEach(function(done) {
             statusAttributeMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')

--- a/test/unit/ngsiv2/lazyAndCommands/command-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/command-test.js
@@ -110,7 +110,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('Command functionalities', function() {
+describe('NGSI-v2 - Command functionalities', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
         var time = new Date(1438760101468); // 2015-08-05T07:35:01.468+00:00
@@ -149,7 +149,7 @@ describe('Command functionalities', function() {
         });
     });
 
-    describe('When a device is preregistered with commands', function() {
+   describe('When a device is preregistered with commands', function() {
         it('should register as Context Provider of the commands', function(done) {
             iotAgentLib.register(device3, function(error) {
                 should.not.exist(error);
@@ -158,7 +158,7 @@ describe('Command functionalities', function() {
             });
         });
     });
-    describe('When a command update arrives to the IoT Agent as Context Provider', function() {
+   describe('When a command update arrives to the IoT Agent as Context Provider', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -260,7 +260,7 @@ describe('Command functionalities', function() {
             });
         });
     });
-    describe('When an update arrives from the south bound for a registered command', function() {
+   describe('When an update arrives from the south bound for a registered command', function() {
         beforeEach(function(done) {
             statusAttributeMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
@@ -283,7 +283,7 @@ describe('Command functionalities', function() {
                 });
         });
     });
-    describe('When an error command arrives from the south bound for a registered command', function() {
+   describe('When an error command arrives from the south bound for a registered command', function() {
         beforeEach(function(done) {
             statusAttributeMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')

--- a/test/unit/ngsiv2/lazyAndCommands/lazy-devices-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/lazy-devices-test.js
@@ -165,7 +165,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When the IoT Agent receives an update on the device data in JSON format', function() {
+    describe('When the IoT Agent receives an update on the device data in JSON format', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -228,11 +228,11 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a IoT Agent receives an update on multiple contexts', function() {
+    describe('When a IoT Agent receives an update on multiple contexts', function() {
         it('should call the device handler for each of the contexts');
     });
 
-   describe('When a context query arrives to the IoT Agent', function() {
+    describe('When a context query arrives to the IoT Agent', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -304,7 +304,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a context query arrives to the IoT Agent and no handler is set', function() {
+    describe('When a context query arrives to the IoT Agent and no handler is set', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -365,7 +365,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a query arrives to the IoT Agent without any attributes', function() {
+    describe('When a query arrives to the IoT Agent without any attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -437,7 +437,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a context query arrives to the IoT Agent for a type with static attributes', function() {
+    describe('When a context query arrives to the IoT Agent for a type with static attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -510,7 +510,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When the IoT Agent receives an update on the device data in JSON format for a type with' +
+    describe('When the IoT Agent receives an update on the device data in JSON format for a type with' +
         'internalAttributes', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
@@ -574,7 +574,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a context query arrives to the IoT Agent and id and type query params are not present', function() {
+    describe('When a context query arrives to the IoT Agent and id and type query params are not present', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -646,7 +646,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a context query arrives to the IoT Agent and id query param is not present', function() {
+    describe('When a context query arrives to the IoT Agent and id query param is not present', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -719,7 +719,7 @@ describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
         });
     });
 
-   describe('When a query arrives to the IoT Agent with id, type and attributes', function() {
+    describe('When a query arrives to the IoT Agent with id, type and attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port +  '/v2/op/query',
                 method: 'POST',

--- a/test/unit/ngsiv2/lazyAndCommands/lazy-devices-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/lazy-devices-test.js
@@ -141,7 +141,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         }
     };
 
-describe('IoT Agent Lazy Devices', function() {
+describe('NGSI-v2 - IoT Agent Lazy Devices', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -165,7 +165,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When the IoT Agent receives an update on the device data in JSON format', function() {
+   describe('When the IoT Agent receives an update on the device data in JSON format', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -228,11 +228,11 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a IoT Agent receives an update on multiple contexts', function() {
+   describe('When a IoT Agent receives an update on multiple contexts', function() {
         it('should call the device handler for each of the contexts');
     });
 
-    describe('When a context query arrives to the IoT Agent', function() {
+   describe('When a context query arrives to the IoT Agent', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -304,7 +304,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a context query arrives to the IoT Agent and no handler is set', function() {
+   describe('When a context query arrives to the IoT Agent and no handler is set', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -365,7 +365,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a query arrives to the IoT Agent without any attributes', function() {
+   describe('When a query arrives to the IoT Agent without any attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -437,7 +437,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a context query arrives to the IoT Agent for a type with static attributes', function() {
+   describe('When a context query arrives to the IoT Agent for a type with static attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -510,7 +510,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When the IoT Agent receives an update on the device data in JSON format for a type with' +
+   describe('When the IoT Agent receives an update on the device data in JSON format for a type with' +
         'internalAttributes', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
@@ -574,7 +574,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a context query arrives to the IoT Agent and id and type query params are not present', function() {
+   describe('When a context query arrives to the IoT Agent and id and type query params are not present', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -646,7 +646,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a context query arrives to the IoT Agent and id query param is not present', function() {
+   describe('When a context query arrives to the IoT Agent and id query param is not present', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/query',
                 method: 'POST',
@@ -719,7 +719,7 @@ describe('IoT Agent Lazy Devices', function() {
         });
     });
 
-    describe('When a query arrives to the IoT Agent with id, type and attributes', function() {
+   describe('When a query arrives to the IoT Agent with id, type and attributes', function() {
         var options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port +  '/v2/op/query',
                 method: 'POST',

--- a/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
@@ -157,7 +157,7 @@ describe('NGSI-v2 - Polling commands', function() {
         });
     });
 
-   describe('When a command update arrives to the IoT Agent for a device with polling', function() {
+    describe('When a command update arrives to the IoT Agent for a device with polling', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -247,7 +247,7 @@ describe('NGSI-v2 - Polling commands', function() {
         });
     });
 
-   describe('When a command arrives with multiple values in the value field', function() {
+    describe('When a command arrives with multiple values in the value field', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -302,7 +302,7 @@ describe('NGSI-v2 - Polling commands', function() {
         });
     });
 
-   describe('When a polling command expires', function() {
+    describe('When a polling command expires', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',

--- a/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
@@ -121,7 +121,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         polling: true
     };
 
-describe('Polling commands', function() {
+describe('NGSI-v2 - Polling commands', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -157,7 +157,7 @@ describe('Polling commands', function() {
         });
     });
 
-    describe('When a command update arrives to the IoT Agent for a device with polling', function() {
+   describe('When a command update arrives to the IoT Agent for a device with polling', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -247,7 +247,7 @@ describe('Polling commands', function() {
         });
     });
 
-    describe('When a command arrives with multiple values in the value field', function() {
+   describe('When a command arrives with multiple values in the value field', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',
@@ -302,7 +302,7 @@ describe('Polling commands', function() {
         });
     });
 
-    describe('When a polling command expires', function() {
+   describe('When a polling command expires', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/v2/op/update',
             method: 'POST',

--- a/test/unit/ngsiv2/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiv2/ngsiService/active-devices-test.js
@@ -166,7 +166,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When the IoT Agent receives new information from a device', function() {
+    describe('When the IoT Agent receives new information from a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -190,7 +190,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information and the timestamp flag is on', function() {
+    describe('When the IoT Agent receives new information and the timestamp flag is on', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -241,7 +241,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoTA gets a set of values with a TimeInstant which are not in ISO8601 format', function() {
+    describe('When the IoTA gets a set of values with a TimeInstant which are not in ISO8601 format', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -280,7 +280,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoTA gets a set of values with a TimeInstant which are in ISO8601 format ' +
+    describe('When the IoTA gets a set of values with a TimeInstant which are in ISO8601 format ' +
         'without milis', function() {
         var modifiedValues;
 
@@ -333,7 +333,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information, the timestamp flag is on' +
+    describe('When the IoT Agent receives new information, the timestamp flag is on' +
     'and timezone is defined', function() {
         var modifiedValues;
 
@@ -388,7 +388,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoTA gets a set of values with a TimeInstant and the timestamp flag is on', function() {
+    describe('When the IoTA gets a set of values with a TimeInstant and the timestamp flag is on', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -439,7 +439,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoTA gets a set of values with a TimeInstant, the timestamp flag is on' +
+    describe('When the IoTA gets a set of values with a TimeInstant, the timestamp flag is on' +
     'and timezone is defined', function() {
         var modifiedValues;
 
@@ -493,7 +493,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoT Agent receives information from a device whose type doesn\'t have a type name', function() {
+    describe('When the IoT Agent receives information from a device whose type doesn\'t have a type name', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -510,7 +510,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the Context Broker returns an HTTP error code updating an entity', function() {
+    describe('When the Context Broker returns an HTTP error code updating an entity', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -539,7 +539,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the Context Broker returns an application error code updating an entity', function() {
+    describe('When the Context Broker returns an application error code updating an entity', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -565,7 +565,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When there is a transport error connecting to the Context Broker', function() {
+    describe('When there is a transport error connecting to the Context Broker', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -594,7 +594,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When the IoT Agent recieves information for a type with a configured Context Broker', function() {
+    describe('When the IoT Agent recieves information for a type with a configured Context Broker', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -618,7 +618,7 @@ describe('NGSI-v2 - Active attributes test', function() {
         });
     });
 
-   describe('When an IoT Agent receives information for a type with static attributes', function() {
+    describe('When an IoT Agent receives information for a type with static attributes', function() {
         var newValues = [
             {
                 name: 'moving',
@@ -650,7 +650,7 @@ describe('NGSI-v2 - Active attributes test', function() {
     });
 
 
-   describe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
+    describe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
         var newValues = [
             {
                 name: 'luminosity',

--- a/test/unit/ngsiv2/ngsiService/active-devices-test.js
+++ b/test/unit/ngsiv2/ngsiService/active-devices-test.js
@@ -144,7 +144,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Active attributes test', function() {
+describe('NGSI-v2 - Active attributes test', function() {
     var values = [
         {
             name: 'state',
@@ -166,7 +166,7 @@ describe('Active attributes test', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When the IoT Agent receives new information from a device', function() {
+   describe('When the IoT Agent receives new information from a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -190,7 +190,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information and the timestamp flag is on', function() {
+   describe('When the IoT Agent receives new information and the timestamp flag is on', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -241,7 +241,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoTA gets a set of values with a TimeInstant which are not in ISO8601 format', function() {
+   describe('When the IoTA gets a set of values with a TimeInstant which are not in ISO8601 format', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -280,7 +280,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoTA gets a set of values with a TimeInstant which are in ISO8601 format ' +
+   describe('When the IoTA gets a set of values with a TimeInstant which are in ISO8601 format ' +
         'without milis', function() {
         var modifiedValues;
 
@@ -333,7 +333,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information, the timestamp flag is on' +
+   describe('When the IoT Agent receives new information, the timestamp flag is on' +
     'and timezone is defined', function() {
         var modifiedValues;
 
@@ -388,7 +388,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoTA gets a set of values with a TimeInstant and the timestamp flag is on', function() {
+   describe('When the IoTA gets a set of values with a TimeInstant and the timestamp flag is on', function() {
         var modifiedValues;
 
         beforeEach(function(done) {
@@ -439,7 +439,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoTA gets a set of values with a TimeInstant, the timestamp flag is on' +
+   describe('When the IoTA gets a set of values with a TimeInstant, the timestamp flag is on' +
     'and timezone is defined', function() {
         var modifiedValues;
 
@@ -493,7 +493,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoT Agent receives information from a device whose type doesn\'t have a type name', function() {
+   describe('When the IoT Agent receives information from a device whose type doesn\'t have a type name', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -510,7 +510,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the Context Broker returns an HTTP error code updating an entity', function() {
+   describe('When the Context Broker returns an HTTP error code updating an entity', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -539,7 +539,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the Context Broker returns an application error code updating an entity', function() {
+   describe('When the Context Broker returns an application error code updating an entity', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -565,7 +565,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When there is a transport error connecting to the Context Broker', function() {
+   describe('When there is a transport error connecting to the Context Broker', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -594,7 +594,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When the IoT Agent recieves information for a type with a configured Context Broker', function() {
+   describe('When the IoT Agent recieves information for a type with a configured Context Broker', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -618,7 +618,7 @@ describe('Active attributes test', function() {
         });
     });
 
-    describe('When an IoT Agent receives information for a type with static attributes', function() {
+   describe('When an IoT Agent receives information for a type with static attributes', function() {
         var newValues = [
             {
                 name: 'moving',
@@ -650,7 +650,7 @@ describe('Active attributes test', function() {
     });
 
 
-    describe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
+   describe('When an IoT Agent receives information for a type with static attributes with metadata', function() {
         var newValues = [
             {
                 name: 'luminosity',

--- a/test/unit/ngsiv2/ngsiService/autocast-test.js
+++ b/test/unit/ngsiv2/ngsiService/autocast-test.js
@@ -81,7 +81,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('JSON native types autocast test', function() {
+describe('NGSI-v2 - JSON native types autocast test', function() {
     beforeEach(function() {
         logger.setLevel('FATAL');
     });
@@ -90,7 +90,7 @@ describe('JSON native types autocast test', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When the IoT Agent receives new information from a device.' +
+   describe('When the IoT Agent receives new information from a device.' +
         'Observation with Number type and Integer value', function() {
 
         var values = [
@@ -124,7 +124,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device.' +
+   describe('When the IoT Agent receives new information from a device.' +
         'Observation with Number type and Float value', function() {
 
         var values = [
@@ -158,7 +158,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device.' +
+   describe('When the IoT Agent receives new information from a device.' +
         'Observation with Boolean type and True value', function() {
 
         var values = [
@@ -192,7 +192,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device.' +
+   describe('When the IoT Agent receives new information from a device.' +
         'Observation with Boolean type and False value', function() {
 
         var values = [
@@ -226,7 +226,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device. Observation with None type', function() {
+   describe('When the IoT Agent receives new information from a device. Observation with None type', function() {
 
         var values = [
             {
@@ -259,7 +259,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device. Observation with Array type', function() {
+   describe('When the IoT Agent receives new information from a device. Observation with Array type', function() {
 
         var values = [
             {
@@ -292,7 +292,7 @@ describe('JSON native types autocast test', function() {
         });
     });
 
-    describe('When the IoT Agent receives new information from a device. Observation with Object type', function() {
+   describe('When the IoT Agent receives new information from a device. Observation with Object type', function() {
 
         var values = [
             {

--- a/test/unit/ngsiv2/ngsiService/autocast-test.js
+++ b/test/unit/ngsiv2/ngsiService/autocast-test.js
@@ -90,7 +90,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When the IoT Agent receives new information from a device.' +
+    describe('When the IoT Agent receives new information from a device.' +
         'Observation with Number type and Integer value', function() {
 
         var values = [
@@ -124,7 +124,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device.' +
+    describe('When the IoT Agent receives new information from a device.' +
         'Observation with Number type and Float value', function() {
 
         var values = [
@@ -158,7 +158,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device.' +
+    describe('When the IoT Agent receives new information from a device.' +
         'Observation with Boolean type and True value', function() {
 
         var values = [
@@ -192,7 +192,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device.' +
+    describe('When the IoT Agent receives new information from a device.' +
         'Observation with Boolean type and False value', function() {
 
         var values = [
@@ -226,7 +226,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device. Observation with None type', function() {
+    describe('When the IoT Agent receives new information from a device. Observation with None type', function() {
 
         var values = [
             {
@@ -259,7 +259,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device. Observation with Array type', function() {
+    describe('When the IoT Agent receives new information from a device. Observation with Array type', function() {
 
         var values = [
             {
@@ -292,7 +292,7 @@ describe('NGSI-v2 - JSON native types autocast test', function() {
         });
     });
 
-   describe('When the IoT Agent receives new information from a device. Observation with Object type', function() {
+    describe('When the IoT Agent receives new information from a device. Observation with Object type', function() {
 
         var values = [
             {

--- a/test/unit/ngsiv2/ngsiService/staticAttributes-test.js
+++ b/test/unit/ngsiv2/ngsiService/staticAttributes-test.js
@@ -104,7 +104,7 @@ describe('NGSI-v2 - Static attributes test', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When information from a device with multiple static attributes and metadata is sent', function() {
+    describe('When information from a device with multiple static attributes and metadata is sent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/ngsiService/staticAttributes-test.js
+++ b/test/unit/ngsiv2/ngsiService/staticAttributes-test.js
@@ -82,7 +82,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
     };
 
 
-describe('Static attributes test', function() {
+describe('NGSI-v2 - Static attributes test', function() {
     var values = [
         {
             name: 'state',
@@ -104,7 +104,7 @@ describe('Static attributes test', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When information from a device with multiple static attributes and metadata is sent', function() {
+   describe('When information from a device with multiple static attributes and metadata is sent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/ngsiService/subscriptions-test.js
+++ b/test/unit/ngsiv2/ngsiService/subscriptions-test.js
@@ -46,7 +46,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Subscription tests', function() {
+describe('NGSI-v2 - Subscription tests', function() {
     beforeEach(function(done) {
         var optionsProvision = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -92,7 +92,7 @@ describe('Subscription tests', function() {
         });
     });
 
-    describe('When a client invokes the subscribe() function for device', function() {
+   describe('When a client invokes the subscribe() function for device', function() {
         it('should send the appropriate request to the Context Broker', function(done) {
             iotAgentLib.getDevice('MicroLight1', 'smartGondor', '/gardens', function(error, device) {
 
@@ -121,7 +121,7 @@ describe('Subscription tests', function() {
             });
         });
     });
-    describe('When a client invokes the unsubscribe() function for an entity', function() {
+   describe('When a client invokes the unsubscribe() function for an entity', function() {
         beforeEach(function(done) {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -160,7 +160,7 @@ describe('Subscription tests', function() {
             });
         });
     });
-    describe('When a client removes a device from the registry', function() {
+   describe('When a client removes a device from the registry', function() {
         beforeEach(function(done) {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -182,7 +182,7 @@ describe('Subscription tests', function() {
             });
         });
     });
-    describe('When a new notification comes to the IoTAgent', function() {
+   describe('When a new notification comes to the IoTAgent', function() {
         beforeEach(function(done) {
             iotAgentLib.getDevice('MicroLight1', 'smartGondor', '/gardens', function(error, device) {
                 iotAgentLib.subscribe(device, ['attr_name'], null, function(error) {
@@ -294,7 +294,7 @@ describe('Subscription tests', function() {
             });
         });
     });
-    describe('When a wrong notification arrives at the IOTA', function() {
+   describe('When a wrong notification arrives at the IOTA', function() {
         it('should not call the handler', function(done) {
             var notificationOptions = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/notify',

--- a/test/unit/ngsiv2/ngsiService/subscriptions-test.js
+++ b/test/unit/ngsiv2/ngsiService/subscriptions-test.js
@@ -92,7 +92,7 @@ describe('NGSI-v2 - Subscription tests', function() {
         });
     });
 
-   describe('When a client invokes the subscribe() function for device', function() {
+    describe('When a client invokes the subscribe() function for device', function() {
         it('should send the appropriate request to the Context Broker', function(done) {
             iotAgentLib.getDevice('MicroLight1', 'smartGondor', '/gardens', function(error, device) {
 
@@ -121,7 +121,7 @@ describe('NGSI-v2 - Subscription tests', function() {
             });
         });
     });
-   describe('When a client invokes the unsubscribe() function for an entity', function() {
+    describe('When a client invokes the unsubscribe() function for an entity', function() {
         beforeEach(function(done) {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -160,7 +160,7 @@ describe('NGSI-v2 - Subscription tests', function() {
             });
         });
     });
-   describe('When a client removes a device from the registry', function() {
+    describe('When a client removes a device from the registry', function() {
         beforeEach(function(done) {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -182,7 +182,7 @@ describe('NGSI-v2 - Subscription tests', function() {
             });
         });
     });
-   describe('When a new notification comes to the IoTAgent', function() {
+    describe('When a new notification comes to the IoTAgent', function() {
         beforeEach(function(done) {
             iotAgentLib.getDevice('MicroLight1', 'smartGondor', '/gardens', function(error, device) {
                 iotAgentLib.subscribe(device, ['attr_name'], null, function(error) {
@@ -294,7 +294,7 @@ describe('NGSI-v2 - Subscription tests', function() {
             });
         });
     });
-   describe('When a wrong notification arrives at the IOTA', function() {
+    describe('When a wrong notification arrives at the IOTA', function() {
         it('should not call the handler', function(done) {
             var notificationOptions = {
                     url: 'http://localhost:' + iotAgentConfig.server.port + '/notify',

--- a/test/unit/ngsiv2/plugins/alias-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/alias-plugin_test.js
@@ -107,7 +107,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Attribute alias plugin', function() {
+describe('NGSI-v2 - Attribute alias plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -125,7 +125,7 @@ describe('Attribute alias plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-    describe('When an update comes for attributes with aliases', function() {
+   describe('When an update comes for attributes with aliases', function() {
         var values = [
             {
                 name: 't',
@@ -160,7 +160,7 @@ describe('Attribute alias plugin', function() {
             });
         });
     });
-    describe('When an update comes for attributes with aliases and a different type', function() {
+   describe('When an update comes for attributes with aliases and a different type', function() {
         var values = [
             {
                 name: 'l',
@@ -190,7 +190,7 @@ describe('Attribute alias plugin', function() {
             });
         });
     });
-    describe('When an update comes for attributes with aliases and integer type', function() {
+   describe('When an update comes for attributes with aliases and integer type', function() {
         var values = [
             {
                 name: 'ut',
@@ -220,7 +220,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and integer type.', function() {
+   describe('When an update comes for attributes with aliases and integer type.', function() {
         var values = [
             {
                 name: 'ut',
@@ -251,7 +251,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and float type', function() {
+   describe('When an update comes for attributes with aliases and float type', function() {
         var values = [
             {
                 name: 'ap',
@@ -282,7 +282,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and boolean type', function() {
+   describe('When an update comes for attributes with aliases and boolean type', function() {
         var values = [
             {
                 name: 's',
@@ -313,7 +313,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and None type', function() {
+   describe('When an update comes for attributes with aliases and None type', function() {
         var values = [
             {
                 name: 'al',
@@ -344,7 +344,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and Array type', function() {
+   describe('When an update comes for attributes with aliases and Array type', function() {
         var values = [
             {
                 name: 'ta',
@@ -375,7 +375,7 @@ describe('Attribute alias plugin', function() {
         });
     });
 
-    describe('When an update comes for attributes with aliases and Object type', function() {
+   describe('When an update comes for attributes with aliases and Object type', function() {
         var values = [
             {
                 name: 'c',
@@ -407,7 +407,7 @@ describe('Attribute alias plugin', function() {
     });
 
 
-    describe('When an update comes for attributes with aliases and Object type, but value is String', function() {
+   describe('When an update comes for attributes with aliases and Object type, but value is String', function() {
         var values = [
             {
                 name: 'c',

--- a/test/unit/ngsiv2/plugins/alias-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/alias-plugin_test.js
@@ -125,7 +125,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-   describe('When an update comes for attributes with aliases', function() {
+    describe('When an update comes for attributes with aliases', function() {
         var values = [
             {
                 name: 't',
@@ -160,7 +160,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
             });
         });
     });
-   describe('When an update comes for attributes with aliases and a different type', function() {
+    describe('When an update comes for attributes with aliases and a different type', function() {
         var values = [
             {
                 name: 'l',
@@ -190,7 +190,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
             });
         });
     });
-   describe('When an update comes for attributes with aliases and integer type', function() {
+    describe('When an update comes for attributes with aliases and integer type', function() {
         var values = [
             {
                 name: 'ut',
@@ -220,7 +220,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and integer type.', function() {
+    describe('When an update comes for attributes with aliases and integer type.', function() {
         var values = [
             {
                 name: 'ut',
@@ -251,7 +251,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and float type', function() {
+    describe('When an update comes for attributes with aliases and float type', function() {
         var values = [
             {
                 name: 'ap',
@@ -282,7 +282,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and boolean type', function() {
+    describe('When an update comes for attributes with aliases and boolean type', function() {
         var values = [
             {
                 name: 's',
@@ -313,7 +313,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and None type', function() {
+    describe('When an update comes for attributes with aliases and None type', function() {
         var values = [
             {
                 name: 'al',
@@ -344,7 +344,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and Array type', function() {
+    describe('When an update comes for attributes with aliases and Array type', function() {
         var values = [
             {
                 name: 'ta',
@@ -375,7 +375,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
         });
     });
 
-   describe('When an update comes for attributes with aliases and Object type', function() {
+    describe('When an update comes for attributes with aliases and Object type', function() {
         var values = [
             {
                 name: 'c',
@@ -407,7 +407,7 @@ describe('NGSI-v2 - Attribute alias plugin', function() {
     });
 
 
-   describe('When an update comes for attributes with aliases and Object type, but value is String', function() {
+    describe('When an update comes for attributes with aliases and Object type, but value is String', function() {
         var values = [
             {
                 name: 'c',

--- a/test/unit/ngsiv2/plugins/bidirectional-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/bidirectional-plugin_test.js
@@ -82,7 +82,7 @@ describe('NGSI-v2 - Bidirectional data plugin', function() {
         });
     });
 
-   describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
+    describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
         beforeEach(function() {
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
@@ -109,7 +109,7 @@ describe('NGSI-v2 - Bidirectional data plugin', function() {
         });
     });
 
-   describe('When a device with bidirectionality subscriptions is removed', function() {
+    describe('When a device with bidirectionality subscriptions is removed', function() {
         var deleteRequest = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'DELETE',
@@ -152,7 +152,7 @@ describe('NGSI-v2 - Bidirectional data plugin', function() {
         });
     });
 
-   describe('When a notification arrives for a bidirectional attribute', function() {
+    describe('When a notification arrives for a bidirectional attribute', function() {
         var notificationOptions = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/notify',
                 method: 'POST',
@@ -252,7 +252,7 @@ describe('NGSI-v2 - Bidirectional data plugin', function() {
         });
     });
 
-   describe('When a new Group provisioning request arrives with bidirectional attributes', function() {
+    describe('When a new Group provisioning request arrives with bidirectional attributes', function() {
         var provisionGroup = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/services',
                 method: 'POST',
@@ -301,7 +301,7 @@ describe('NGSI-v2 - Bidirectional data plugin', function() {
         });
     });
 
-   describe('When a notification arrives for a bidirectional attribute in a Configuration Group', function() {
+    describe('When a notification arrives for a bidirectional attribute in a Configuration Group', function() {
         var provisionGroup = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/services',
                 method: 'POST',
@@ -423,7 +423,7 @@ describe('NGSI-v2 - Bidirectional data plugin and CB is defined using environmen
         });
     });
 
-   describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
+    describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
         beforeEach(function() {
             contextBrokerMock = nock('http://cbhost:1026')
                 .matchHeader('fiware-service', 'smartGondor')

--- a/test/unit/ngsiv2/plugins/bidirectional-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/bidirectional-plugin_test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Bidirectional data plugin', function() {
+describe('NGSI-v2 - Bidirectional data plugin', function() {
     var options = {
         url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
         method: 'POST',
@@ -82,7 +82,7 @@ describe('Bidirectional data plugin', function() {
         });
     });
 
-    describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
+   describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
         beforeEach(function() {
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
@@ -109,7 +109,7 @@ describe('Bidirectional data plugin', function() {
         });
     });
 
-    describe('When a device with bidirectionality subscriptions is removed', function() {
+   describe('When a device with bidirectionality subscriptions is removed', function() {
         var deleteRequest = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'DELETE',
@@ -152,7 +152,7 @@ describe('Bidirectional data plugin', function() {
         });
     });
 
-    describe('When a notification arrives for a bidirectional attribute', function() {
+   describe('When a notification arrives for a bidirectional attribute', function() {
         var notificationOptions = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/notify',
                 method: 'POST',
@@ -252,7 +252,7 @@ describe('Bidirectional data plugin', function() {
         });
     });
 
-    describe('When a new Group provisioning request arrives with bidirectional attributes', function() {
+   describe('When a new Group provisioning request arrives with bidirectional attributes', function() {
         var provisionGroup = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/services',
                 method: 'POST',
@@ -301,7 +301,7 @@ describe('Bidirectional data plugin', function() {
         });
     });
 
-    describe('When a notification arrives for a bidirectional attribute in a Configuration Group', function() {
+   describe('When a notification arrives for a bidirectional attribute in a Configuration Group', function() {
         var provisionGroup = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/services',
                 method: 'POST',
@@ -388,7 +388,7 @@ describe('Bidirectional data plugin', function() {
     });
 });
 
-describe('Bidirectional data plugin and CB is defined using environment variables', function() {
+describe('NGSI-v2 - Bidirectional data plugin and CB is defined using environment variables', function() {
     var options = {
         url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
         method: 'POST',
@@ -423,7 +423,7 @@ describe('Bidirectional data plugin and CB is defined using environment variable
         });
     });
 
-    describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
+   describe('When a new provisioning request arrives to the IoTA with bidirectionality', function() {
         beforeEach(function() {
             contextBrokerMock = nock('http://cbhost:1026')
                 .matchHeader('fiware-service', 'smartGondor')

--- a/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
@@ -137,7 +137,7 @@ describe('NGSI-v2 - Timestamp compression plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-   describe('When an update comes with a timestamp through the plugin', function() {
+    describe('When an update comes with a timestamp through the plugin', function() {
         var values = [
             {
                 name: 'state',
@@ -172,7 +172,7 @@ describe('NGSI-v2 - Timestamp compression plugin', function() {
         });
     });
 
-   describe('When an update comes with a timestamp through the plugin with metadata.', function() {
+    describe('When an update comes with a timestamp through the plugin with metadata.', function() {
         var values = [
             {
                 name: 'state',
@@ -214,7 +214,7 @@ describe('NGSI-v2 - Timestamp compression plugin', function() {
         });
     });
 
-   describe('When a query comes for a timestamp through the plugin', function() {
+    describe('When a query comes for a timestamp through the plugin', function() {
         var values = [
             'state',
             'TheTargetValue'

--- a/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/compress-timestamp-plugin_test.js
@@ -120,7 +120,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Timestamp compression plugin', function() {
+describe('NGSI-v2 - Timestamp compression plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
         iotAgentLib.activate(iotAgentConfig, function() {
@@ -137,7 +137,7 @@ describe('Timestamp compression plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-    describe('When an update comes with a timestamp through the plugin', function() {
+   describe('When an update comes with a timestamp through the plugin', function() {
         var values = [
             {
                 name: 'state',
@@ -172,7 +172,7 @@ describe('Timestamp compression plugin', function() {
         });
     });
 
-    describe('When an update comes with a timestamp through the plugin with metadata.', function() {
+   describe('When an update comes with a timestamp through the plugin with metadata.', function() {
         var values = [
             {
                 name: 'state',
@@ -214,7 +214,7 @@ describe('Timestamp compression plugin', function() {
         });
     });
 
-    describe('When a query comes for a timestamp through the plugin', function() {
+   describe('When a query comes for a timestamp through the plugin', function() {
         var values = [
             'state',
             'TheTargetValue'

--- a/test/unit/ngsiv2/plugins/event-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/event-plugin_test.js
@@ -80,7 +80,7 @@ describe('NGSI-v2 - Event plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-   describe('When an update comes with an event to the plugin', function() {
+    describe('When an update comes with an event to the plugin', function() {
         var values = [
             {
                 name: 'state',

--- a/test/unit/ngsiv2/plugins/event-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/event-plugin_test.js
@@ -62,7 +62,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Event plugin', function() {
+describe('NGSI-v2 - Event plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -80,7 +80,7 @@ describe('Event plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-    describe('When an update comes with an event to the plugin', function() {
+   describe('When an update comes with an event to the plugin', function() {
         var values = [
             {
                 name: 'state',

--- a/test/unit/ngsiv2/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/multientity-plugin_test.js
@@ -223,7 +223,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Multi-entity plugin', function() {
+describe('NGSI-v2 - Multi-entity plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -243,7 +243,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
-    describe('When an update comes for a multientity measurement', function() {
+   describe('When an update comes for a multientity measurement', function() {
         var values = [
             {
                 name: 'p',
@@ -277,7 +277,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
-    describe('When an update comes for a multientity measurement with same attribute name', function() {
+   describe('When an update comes for a multientity measurement with same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -306,7 +306,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
-    describe('When an update comes for a multientity multi measurement with same attribute name', function() {
+   describe('When an update comes for a multientity multi measurement with same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -341,7 +341,7 @@ describe('Multi-entity plugin', function() {
     });
 
     /* jshint maxlen: 200 */
-    describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
+   describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -376,7 +376,7 @@ describe('Multi-entity plugin', function() {
     });
 
 
-    describe('When an update comes for a multientity defined with an expression', function() {
+   describe('When an update comes for a multientity defined with an expression', function() {
         var values = [
             {
                 name: 'p',
@@ -415,7 +415,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
-    describe('When an update comes for a multientity measurement without type for one entity', function() {
+   describe('When an update comes for a multientity measurement without type for one entity', function() {
         var values = [
             {
                 name: 'p',
@@ -449,7 +449,7 @@ describe('Multi-entity plugin', function() {
         });
     });
 
-    describe('When an update comes for a multientity measurement and there are attributes with' +
+   describe('When an update comes for a multientity measurement and there are attributes with' +
         ' the same name but different alias and mapped to different CB entities', function() {
         var values = [
             {
@@ -479,7 +479,7 @@ describe('Multi-entity plugin', function() {
         });
     });
     
-    describe('When an update comes for a multientity multi measurement and there are attributes with' +
+   describe('When an update comes for a multientity multi measurement and there are attributes with' +
         ' the same name but different alias and mapped to different CB entities', function() {
         var values = [
             {
@@ -526,7 +526,7 @@ describe('Multi-entity plugin', function() {
     
 });
 
-describe('Multi-entity plugin is executed before timestamp process plugin', function() {
+describe('NGSI-v2 - Multi-entity plugin is executed before timestamp process plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -548,7 +548,7 @@ describe('Multi-entity plugin is executed before timestamp process plugin', func
         });
     });
 
-    describe('When an update comes for a multientity measurement and timestamp is enabled in config file', function() {
+   describe('When an update comes for a multientity measurement and timestamp is enabled in config file', function() {
         var values = [
             {
                 name: 'p',
@@ -692,7 +692,7 @@ describe('Multi-entity plugin is executed before timestamp process plugin', func
     });
 });
 
-describe('Multi-entity plugin is executed for a command update for a regular entity ', function () {
+describe('NGSI-v2 - Multi-entity plugin is executed for a command update for a regular entity ', function () {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/ngsiv2/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/multientity-plugin_test.js
@@ -243,7 +243,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
 
-   describe('When an update comes for a multientity measurement', function() {
+    describe('When an update comes for a multientity measurement', function() {
         var values = [
             {
                 name: 'p',
@@ -277,7 +277,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
 
-   describe('When an update comes for a multientity measurement with same attribute name', function() {
+    describe('When an update comes for a multientity measurement with same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -306,7 +306,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
 
-   describe('When an update comes for a multientity multi measurement with same attribute name', function() {
+    describe('When an update comes for a multientity multi measurement with same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -341,7 +341,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
     });
 
     /* jshint maxlen: 200 */
-   describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
+    describe('When an update comes for a multientity multi measurement with metadata and the same attribute name', function() {
         var values = [
             {
                 name: 'h',
@@ -376,7 +376,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
     });
 
 
-   describe('When an update comes for a multientity defined with an expression', function() {
+    describe('When an update comes for a multientity defined with an expression', function() {
         var values = [
             {
                 name: 'p',
@@ -415,7 +415,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
 
-   describe('When an update comes for a multientity measurement without type for one entity', function() {
+    describe('When an update comes for a multientity measurement without type for one entity', function() {
         var values = [
             {
                 name: 'p',
@@ -449,7 +449,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
 
-   describe('When an update comes for a multientity measurement and there are attributes with' +
+    describe('When an update comes for a multientity measurement and there are attributes with' +
         ' the same name but different alias and mapped to different CB entities', function() {
         var values = [
             {
@@ -479,7 +479,7 @@ describe('NGSI-v2 - Multi-entity plugin', function() {
         });
     });
     
-   describe('When an update comes for a multientity multi measurement and there are attributes with' +
+    describe('When an update comes for a multientity multi measurement and there are attributes with' +
         ' the same name but different alias and mapped to different CB entities', function() {
         var values = [
             {
@@ -548,7 +548,7 @@ describe('NGSI-v2 - Multi-entity plugin is executed before timestamp process plu
         });
     });
 
-   describe('When an update comes for a multientity measurement and timestamp is enabled in config file', function() {
+    describe('When an update comes for a multientity measurement and timestamp is enabled in config file', function() {
         var values = [
             {
                 name: 'p',

--- a/test/unit/ngsiv2/plugins/timestamp-processing-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/timestamp-processing-plugin_test.js
@@ -63,7 +63,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Timestamp processing plugin', function() {
+describe('NGSI-v2 - Timestamp processing plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 
@@ -80,7 +80,7 @@ describe('Timestamp processing plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-    describe('When an update comes with a timestamp through the plugin', function() {
+   describe('When an update comes with a timestamp through the plugin', function() {
         var values = [
             {
                 name: 'state',

--- a/test/unit/ngsiv2/plugins/timestamp-processing-plugin_test.js
+++ b/test/unit/ngsiv2/plugins/timestamp-processing-plugin_test.js
@@ -80,7 +80,7 @@ describe('NGSI-v2 - Timestamp processing plugin', function() {
             iotAgentLib.deactivate(done);
         });
     });
-   describe('When an update comes with a timestamp through the plugin', function() {
+    describe('When an update comes with a timestamp through the plugin', function() {
         var values = [
             {
                 name: 'state',

--- a/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
@@ -79,7 +79,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
+    describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
         beforeEach(function() {
             nock.cleanAll();
             contextBrokerMock = nock('http://192.168.1.1:1026')
@@ -210,7 +210,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When a device provisioning request with a TimeInstant attribute arrives to the IoTA', function() {
+    describe('When a device provisioning request with a TimeInstant attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -253,7 +253,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
     });
 
 
-   describe('When a device provisioning request with a timestamp provision attribute arrives to the IoTA', function() {
+    describe('When a device provisioning request with a timestamp provision attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -295,7 +295,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request with a autoprovision attribute arrives to the IoTA', function() {
+    describe('When a device provisioning request with a autoprovision attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -336,7 +336,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request arrives to the IoTA' +
+    describe('When a device provisioning request arrives to the IoTA' +
         'and timestamp is enabled in configuration', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -399,7 +399,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request with the minimum required data arrives to the IoT Agent', function() {
+    describe('When a device provisioning request with the minimum required data arrives to the IoT Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -455,7 +455,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request with geo:point attributes arrives', function() {
+    describe('When a device provisioning request with geo:point attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -487,7 +487,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request with DateTime attributes arrives', function() {
+    describe('When a device provisioning request with DateTime attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -520,7 +520,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
     });
 
 
-   describe('When two devices with the same ID but different services arrive to the agent', function() {
+    describe('When two devices with the same ID but different services arrive to the agent', function() {
         var options1 = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                 method: 'POST',
@@ -589,7 +589,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When there is a connection error with a String code connecting the CB', function() {
+    describe('When there is a connection error with a String code connecting the CB', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -631,7 +631,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When there is a connection error with a Number code connecting the CB', function() {
+    describe('When there is a connection error with a Number code connecting the CB', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -673,7 +673,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         });
     });
 
-   describe('When a device provisioning request with missing data arrives to the IoT Agent', function() {
+    describe('When a device provisioning request with missing data arrives to the IoT Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -695,7 +695,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When two device provisioning requests with the same service and Device ID arrive', function() {
+    describe('When two device provisioning requests with the same service and Device ID arrive', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -736,7 +736,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When a device provisioning request is malformed', function() {
+    describe('When a device provisioning request is malformed', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -759,7 +759,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When an agent is activated with a different base root', function() {
+    describe('When an agent is activated with a different base root', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/newBaseRoot/iot/devices',
             method: 'POST',
@@ -793,7 +793,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When a device provisioning request without the mandatory headers arrives to the Agent', function() {
+    describe('When a device provisioning request without the mandatory headers arrives to the Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -811,7 +811,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
             });
         });
     });
-   describe('When a device delete request arrives to the Agent for a not existing device', function() {
+    describe('When a device delete request arrives to the Agent for a not existing device', function() {
       var options = {
           url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
           headers: {

--- a/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Device provisioning API: Provision devices', function() {
+describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 
@@ -79,7 +79,7 @@ describe('Device provisioning API: Provision devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
+   describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
         beforeEach(function() {
             nock.cleanAll();
             contextBrokerMock = nock('http://192.168.1.1:1026')
@@ -210,7 +210,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When a device provisioning request with a TimeInstant attribute arrives to the IoTA', function() {
+   describe('When a device provisioning request with a TimeInstant attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -253,7 +253,7 @@ describe('Device provisioning API: Provision devices', function() {
     });
 
 
-    describe('When a device provisioning request with a timestamp provision attribute arrives to the IoTA', function() {
+   describe('When a device provisioning request with a timestamp provision attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -295,7 +295,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request with a autoprovision attribute arrives to the IoTA', function() {
+   describe('When a device provisioning request with a autoprovision attribute arrives to the IoTA', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -336,7 +336,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request arrives to the IoTA' +
+   describe('When a device provisioning request arrives to the IoTA' +
         'and timestamp is enabled in configuration', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
@@ -399,7 +399,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request with the minimum required data arrives to the IoT Agent', function() {
+   describe('When a device provisioning request with the minimum required data arrives to the IoT Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -455,7 +455,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request with geo:point attributes arrives', function() {
+   describe('When a device provisioning request with geo:point attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -487,7 +487,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request with DateTime attributes arrives', function() {
+   describe('When a device provisioning request with DateTime attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -520,7 +520,7 @@ describe('Device provisioning API: Provision devices', function() {
     });
 
 
-    describe('When two devices with the same ID but different services arrive to the agent', function() {
+   describe('When two devices with the same ID but different services arrive to the agent', function() {
         var options1 = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                 method: 'POST',
@@ -589,7 +589,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When there is a connection error with a String code connecting the CB', function() {
+   describe('When there is a connection error with a String code connecting the CB', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -631,7 +631,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When there is a connection error with a Number code connecting the CB', function() {
+   describe('When there is a connection error with a Number code connecting the CB', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -673,7 +673,7 @@ describe('Device provisioning API: Provision devices', function() {
         });
     });
 
-    describe('When a device provisioning request with missing data arrives to the IoT Agent', function() {
+   describe('When a device provisioning request with missing data arrives to the IoT Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -695,7 +695,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When two device provisioning requests with the same service and Device ID arrive', function() {
+   describe('When two device provisioning requests with the same service and Device ID arrive', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -736,7 +736,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When a device provisioning request is malformed', function() {
+   describe('When a device provisioning request is malformed', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -759,7 +759,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When an agent is activated with a different base root', function() {
+   describe('When an agent is activated with a different base root', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/newBaseRoot/iot/devices',
             method: 'POST',
@@ -793,7 +793,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When a device provisioning request without the mandatory headers arrives to the Agent', function() {
+   describe('When a device provisioning request without the mandatory headers arrives to the Agent', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -811,7 +811,7 @@ describe('Device provisioning API: Provision devices', function() {
             });
         });
     });
-    describe('When a device delete request arrives to the Agent for a not existing device', function() {
+   describe('When a device delete request arrives to the Agent for a not existing device', function() {
       var options = {
           url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
           headers: {

--- a/test/unit/ngsiv2/provisioning/device-registration_test.js
+++ b/test/unit/ngsiv2/provisioning/device-registration_test.js
@@ -89,7 +89,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('IoT Agent Device Registration', function() {
+describe('NGSI-v2 - IoT Agent Device Registration', function() {
     beforeEach(function() {
         logger.setLevel('FATAL');
     });
@@ -103,7 +103,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When a new device is connected to the IoT Agent', function() {
+   describe('When a new device is connected to the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -139,7 +139,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When the Context Broker returns a NGSI error while registering a device', function() {
+   describe('When the Context Broker returns a NGSI error while registering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -166,7 +166,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When the Context Broker returns an HTTP transport error while registering a device', function() {
+   describe('When the Context Broker returns an HTTP transport error while registering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             var nockBody = utils.readExampleFile(
@@ -194,7 +194,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When a device is requested to the library using its ID', function() {
+   describe('When a device is requested to the library using its ID', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -233,7 +233,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When an unexistent device is requested to the library using its ID', function() {
+   describe('When an unexistent device is requested to the library using its ID', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -263,7 +263,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When a device is removed from the IoT Agent', function() {
+   describe('When a device is removed from the IoT Agent', function() {
         beforeEach(function(done) {
 
             nock.cleanAll();
@@ -312,7 +312,7 @@ describe('IoT Agent Device Registration', function() {
         });
     });
 
-    describe('When the Context Broker returns an error while unregistering a device', function() {
+   describe('When the Context Broker returns an error while unregistering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             contextBrokerMock = nock('http://192.168.1.1:1026')

--- a/test/unit/ngsiv2/provisioning/device-registration_test.js
+++ b/test/unit/ngsiv2/provisioning/device-registration_test.js
@@ -103,7 +103,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When a new device is connected to the IoT Agent', function() {
+    describe('When a new device is connected to the IoT Agent', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -139,7 +139,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When the Context Broker returns a NGSI error while registering a device', function() {
+    describe('When the Context Broker returns a NGSI error while registering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -166,7 +166,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When the Context Broker returns an HTTP transport error while registering a device', function() {
+    describe('When the Context Broker returns an HTTP transport error while registering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             var nockBody = utils.readExampleFile(
@@ -194,7 +194,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When a device is requested to the library using its ID', function() {
+    describe('When a device is requested to the library using its ID', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -233,7 +233,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When an unexistent device is requested to the library using its ID', function() {
+    describe('When an unexistent device is requested to the library using its ID', function() {
         beforeEach(function(done) {
             nock.cleanAll();
 
@@ -263,7 +263,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When a device is removed from the IoT Agent', function() {
+    describe('When a device is removed from the IoT Agent', function() {
         beforeEach(function(done) {
 
             nock.cleanAll();
@@ -312,7 +312,7 @@ describe('NGSI-v2 - IoT Agent Device Registration', function() {
         });
     });
 
-   describe('When the Context Broker returns an error while unregistering a device', function() {
+    describe('When the Context Broker returns an error while unregistering a device', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             contextBrokerMock = nock('http://192.168.1.1:1026')

--- a/test/unit/ngsiv2/provisioning/device-update-registration_test.js
+++ b/test/unit/ngsiv2/provisioning/device-update-registration_test.js
@@ -169,7 +169,7 @@ describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
         });
     });
 
-   describe('When a device is preregistered and its registration information updated', function() {
+    describe('When a device is preregistered and its registration information updated', function() {
         beforeEach(function() {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -217,7 +217,7 @@ describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
         });
     });
 
-   describe('When a device is preregistered and it is updated with new commands', function() {
+    describe('When a device is preregistered and it is updated with new commands', function() {
         beforeEach(function() {
 
             delete deviceCommandUpdated.registrationId;
@@ -267,7 +267,7 @@ describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
         });
     });
 
-   describe('When a update action is executed in a non registered device', function() {
+    describe('When a update action is executed in a non registered device', function() {
 
         it('should return a DEVICE_NOT_FOUND error', function(done) {
             iotAgentLib.updateRegister(unknownDevice, function(error) {
@@ -277,7 +277,7 @@ describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
             });
         });
     });
-   describe('When a device register is updated in the Context Broker and the request fail to connect', function() {
+    describe('When a device register is updated in the Context Broker and the request fail to connect', function() {
         beforeEach(function() {
 
             // FIXME: When https://github.com/telefonicaid/fiware-orion/issues/3007 is merged into master branch,
@@ -302,7 +302,7 @@ describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
             });
         });
     });
-   describe('When a device register is updated in the Context Broker and the registration is not found', function() {
+    describe('When a device register is updated in the Context Broker and the registration is not found', function() {
         it('should create the registration anew');
     });
 });

--- a/test/unit/ngsiv2/provisioning/device-update-registration_test.js
+++ b/test/unit/ngsiv2/provisioning/device-update-registration_test.js
@@ -133,7 +133,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         active: []
     };
 
-describe('IoT Agent Device Update Registration', function() {
+describe('NGSI-v2 - IoT Agent Device Update Registration', function() {
     beforeEach(function(done) {
         delete device1.registrationId;
         logger.setLevel('FATAL');
@@ -169,7 +169,7 @@ describe('IoT Agent Device Update Registration', function() {
         });
     });
 
-    describe('When a device is preregistered and its registration information updated', function() {
+   describe('When a device is preregistered and its registration information updated', function() {
         beforeEach(function() {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
@@ -217,7 +217,7 @@ describe('IoT Agent Device Update Registration', function() {
         });
     });
 
-    describe('When a device is preregistered and it is updated with new commands', function() {
+   describe('When a device is preregistered and it is updated with new commands', function() {
         beforeEach(function() {
 
             delete deviceCommandUpdated.registrationId;
@@ -267,7 +267,7 @@ describe('IoT Agent Device Update Registration', function() {
         });
     });
 
-    describe('When a update action is executed in a non registered device', function() {
+   describe('When a update action is executed in a non registered device', function() {
 
         it('should return a DEVICE_NOT_FOUND error', function(done) {
             iotAgentLib.updateRegister(unknownDevice, function(error) {
@@ -277,7 +277,7 @@ describe('IoT Agent Device Update Registration', function() {
             });
         });
     });
-    describe('When a device register is updated in the Context Broker and the request fail to connect', function() {
+   describe('When a device register is updated in the Context Broker and the request fail to connect', function() {
         beforeEach(function() {
 
             // FIXME: When https://github.com/telefonicaid/fiware-orion/issues/3007 is merged into master branch,
@@ -302,7 +302,7 @@ describe('IoT Agent Device Update Registration', function() {
             });
         });
     });
-    describe('When a device register is updated in the Context Broker and the registration is not found', function() {
+   describe('When a device register is updated in the Context Broker and the registration is not found', function() {
         it('should create the registration anew');
     });
 });

--- a/test/unit/ngsiv2/provisioning/listProvisionedDevices-test.js
+++ b/test/unit/ngsiv2/provisioning/listProvisionedDevices-test.js
@@ -137,7 +137,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
         iotAgentLib.deactivate(done);
     });
 
-   describe('When a request for the list of provisioned devices arrive', function() {
+    describe('When a request for the list of provisioned devices arrive', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             headers: {
@@ -201,7 +201,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
             });
         });
     });
-   describe('When a request for the information about a specific device arrives', function() {
+    describe('When a request for the information about a specific device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
@@ -244,7 +244,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
             });
         });
     });
-   describe('When a request for a device with plugin attributes arrives', function() {
+    describe('When a request for a device with plugin attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/LightFull',
             headers: {
@@ -275,7 +275,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
             });
         });
     });
-   describe('When a request for an unexistent device arrives', function() {
+    describe('When a request for an unexistent device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
             headers: {
@@ -294,7 +294,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
         });
     });
 
-   describe('When a request for listing all the devices with a limit of 3 arrives', function() {
+    describe('When a request for listing all the devices with a limit of 3 arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices?limit=3',
             headers: {
@@ -367,7 +367,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
         });
     });
 
-   describe('When a request for listing all the devices with a offset of 3 arrives', function() {
+    describe('When a request for listing all the devices with a offset of 3 arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices?offset=3',
             headers: {
@@ -427,7 +427,7 @@ describe('NGSI-v2 - Device provisioning API: List provisioned devices', function
         });
     });
 
-   describe('When a listing request arrives and there are devices in other service and servicepath', function() {
+    describe('When a listing request arrives and there are devices in other service and servicepath', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             headers: {

--- a/test/unit/ngsiv2/provisioning/listProvisionedDevices-test.js
+++ b/test/unit/ngsiv2/provisioning/listProvisionedDevices-test.js
@@ -51,7 +51,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Device provisioning API: List provisioned devices', function() {
+describe('NGSI-v2 - Device provisioning API: List provisioned devices', function() {
     var provisioning1Options,
         provisioning2Options,
         provisioning3Options,
@@ -137,7 +137,7 @@ describe('Device provisioning API: List provisioned devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When a request for the list of provisioned devices arrive', function() {
+   describe('When a request for the list of provisioned devices arrive', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             headers: {
@@ -201,7 +201,7 @@ describe('Device provisioning API: List provisioned devices', function() {
             });
         });
     });
-    describe('When a request for the information about a specific device arrives', function() {
+   describe('When a request for the information about a specific device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
@@ -244,7 +244,7 @@ describe('Device provisioning API: List provisioned devices', function() {
             });
         });
     });
-    describe('When a request for a device with plugin attributes arrives', function() {
+   describe('When a request for a device with plugin attributes arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/LightFull',
             headers: {
@@ -275,7 +275,7 @@ describe('Device provisioning API: List provisioned devices', function() {
             });
         });
     });
-    describe('When a request for an unexistent device arrives', function() {
+   describe('When a request for an unexistent device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light84',
             headers: {
@@ -294,7 +294,7 @@ describe('Device provisioning API: List provisioned devices', function() {
         });
     });
 
-    describe('When a request for listing all the devices with a limit of 3 arrives', function() {
+   describe('When a request for listing all the devices with a limit of 3 arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices?limit=3',
             headers: {
@@ -367,7 +367,7 @@ describe('Device provisioning API: List provisioned devices', function() {
         });
     });
 
-    describe('When a request for listing all the devices with a offset of 3 arrives', function() {
+   describe('When a request for listing all the devices with a offset of 3 arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices?offset=3',
             headers: {
@@ -427,7 +427,7 @@ describe('Device provisioning API: List provisioned devices', function() {
         });
     });
 
-    describe('When a listing request arrives and there are devices in other service and servicepath', function() {
+   describe('When a listing request arrives and there are devices in other service and servicepath', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             headers: {

--- a/test/unit/ngsiv2/provisioning/provisionDeviceMultientity-test.js
+++ b/test/unit/ngsiv2/provisioning/provisionDeviceMultientity-test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Device provisioning API: Provision devices', function() {
+describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 
@@ -63,7 +63,7 @@ describe('Device provisioning API: Provision devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
+   describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
         beforeEach(function() {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/provisioning/provisionDeviceMultientity-test.js
+++ b/test/unit/ngsiv2/provisioning/provisionDeviceMultientity-test.js
@@ -63,7 +63,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
+    describe('When a device provisioning request with all the required data arrives to the IoT Agent', function() {
         beforeEach(function() {
             nock.cleanAll();
 

--- a/test/unit/ngsiv2/provisioning/removeProvisionedDevice-test.js
+++ b/test/unit/ngsiv2/provisioning/removeProvisionedDevice-test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Device provisioning API: Remove provisioned devices', function() {
+describe('NGSI-v2 - Device provisioning API: Remove provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -144,7 +144,7 @@ describe('Device provisioning API: Remove provisioned devices', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When a request to remove a provision device arrives', function() {
+   describe('When a request to remove a provision device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
@@ -215,7 +215,7 @@ describe('Device provisioning API: Remove provisioned devices', function() {
         });
     });
 
-    describe('When a request to remove a provision device arrives. Device without lazy atts or commands', function() {
+   describe('When a request to remove a provision device arrives. Device without lazy atts or commands', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light3',
             headers: {

--- a/test/unit/ngsiv2/provisioning/removeProvisionedDevice-test.js
+++ b/test/unit/ngsiv2/provisioning/removeProvisionedDevice-test.js
@@ -144,7 +144,7 @@ describe('NGSI-v2 - Device provisioning API: Remove provisioned devices', functi
         iotAgentLib.deactivate(done);
     });
 
-   describe('When a request to remove a provision device arrives', function() {
+    describe('When a request to remove a provision device arrives', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             headers: {
@@ -215,7 +215,7 @@ describe('NGSI-v2 - Device provisioning API: Remove provisioned devices', functi
         });
     });
 
-   describe('When a request to remove a provision device arrives. Device without lazy atts or commands', function() {
+    describe('When a request to remove a provision device arrives. Device without lazy atts or commands', function() {
         var options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light3',
             headers: {

--- a/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
+++ b/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
@@ -69,7 +69,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         }
     };
 
-describe('Provisioning API: Single service mode', function() {
+describe('NGSI-v2 - Provisioning API: Single service mode', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 
@@ -84,7 +84,7 @@ describe('Provisioning API: Single service mode', function() {
         iotAgentLib.deactivate(done);
     });
 
-    describe('When a new configuration arrives to an already configured subservice', function() {
+   describe('When a new configuration arrives to an already configured subservice', function() {
         var groupCreationDuplicated = {
             url: 'http://localhost:4041/iot/services',
             method: 'POST',
@@ -109,7 +109,7 @@ describe('Provisioning API: Single service mode', function() {
             });
         });
     });
-    describe('When a device is provisioned with an ID that already exists in the configuration', function() {
+   describe('When a device is provisioned with an ID that already exists in the configuration', function() {
         var deviceCreationDuplicated = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -155,7 +155,7 @@ describe('Provisioning API: Single service mode', function() {
             });
         });
     });
-    describe('When a device is provisioned with an ID that exists globally but not in the configuration', function() {
+   describe('When a device is provisioned with an ID that exists globally but not in the configuration', function() {
         var alternativeDeviceCreation = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                 method: 'POST',
@@ -225,7 +225,7 @@ describe('Provisioning API: Single service mode', function() {
             });
         });
     });
-    describe('When a device is provisioned without a type and with a default configuration type', function() {
+   describe('When a device is provisioned without a type and with a default configuration type', function() {
         var getDevice = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
                 method: 'GET',
@@ -277,7 +277,7 @@ describe('Provisioning API: Single service mode', function() {
             });
         });
     });
-    describe('When a device is provisioned for a configuration', function() {
+   describe('When a device is provisioned for a configuration', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             contextBrokerMock = nock('http://unexistentHost:1026')

--- a/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
+++ b/test/unit/ngsiv2/provisioning/singleConfigurationMode-test.js
@@ -84,7 +84,7 @@ describe('NGSI-v2 - Provisioning API: Single service mode', function() {
         iotAgentLib.deactivate(done);
     });
 
-   describe('When a new configuration arrives to an already configured subservice', function() {
+    describe('When a new configuration arrives to an already configured subservice', function() {
         var groupCreationDuplicated = {
             url: 'http://localhost:4041/iot/services',
             method: 'POST',
@@ -109,7 +109,7 @@ describe('NGSI-v2 - Provisioning API: Single service mode', function() {
             });
         });
     });
-   describe('When a device is provisioned with an ID that already exists in the configuration', function() {
+    describe('When a device is provisioned with an ID that already exists in the configuration', function() {
         var deviceCreationDuplicated = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -155,7 +155,7 @@ describe('NGSI-v2 - Provisioning API: Single service mode', function() {
             });
         });
     });
-   describe('When a device is provisioned with an ID that exists globally but not in the configuration', function() {
+    describe('When a device is provisioned with an ID that exists globally but not in the configuration', function() {
         var alternativeDeviceCreation = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                 method: 'POST',
@@ -225,7 +225,7 @@ describe('NGSI-v2 - Provisioning API: Single service mode', function() {
             });
         });
     });
-   describe('When a device is provisioned without a type and with a default configuration type', function() {
+    describe('When a device is provisioned without a type and with a default configuration type', function() {
         var getDevice = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
                 method: 'GET',
@@ -277,7 +277,7 @@ describe('NGSI-v2 - Provisioning API: Single service mode', function() {
             });
         });
     });
-   describe('When a device is provisioned for a configuration', function() {
+    describe('When a device is provisioned for a configuration', function() {
         beforeEach(function(done) {
             nock.cleanAll();
             contextBrokerMock = nock('http://unexistentHost:1026')

--- a/test/unit/ngsiv2/provisioning/updateProvisionedDevices-test.js
+++ b/test/unit/ngsiv2/provisioning/updateProvisionedDevices-test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
         providerUrl: 'http://smartGondor.com'
     };
 
-describe('Device provisioning API: Update provisioned devices', function() {
+describe('NGSI-v2 - Device provisioning API: Update provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',
@@ -147,7 +147,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
         });
     });
 
-    describe('When a request to update a provision device arrives', function() {
+   describe('When a request to update a provision device arrives', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -244,7 +244,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
             });
         });
     });
-    describe('When an update request arrives with a new Device ID', function() {
+   describe('When an update request arrives with a new Device ID', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -264,7 +264,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
             });
         });
     });
-    describe('When a wrong update request payload arrives', function() {
+   describe('When a wrong update request payload arrives', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -285,7 +285,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
         });
     });
 
-    describe('When a device is provisioned without attributes and new ones are added through an update', function() {
+   describe('When a device is provisioned without attributes and new ones are added through an update', function() {
         var optionsUpdate = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/MicroLight2',
                 method: 'PUT',
@@ -360,7 +360,7 @@ describe('Device provisioning API: Update provisioned devices', function() {
         });
     });
 
-    describe('When a device is updated to add static attributes', function() {
+   describe('When a device is updated to add static attributes', function() {
         /* jshint camelcase: false */
 
         var optionsUpdate = {

--- a/test/unit/ngsiv2/provisioning/updateProvisionedDevices-test.js
+++ b/test/unit/ngsiv2/provisioning/updateProvisionedDevices-test.js
@@ -147,7 +147,7 @@ describe('NGSI-v2 - Device provisioning API: Update provisioned devices', functi
         });
     });
 
-   describe('When a request to update a provision device arrives', function() {
+    describe('When a request to update a provision device arrives', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -244,7 +244,7 @@ describe('NGSI-v2 - Device provisioning API: Update provisioned devices', functi
             });
         });
     });
-   describe('When an update request arrives with a new Device ID', function() {
+    describe('When an update request arrives with a new Device ID', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -264,7 +264,7 @@ describe('NGSI-v2 - Device provisioning API: Update provisioned devices', functi
             });
         });
     });
-   describe('When a wrong update request payload arrives', function() {
+    describe('When a wrong update request payload arrives', function() {
         var optionsUpdate = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/Light1',
             method: 'PUT',
@@ -285,7 +285,7 @@ describe('NGSI-v2 - Device provisioning API: Update provisioned devices', functi
         });
     });
 
-   describe('When a device is provisioned without attributes and new ones are added through an update', function() {
+    describe('When a device is provisioned without attributes and new ones are added through an update', function() {
         var optionsUpdate = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices/MicroLight2',
                 method: 'PUT',
@@ -360,7 +360,7 @@ describe('NGSI-v2 - Device provisioning API: Update provisioned devices', functi
         });
     });
 
-   describe('When a device is updated to add static attributes', function() {
+    describe('When a device is updated to add static attributes', function() {
         /* jshint camelcase: false */
 
         var optionsUpdate = {

--- a/test/unit/plugins/bidirectional-plugin_test.js
+++ b/test/unit/plugins/bidirectional-plugin_test.js
@@ -62,7 +62,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Bidirectional data plugin', function() {
+describe('NGSI-v1 - Bidirectional data plugin', function() {
     var options = {
         url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
         method: 'POST',

--- a/test/unit/plugins/compress-timestamp-plugin_test.js
+++ b/test/unit/plugins/compress-timestamp-plugin_test.js
@@ -118,7 +118,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Timestamp compression plugin', function() {
+describe('NGSI-v1 - Timestamp compression plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/plugins/event-plugin_test.js
+++ b/test/unit/plugins/event-plugin_test.js
@@ -61,7 +61,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Event plugin', function() {
+describe('NGSI-v1 - Event plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/plugins/multientity-plugin_test.js
+++ b/test/unit/plugins/multientity-plugin_test.js
@@ -101,7 +101,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Multi-entity plugin', function() {
+describe('NGSI-v1 - Multi-entity plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/plugins/timestamp-processing-plugin_test.js
+++ b/test/unit/plugins/timestamp-processing-plugin_test.js
@@ -61,7 +61,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Timestamp processing plugin', function() {
+describe('NGSI-v1 - Timestamp processing plugin', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/provisioning/device-provisioning-api_test.js
+++ b/test/unit/provisioning/device-provisioning-api_test.js
@@ -46,7 +46,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Device provisioning API: Provision devices', function() {
+describe('NGSI-v1 - Device provisioning API: Provision devices', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 

--- a/test/unit/provisioning/device-registration_test.js
+++ b/test/unit/provisioning/device-registration_test.js
@@ -87,7 +87,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         subservice: 'gardens'
     };
 
-describe('IoT Agent Device Registration', function() {
+describe('NGSI-v1 - IoT Agent Device Registration', function() {
     beforeEach(function() {
         logger.setLevel('FATAL');
     });

--- a/test/unit/provisioning/device-update-registration_test.js
+++ b/test/unit/provisioning/device-update-registration_test.js
@@ -131,7 +131,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         active: []
     };
 
-describe('IoT Agent Device Update Registration', function() {
+describe('NGSI-v1 - IoT Agent Device Update Registration', function() {
     beforeEach(function(done) {
         logger.setLevel('FATAL');
 

--- a/test/unit/provisioning/listProvisionedDevices-test.js
+++ b/test/unit/provisioning/listProvisionedDevices-test.js
@@ -48,7 +48,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Device provisioning API: List provisioned devices', function() {
+describe('NGSI-v1 - Device provisioning API: List provisioned devices', function() {
     var provisioning1Options,
         provisioning2Options,
         provisioning3Options,

--- a/test/unit/provisioning/provisionDeviceMultientity-test.js
+++ b/test/unit/provisioning/provisionDeviceMultientity-test.js
@@ -46,7 +46,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Device provisioning API: Provision devices', function() {
+describe('NGSI-v1 - Device provisioning API: Provision devices', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 

--- a/test/unit/provisioning/removeProvisionedDevice-test.js
+++ b/test/unit/provisioning/removeProvisionedDevice-test.js
@@ -46,7 +46,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Device provisioning API: Remove provisioned devices', function() {
+describe('NGSI-v1 - Device provisioning API: Remove provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',

--- a/test/unit/provisioning/singleConfigurationMode-test.js
+++ b/test/unit/provisioning/singleConfigurationMode-test.js
@@ -67,7 +67,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         }
     };
 
-describe('Provisioning API: Single service mode', function() {
+describe('NGSI-v1 - Provisioning API: Single service mode', function() {
     beforeEach(function(done) {
         nock.cleanAll();
 

--- a/test/unit/provisioning/updateProvisionedDevices-test.js
+++ b/test/unit/provisioning/updateProvisionedDevices-test.js
@@ -46,7 +46,7 @@ var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
         deviceRegistrationDuration: 'P1M'
     };
 
-describe('Device provisioning API: Update provisioned devices', function() {
+describe('NGSI-v1 - Device provisioning API: Update provisioned devices', function() {
     var provisioning1Options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
             method: 'POST',


### PR DESCRIPTION
Simple Grep rename of the descriptions of the **NGSI v2** tests, to distinguish them from the **NGSI-LD** test suite

Also updated the **NGSI-v1** test files which have equivalent tests to distinguish between v1, v2 and LD
