### PR TITLE
fix: NGSI-LD v1.2.1 and v1.3.1 success response codes on entities creation / update

### DIFF
--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -76,7 +76,7 @@ function createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback) {
             alarms.raise(constants.ORION_ALARM, error);
 
             callback(error);
-        } else if (response && response.statusCode === 204) {
+        } else if (response && (response.statusCode === 200 || response.statusCode == 201 || response.statusCode == 204)) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Initial entity created successfully.');
             callback(null, newDevice);
@@ -118,7 +118,7 @@ function updateEntityHandlerNgsiLD(deviceData, updatedDevice, callback) {
             alarms.raise(constants.ORION_ALARM, error);
 
             callback(error);
-        } else if (response && response.statusCode === 204) {
+        } else if (response && (response.statusCode === 200 || response.statusCode == 204)) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Entity updated successfully.');
             callback(null, updatedDevice);

--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -76,7 +76,11 @@ function createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback) {
             alarms.raise(constants.ORION_ALARM, error);
 
             callback(error);
-        } else if (response && (response.statusCode === 200 || response.statusCode == 201 || response.statusCode == 204)) {
+        }
+        // Handling different response codes for batch entity upsert in NGSI-LD specification:
+        // - In v1.2.1, response code is 200
+        // - In v1.3.1, response code is 201 if some created entities, 204 if just updated existing
+        else if (response && (response.statusCode === 200 || response.statusCode == 201 || response.statusCode == 204)) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Initial entity created successfully.');
             callback(null, newDevice);
@@ -118,7 +122,11 @@ function updateEntityHandlerNgsiLD(deviceData, updatedDevice, callback) {
             alarms.raise(constants.ORION_ALARM, error);
 
             callback(error);
-        } else if (response && (response.statusCode === 200 || response.statusCode == 204)) {
+        }
+        // Handling different response codes for batch entity upsert in NGSI-LD specification:
+        // - In v1.2.1, response code is 200
+        // - In v1.3.1, response code is 204 (not handling 201 as entities already previously created)
+        else if (response && (response.statusCode === 200 || response.statusCode == 204)) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Entity updated successfully.');
             callback(null, updatedDevice);

--- a/test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js
@@ -593,6 +593,121 @@ describe('NGSI-LD - Device provisioning API: Provision devices', function() {
         });
     });
 
+    describe('When the Context Broker returns an unrecognized status code provisioning an entity', function() {
+        const options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/examples/deviceProvisioningRequests/provisionMinimumDevice.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function(done) {
+            nock.cleanAll();
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .post(
+                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    utils.readExampleFile(
+                        './test/unit/ngsi-ld/examples/' + 'contextRequests/createMinimumProvisionedDevice.json'
+                    )
+                )
+                .reply(207);
+
+            done();
+        });
+
+        it('should return an error message in the response body', function(done) {
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                response.body.name.should.equal('ENTITY_GENERIC_ERROR');
+                response.body.message.should.equal('Error accesing entity data for device: MicroLight1 of type: MicroLights');
+                response.statusCode.should.equal(200);
+
+                done();
+            });
+        });
+    });
+
+    describe('When the Context Broker returns a 200 status code (NGSI-LD v1.2.1) provisioning an entity', function() {
+        const options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+            method: 'POST',
+            json: utils.readExampleFile('./test/unit/examples/deviceProvisioningRequests/provisionMinimumDevice.json'),
+            headers: {
+                'fiware-service': 'smartGondor',
+                'fiware-servicepath': '/gardens'
+            }
+        };
+
+        beforeEach(function(done) {
+            nock.cleanAll();
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .post(
+                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    utils.readExampleFile(
+                        './test/unit/ngsi-ld/examples/' + 'contextRequests/createMinimumProvisionedDevice.json'
+                    )
+                )
+                .reply(200);
+
+            done();
+        });
+
+        it('should be considered as a successful provisioning of the entity', function(done) {
+            request(options, function(error, response, body) {
+                should.not.exist(error);
+                response.body.should.be.empty();
+                response.statusCode.should.equal(201);
+
+                done();
+            });
+        });
+    });
+
+    describe(
+        'When the Context Broker returns a 201 status code (NGSI-LD v1.3.1 - created entities) provisioning an entity', 
+        function() {
+            const options = {
+                url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
+                method: 'POST',
+                json: utils.readExampleFile('./test/unit/examples/deviceProvisioningRequests/provisionMinimumDevice.json'),
+                headers: {
+                    'fiware-service': 'smartGondor',
+                    'fiware-servicepath': '/gardens'
+                }
+            };
+
+            beforeEach(function(done) {
+                nock.cleanAll();
+                contextBrokerMock = nock('http://192.168.1.1:1026')
+                    .matchHeader('fiware-service', 'smartGondor')
+                    .post(
+                        '/ngsi-ld/v1/entityOperations/upsert/',
+                        utils.readExampleFile(
+                            './test/unit/ngsi-ld/examples/' + 'contextRequests/createMinimumProvisionedDevice.json'
+                        )
+                    )
+                    .reply(201);
+
+                done();
+            });
+
+            it('should be considered as a successful provisioning of the entity', function(done) {
+                request(options, function(error, response, body) {
+                    should.not.exist(error);
+                    response.body.should.be.empty();
+                    response.statusCode.should.equal(201);
+
+                    done();
+                });
+            });
+        }
+    );
+
     describe('When there is a connection error with a String code connecting the CB', function() {
         const options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',


### PR DESCRIPTION
- In v1.2.1, response code is 200 (the current official version)
- In v1.3.1, response code is 201 if some created entities, 204 if just updated existing (the soon to be released version)

This PR aims at handling these differences in the response code when creating or updating entities in the context broker.