### PR TITLE
fix the mongodb authentication

### DIFF
--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -51,19 +51,15 @@ function loadModels() {
  *
  * @this Reference to the dbConn module itself.
  */
-function init(host, db, port, username, password, options, callback) {
+function init(host, db, port, options, callback) {
     /*jshint camelcase:false, validthis:true */
     var hosts,
         url,
-        credentials = '',
         retries = 0,
         lastError,
         maxRetries = (config.getConfig().mongodb && config.getConfig().mongodb.retries ||
             constants.DEFAULT_MONGODB_RETRIES);
 
-    if (username && password) {
-        credentials = username + ':' + password + '@';
-    }
 
     function addPort(item) {
         return item + ':' + port;
@@ -83,15 +79,8 @@ function init(host, db, port, username, password, options, callback) {
         .map(addPort)
         .reduce(commaConcat, '');
 
-    url = 'mongodb://' + credentials + hosts + '/' + db;
+    url = 'mongodb://' + hosts + '/' + db;
 
-    if (options.replicaSet) {
-        url += '?replicaSet=' + options.replicaSet.rs_name;
-    }
-
-    if (options.authSource) {
-        url += (options.replicaSet ? '&' : '?') + 'authSource=' + options.authSource.db_name;
-    }
 
     function createConnectionHandler(error, results) {
         if (defaultDb) {
@@ -196,20 +185,20 @@ function configureDb(callback) {
             }
 
             if (currentConfig.mongodb.replicaSet) {
-                options.replset = { rs_name: currentConfig.mongodb.replicaSet };
+                options.replicaSet = currentConfig.mongodb.replicaSet;
             }
 
             if (currentConfig.mongodb.user && currentConfig.mongodb.password) {
-                currentConfig.username = currentConfig.mongodb.user;
-                currentConfig.password = currentConfig.mongodb.password;
+                options.auth = {};
+                options.auth.user = currentConfig.mongodb.user;
+                options.auth.password = currentConfig.mongodb.password;
             }
 
             if (currentConfig.mongodb.authSource) {
-                options.authSource = {db_name: currentConfig.mongodb.authSource};
+                options.authSource = currentConfig.mongodb.authSource;
             }
 
-            init(config.getConfig().mongodb.host, dbName, port,
-                currentConfig.username, currentConfig.password, options, callback);
+            init(config.getConfig().mongodb.host, dbName, port, options, callback);
         }
     } else {
         callback();


### PR DESCRIPTION
With this pr the mongodb authentication is fixed. Here I have incorporated the suggestions of @srrspace mentioned here https://github.com/telefonicaid/iotagent-node-lib/commit/13f67ead5327ebdcd97a7b7858ac64a361ad9655 . Username, Password, AuthSource and ReplicaSet are no longer written in the connection string but in the options. The option parameter are looked up here http://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html#connect .

I tested it with a mongodb with replicaset and authentication and without replicaset and authentication.