### PR TITLE
Security improvement: Move secret support within Node

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 Fix: Static attributes from service not applied if device has static attributes (#757)
+Move Docker secret support inside the Node Application - remove Entrypoint (#885)

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -179,18 +179,18 @@ function processEnvironmentVariables() {
             'IOTA_MONGO_PASSWORD'
         ];
 
+    // Substitute Docker Secret Variables where set.
+    protectedVariables.forEach((key) => {
+        getSecretData(key);
+    });
     environmentVariables.forEach((key) => {
         let value = process.env[key];
         if (value) {
-            if (key.endsWith('USER') || key.endsWith('PASSWORD')) {
+            if (key.endsWith('USER') || key.endsWith('PASSWORD') || key.endsWith('CLIENT_ID') || key.endsWith('CLIENT_SECRET')) {
                 value = '********';
             }
             logger.info('Setting %s to environment value: %s', key, value);
         }
-    });
-    // Substitute Docker Secret Variables where set.
-    protectedVariables.forEach((key) => {
-        getSecretData(key);
     });
 
     // Context Broker Configuration (ensuring the configuration sub-object exists before start using it)

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -186,7 +186,10 @@ function processEnvironmentVariables() {
     environmentVariables.forEach((key) => {
         let value = process.env[key];
         if (value) {
-            if (key.endsWith('USER') || key.endsWith('PASSWORD') || key.endsWith('CLIENT_ID') || key.endsWith('CLIENT_SECRET')) {
+            if (key.endsWith('USER') || 
+                key.endsWith('PASSWORD') || 
+                key.endsWith('CLIENT_ID') || 
+                key.endsWith('CLIENT_SECRET')) {
                 value = '********';
             }
             logger.info('Setting %s to environment value: %s', key, value);

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -34,6 +34,9 @@ var config = {},
     commandRegistry,
     securityService;
 
+const secrets = require('@cloudreach/docker-secrets');
+const path = require('path');
+
 function anyIsSet(variableSet) {
     for (var i = 0; i < variableSet.length; i++) {
         if (process.env[variableSet[i]]) {
@@ -45,55 +48,105 @@ function anyIsSet(variableSet) {
 }
 
 /**
+ * If an ENV is a protected Docker Secret extract the value of the secret data
+ */
+function getSecretData(key) {
+    const filepath = process.env[key + '_FILE'];
+    if (!!filepath) {
+        process.env[key] = secrets[path.parse(filepath).base] || process.env[key];
+    }
+}
+
+/*
+*  Inform the user if security is correctly enabled.
+*/
+function logAuthState() {
+
+    const stars = '***********************************************';
+    if (config.authentication === undefined) {
+        logger.warn(
+            stars +
+                '\n' +
+                'WARNING: authentication for secure connections is not in use,\n' +
+                'It is recommended to enable authentication\n' +
+                stars
+        );
+    } else {
+        const authKeystone = !!config.authentication.user && 
+            !!config.authentication.password;
+        const authKeyrock = !!config.authentication.clientSecret &&
+            !!config.authentication.clientId;
+            
+        if (authKeystone) {
+            logger.info(
+                'INFO: IoT Agent=>Keystone Auth credentials have been configured'
+            );
+        } else if (authKeyrock) {
+            logger.info(
+                'INFO: IoT Agent=>Keyrock Auth credentials have been configured'
+            );
+        } else {
+            logger.warn(
+                stars +
+                    '\n' +
+                    'WARNING: authentication for secure connections is in use,\n' +
+                    ' but default Auth credentials have not been overridden\n' +
+                    stars
+            );
+        }
+    }
+}
+
+/**
  * Looks for environment variables that could override configuration values.
  */
 function processEnvironmentVariables() {
     var environmentVariables = [
-             'IOTA_CB_URL',
-             'IOTA_CB_HOST',
-             'IOTA_CB_PORT',
-             'IOTA_CB_NGSI_VERSION',
-             'IOTA_NORTH_HOST',
-             'IOTA_NORTH_PORT',
-             'IOTA_PROVIDER_URL',
-             'IOTA_AUTH_ENABLED',
-             'IOTA_AUTH_TYPE',
-             'IOTA_AUTH_HEADER',
-             'IOTA_AUTH_URL',
-             'IOTA_AUTH_HOST',
-             'IOTA_AUTH_PORT',
-             'IOTA_AUTH_USER',
-             'IOTA_AUTH_PASSWORD',
-             'IOTA_AUTH_CLIENT_ID',
-             'IOTA_AUTH_CLIENT_SECRET',
-             'IOTA_AUTH_TOKEN_PATH',
-             'IOTA_AUTH_PERMANENT_TOKEN',
-             'IOTA_REGISTRY_TYPE',
-             'IOTA_LOG_LEVEL',
-             'IOTA_TIMESTAMP',
-             'IOTA_IOTAM_HOST',
-             'IOTA_IOTAM_PORT',
-             'IOTA_IOTAM_PATH',
-             'IOTA_IOTAM_PROTOCOL',
-             'IOTA_IOTAM_DESCRIPTION',
-             'IOTA_DEFAULT_RESOURCE',
-             'IOTA_DEFAULT_EXPLICITATTRS',
-             'IOTA_MONGO_HOST',
-             'IOTA_MONGO_PORT',
-             'IOTA_MONGO_DB',
-             'IOTA_MONGO_REPLICASET',
-             'IOTA_AUTOCAST',
-             'IOTA_MONGO_PASSWORD',
-             'IOTA_MONGO_AUTH_SOURCE',
-             'IOTA_MONGO_RETRIES',
-             'IOTA_MONGO_USER',
-             'IOTA_MONGO_RETRY_TIME',
-             'IOTA_SINGLE_MODE',
-             'IOTA_APPEND_MODE',
-             'IOTA_POLLING_EXPIRATION',
-             'IOTA_POLLING_DAEMON_FREQ',
-             'IOTA_MULTI_CORE',
-             'IOTA_DEFAULT_EXPRESSION_LANGUAGE'
+            'IOTA_CB_URL',
+            'IOTA_CB_HOST',
+            'IOTA_CB_PORT',
+            'IOTA_CB_NGSI_VERSION',
+            'IOTA_NORTH_HOST',
+            'IOTA_NORTH_PORT',
+            'IOTA_PROVIDER_URL',
+            'IOTA_AUTH_ENABLED',
+            'IOTA_AUTH_TYPE',
+            'IOTA_AUTH_HEADER',
+            'IOTA_AUTH_URL',
+            'IOTA_AUTH_HOST',
+            'IOTA_AUTH_PORT',
+            'IOTA_AUTH_USER',
+            'IOTA_AUTH_PASSWORD',
+            'IOTA_AUTH_CLIENT_ID',
+            'IOTA_AUTH_CLIENT_SECRET',
+            'IOTA_AUTH_TOKEN_PATH',
+            'IOTA_AUTH_PERMANENT_TOKEN',
+            'IOTA_REGISTRY_TYPE',
+            'IOTA_LOG_LEVEL',
+            'IOTA_TIMESTAMP',
+            'IOTA_IOTAM_HOST',
+            'IOTA_IOTAM_PORT',
+            'IOTA_IOTAM_PATH',
+            'IOTA_IOTAM_PROTOCOL',
+            'IOTA_IOTAM_DESCRIPTION',
+            'IOTA_DEFAULT_RESOURCE',
+            'IOTA_DEFAULT_EXPLICITATTRS',
+            'IOTA_MONGO_HOST',
+            'IOTA_MONGO_PORT',
+            'IOTA_MONGO_DB',
+            'IOTA_MONGO_REPLICASET',
+            'IOTA_AUTOCAST',
+            'IOTA_MONGO_PASSWORD',
+            'IOTA_MONGO_AUTH_SOURCE',
+            'IOTA_MONGO_RETRIES',
+            'IOTA_MONGO_USER',
+            'IOTA_MONGO_RETRY_TIME',
+            'IOTA_SINGLE_MODE',
+            'IOTA_APPEND_MODE',
+            'IOTA_POLLING_EXPIRATION',
+            'IOTA_POLLING_DAEMON_FREQ',
+            'IOTA_MULTI_CORE',
+            'IOTA_DEFAULT_EXPRESSION_LANGUAGE'
         ],
         iotamVariables = [
             'IOTA_IOTAM_URL',
@@ -116,17 +169,29 @@ function processEnvironmentVariables() {
             'IOTA_MONGO_RETRY_TIME',
             'IOTA_MONGO_SSL',
             'IOTA_MONGO_EXTRAARGS'
+        ],
+        protectedVariables = [
+            'IOTA_AUTH_USER',
+            'IOTA_AUTH_PASSWORD',
+            'IOTA_AUTH_CLIENT_ID',
+            'IOTA_AUTH_CLIENT_SECRET',
+            'IOTA_MONGO_USER',
+            'IOTA_MONGO_PASSWORD'
         ];
 
-    for (var i = 0; i < environmentVariables.length; i++) {
-        var value = process.env[environmentVariables[i]];
+    environmentVariables.forEach((key) => {
+        let value = process.env[key];
         if (value) {
-            if (environmentVariables[i].endsWith('USER') || environmentVariables[i].endsWith('PASSWORD')) {
+            if (key.endsWith('USER') || key.endsWith('PASSWORD')) {
                 value = '********';
             }
-            logger.info('Setting %s to environment value: %s', environmentVariables[i], value);
+            logger.info('Setting %s to environment value: %s', key, value);
         }
-    }
+    });
+    // Substitute Docker Secret Variables where set.
+    protectedVariables.forEach((key) => {
+        getSecretData(key);
+    });
 
     // Context Broker Configuration (ensuring the configuration sub-object exists before start using it)
     if (config.contextBroker === undefined) {
@@ -176,7 +241,8 @@ function processEnvironmentVariables() {
     // Authentication Parameters - General
     if (process.env.IOTA_AUTH_ENABLED) {
         config.authentication = {};
-        config.authentication.enabled = process.env.IOTA_AUTH_ENABLED === 'true';
+        config.authentication.enabled =
+            process.env.IOTA_AUTH_ENABLED === 'true';
     }
     if (process.env.IOTA_AUTH_TYPE) {
         config.authentication.type = process.env.IOTA_AUTH_TYPE;
@@ -206,14 +272,16 @@ function processEnvironmentVariables() {
         config.authentication.clientId = process.env.IOTA_AUTH_CLIENT_ID;
     }
     if (process.env.IOTA_AUTH_CLIENT_SECRET) {
-        config.authentication.clientSecret = process.env.IOTA_AUTH_CLIENT_SECRET;
+        config.authentication.clientSecret =
+            process.env.IOTA_AUTH_CLIENT_SECRET;
     }
     if (process.env.IOTA_AUTH_TOKEN_PATH) {
         config.authentication.tokenPath = process.env.IOTA_AUTH_TOKEN_PATH;
     }
     // Authentication Parameters - Keyrock only
     if (process.env.IOTA_AUTH_PERMANENT_TOKEN) {
-        config.authentication.permanentToken = process.env.IOTA_AUTH_PERMANENT_TOKEN;
+        config.authentication.permanentToken =
+            process.env.IOTA_AUTH_PERMANENT_TOKEN;
     }
     // Authentication Parameters - Keystone only
     if (process.env.IOTA_AUTH_USER) {
@@ -224,8 +292,8 @@ function processEnvironmentVariables() {
     }
 
     // Registry configuration (memory or database)
+    config.deviceRegistry = config.deviceRegistry || {};
     if (process.env.IOTA_REGISTRY_TYPE) {
-        config.deviceRegistry = {};
         config.deviceRegistry.type = process.env.IOTA_REGISTRY_TYPE;
     }
 
@@ -324,13 +392,18 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_MONGO_SSL) {
-        config.mongodb.ssl = process.env.IOTA_MONGO_SSL.toLowerCase() === 'true';
+        config.mongodb.ssl =
+            process.env.IOTA_MONGO_SSL.toLowerCase() === 'true';
     }
 
     if (process.env.IOTA_MONGO_EXTRAARGS) {
         try {
             var ea = JSON.parse(process.env.IOTA_MONGO_EXTRAARGS);
-            if (ea !== null && typeof(ea) === 'object' && ea.constructor === Object) {
+            if (
+                ea !== null &&
+                typeof ea === 'object' &&
+                ea.constructor === Object
+            ) {
                 config.mongodb.extraArgs = ea;
             }
         } catch (e) {}
@@ -338,7 +411,8 @@ function processEnvironmentVariables() {
 
     // Other configuration properties
     if (process.env.IOTA_SINGLE_MODE) {
-        config.singleConfigurationMode = process.env.IOTA_SINGLE_MODE === 'true';
+        config.singleConfigurationMode =
+            process.env.IOTA_SINGLE_MODE === 'true';
     }
 
     if (process.env.IOTA_APPEND_MODE) {
@@ -364,9 +438,9 @@ function processEnvironmentVariables() {
     }
 
     if (process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE) {
-        config.defaultExpressionLanguage = process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE;
+        config.defaultExpressionLanguage =
+            process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE;
     }
-
 }
 
 function setConfig(newConfig) {
@@ -377,6 +451,7 @@ function setConfig(newConfig) {
     }
 
     processEnvironmentVariables();
+    logAuthState();
 }
 
 function getConfig() {
@@ -413,9 +488,11 @@ function getCommandRegistry() {
  * @return     {boolean}  Result of the checking
  */
 function checkNgsi2() {
-    if (config.contextBroker &&
+    if (
+        config.contextBroker &&
         config.contextBroker.ngsiVersion &&
-        config.contextBroker.ngsiVersion === 'v2') {
+        config.contextBroker.ngsiVersion === 'v2'
+    ) {
         return true;
     }
 
@@ -430,6 +507,7 @@ function getSecurityService() {
     return securityService;
 }
 
+
 exports.setConfig = setConfig;
 exports.getConfig = getConfig;
 exports.setRegistry = setRegistry;
@@ -441,3 +519,4 @@ exports.getCommandRegistry = getCommandRegistry;
 exports.checkNgsi2 = checkNgsi2;
 exports.setSecurityService = setSecurityService;
 exports.getSecurityService = getSecurityService;
+exports.getSecretData = getSecretData;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
-    "@cloudreach/docker-secrets": "^1.0.3",
+    "@cloudreach/docker-secrets": "~1.0.3",
     "async": "2.6.2",
     "body-parser": "~1.19.0",
     "command-shell-lib": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
+    "@cloudreach/docker-secrets": "^1.0.3",
     "async": "2.6.2",
     "body-parser": "~1.19.0",
     "command-shell-lib": "1.0.0",

--- a/test/unit/ngsiv2/general/startup-test.js
+++ b/test/unit/ngsiv2/general/startup-test.js
@@ -292,4 +292,59 @@ describe('NGSI-v2 - Startup tests', function() {
             });
         });
     });
+
+
+    describe('When the IoT Agent is started with Keystone', function() {
+        beforeEach(function() {
+            process.env.IOTA_AUTH_ENABLED = 'true';
+            process.env.IOTA_AUTH_USER = '1111';
+            process.env.IOTA_AUTH_PASSWORD = 'xxxx';
+            
+        });
+
+        afterEach(function() {
+            delete process.env.IOTA_AUTH_ENABLED;
+            delete process.env.IOTA_AUTH_USER;
+            delete process.env.IOTA_AUTH_PASSWORD;
+        });
+
+        afterEach(function(done) {
+            iotAgentLib.deactivate(done);
+        });
+
+        it('should load the correct configuration parameters', function(done) {
+            iotAgentLib.activate(iotAgentConfig, function(error) {
+                config.getConfig().authentication.user.should.equal('1111');
+                config.getConfig().authentication.password.should.equal('xxxx');
+                done();
+            });
+        });
+    });
+
+    describe('When the IoT Agent is started with Keyrock', function() {
+        beforeEach(function() {
+            process.env.IOTA_AUTH_ENABLED = 'true';
+            process.env.IOTA_AUTH_CLIENT_ID = '1111';
+            process.env.IOTA_AUTH_CLIENT_SECRET = 'xxxx';
+            
+        });
+
+        afterEach(function() {
+            delete process.env.IOTA_AUTH_ENABLED;
+            delete process.env.IOTA_AUTH_CLIENT_ID;
+            delete process.env.IOTA_AUTH_CLIENT_SECRET;
+        });
+
+        afterEach(function(done) {
+            iotAgentLib.deactivate(done);
+        });
+
+        it('should load the correct configuration parameters', function(done) {
+            iotAgentLib.activate(iotAgentConfig, function(error) {
+                config.getConfig().authentication.clientId.should.equal('1111');
+                config.getConfig().authentication.clientSecret.should.equal('xxxx');
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Currently the Docker Secret and Password processing lies within an entrypoint bash file e.g.: 

https://github.com/telefonicaid/iotagent-ul/blob/master/docker/entrypoint.sh

From a security perspective this isn't ideal, as the dockerization will be Node.js + bash script combination. This means the application can never be run *Distroless* as it relies on bash, and therefore offers a wider attack profile.

https://medium.com/@dwdraju/distroless-is-for-security-if-not-for-size-6eac789f695f

This PR moves as much of the bash scripting as possible inside the Node app, which will allow for the creation of smaller, securer *Distroless* Docker images.

A sample *Distroless* build can be found here: https://github.com/FIWARE/tutorials.Step-by-Step/blob/master/docker/Dockerfile 


```Dockerfile
# Create an anonymous user
RUN sed -i -r "/^(root|nobody)/!d" /etc/passwd /etc/shadow /etc/group \
    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd


# Remove the distro as part of a two stage build.
FROM gcr.io/distroless/nodejs:${NODE_MAJOR_VERSION}
COPY --from=build-env /usr/src/app /usr/src/app
USER nobody
WORKDIR /usr/src/app

# Ports used by application
EXPOSE ${WEB_APP_PORT:-3000} ${DUMMY_DEVICES_PORT:-3001}
# Start the application
CMD ["./bin/www"]

HEALTHCHECK NONE
```

This style of Dockerization could be ported over to the IoT Agents themselves and the bash script removed.

