### PR TITLE
fix jexl transformation expression when is  a JSON based value

### DIFF
--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -133,12 +133,12 @@ function expressionApplier(context, typeInformation) {
         else if (attribute.type === 'None') {
             newAttribute.value = null;
         }
-        else if (attribute.type === 'Text') {
+        else if (attribute.type === 'Text' || attribute.type === 'String') {
             newAttribute.value = String(newAttribute.value);
         }
-        else if (attribute.type !== 'StructuredValue') {
-            newAttribute.value = String(newAttribute.value);
-        }
+        //else if (attribute.type !== 'StructuredValue') {
+        //    newAttribute.value = String(newAttribute.value);
+        //}
 
         return newAttribute;
     };

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -140,7 +140,7 @@ function expressionApplier(context, typeInformation) {
             newAttribute.value = String(newAttribute.value);
         }
         else if (attribute.type.toLowerCase().includes('structuredvalue') ||
-                 attribute.type.toLowerCase().startWith('geo') ||
+                 attribute.type.toLowerCase().startsWith('geo') ||
                  attribute.type.toLowerCase().includes('json') ) {
             newAttribute.value = newAttribute.value;
         } else {

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -162,7 +162,6 @@ function contextAvailable(expression, context) {
       return token.type === 'identifier';
     });
     var keys = Object.keys(context);
-    // print context to see where is type
     var validContext = true;
     identifiers.some(function(element) {
       if (!keys.includes(element.value) && !isTransform(element.value)) {

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -46,7 +46,7 @@ function parse(expression, context, callback) {
     try {
       
         result = jexl.evalSync (expression, context);
-
+        logger.debug(logContext, 'parse expression result "[%j]" ', result);
     } catch (e) {
       error = new errors.InvalidExpression(expression);
       if (callback) {
@@ -93,7 +93,10 @@ function extractContext(attributeList) {
 }
 
 function applyExpression(expression, context, typeInformation) {
-    return jexl.evalSync (expression, context);
+    var result;
+    result = jexl.evalSync (expression, context);
+    logger.debug(logContext, 'applyExpression result "[%j]" ', result);
+    return result;
 }
 
 function expressionApplier(context, typeInformation) {
@@ -136,10 +139,13 @@ function expressionApplier(context, typeInformation) {
         else if (attribute.type === 'Text' || attribute.type === 'String') {
             newAttribute.value = String(newAttribute.value);
         }
-        //else if (attribute.type !== 'StructuredValue') {
-        //    newAttribute.value = String(newAttribute.value);
-        //}
-
+        else if (attribute.type.toLowerCase().includes('structuredvalue') ||
+                 attribute.type.toLowerCase().startWith('geo') ||
+                 attribute.type.toLowerCase().includes('json') ) {
+            newAttribute.value = newAttribute.value;
+        } else {
+            newAttribute.value = String(newAttribute.value);
+        }
         return newAttribute;
     };
 }
@@ -156,12 +162,17 @@ function contextAvailable(expression, context) {
       return token.type === 'identifier';
     });
     var keys = Object.keys(context);
+    // print context to see where is type
     var validContext = true;
     identifiers.some(function(element) {
       if (!keys.includes(element.value) && !isTransform(element.value)) {
         validContext = false;
         logger.warn(logContext, 'For expression "[%s]" context does not have element %s' , expression, element.value);
-      } 
+      }
+      // FIXME: Workaround to allow keys of JSON geopoints
+      if (element.value === "type" || element.value === "coordinates") {
+        validContext = true;
+      }
       return validContext === false;
     });
     if(validContext) {

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -170,7 +170,7 @@ function contextAvailable(expression, context) {
         logger.warn(logContext, 'For expression "[%s]" context does not have element %s' , expression, element.value);
       }
       // FIXME: Workaround to allow keys of JSON geopoints
-      if (element.value === "type" || element.value === "coordinates") {
+      if (element.value === 'type' || element.value === 'coordinates') {
         validContext = true;
       }
       return validContext === false;


### PR DESCRIPTION
bug in previos PR https://github.com/telefonicaid/iotagent-node-lib/pull/861
to avoid json expression will be transformed to [object Object]

```
{
            "name" : "mylocation",
            "type" : "geo:json",
            "expression" : "{type: \"Point\", coordinates: [lat,lon]}"
        }
```

No CNR update is needed since is reopen a previous PR