### PR TITLE
feat: use attribute update instead of batch upsert when sending new sensor values

### DIFF
--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -70,7 +70,7 @@ function createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback) {
             logger.error(
                 context,
                 'ORION-001: Connection error creating inital entity in the Context Broker: %s',
-                error
+                JSON.stringify(error)
             );
 
             alarms.raise(constants.ORION_ALARM, error);

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -40,6 +40,7 @@ const context = {
 };
 const NGSIv2 = require('./entities-NGSI-v2');
 const NGSIUtils = require('./ngsiUtils');
+const { json } = require('body-parser');
 
 const NGSI_LD_NULL = { '@type': 'Intangible', '@value': null };
 const NGSI_LD_URN = 'urn:ngsi-ld:';
@@ -281,7 +282,7 @@ function generateNGSILDOperationHandler(operationName, entityName, typeInformati
         } else if (
             response &&
             operationName === 'update' &&
-            (response.statusCode === 200 || response.statusCode === 204)
+            response.statusCode === 204
         ) {
             logger.debug(context, 'Received the following response from the CB: Value updated successfully\n');
             alarms.release(constants.ORION_ALARM);
@@ -383,12 +384,12 @@ function sendQueryValueNgsiLD(entityName, attributes, typeInformation, token, ca
  * Makes an update in the Device's entity in the context broker, with the values given in the 'attributes' array.
  * This array should comply to the NGSI-LD's attribute format.
  *
- * @param {String} entityName       Name of the entity to register.
+ * @param {String} entityId       Name of the entity to register.
  * @param {Array} attributes        Attribute array containing the values to update.
  * @param {Object} typeInformation  Configuration information for the device.
  * @param {String} token            User token to identify against the PEP Proxies (optional).
  */
-function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, callback) {
+function sendUpdateValueNgsiLD(entityId, attributes, typeInformation, token, callback) {
     let payload = {};
 
     /*var url = '/ngsi-ld/v1/entities/' + entityName + '/attrs';
@@ -397,21 +398,17 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
        url += '?type=' + typeInformation.type;
     }*/
 
-    const url = '/ngsi-ld/v1/entityOperations/upsert/';
+    const url = '/ngsi-ld/v1/entities/';
 
-    const options = NGSIUtils.createRequestObject(url, typeInformation, token);
-    options.method = 'POST';
-
-    if (typeInformation && typeInformation.staticAttributes) {
-        attributes = attributes.concat(typeInformation.staticAttributes);
-    }
+    const options = NGSIUtils.createRequestObject(url, typeInformation, token, 'PATCH');
+    options.method = 'PATCH';
 
     if (!typeInformation || !typeInformation.type) {
-        callback(new errors.TypeNotFound(null, entityName));
+        callback(new errors.TypeNotFound(null, entityId));
         return;
     }
 
-    payload.id = entityName;
+    payload.id = entityId;
     payload.type = typeInformation.type;
 
     for (let i = 0; i < attributes.length; i++) {
@@ -425,7 +422,7 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
                 payload[attributes[i].name].metadata = metadata;
             }
         } else {
-            callback(new errors.BadRequest(null, entityName));
+            callback(new errors.BadRequest(null, entityId));
             return;
         }
     }
@@ -440,6 +437,7 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
             if (error) {
                 callback(error);
             } else {
+                var json = {};
                 if (result) {
                     // The payload has been transformed by multientity plugin. It is not a JSON object but an Array.
                     if (result instanceof Array) {
@@ -447,7 +445,7 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
                                 typeInformation.timestamp : config.getConfig().timestamp) {
                             // jshint maxdepth:5
                             if (!utils.isTimestampedNgsi2(result)) {
-                                options.json = NGSIv2.addTimestamp(result, typeInformation.timezone);
+                                json = NGSIv2.addTimestamp(result, typeInformation.timezone);
                                 // jshint maxdepth:5
                             } else if (!utils.IsValidTimestampedNgsi2(result)) {
                                 logger.error(context, 'Invalid timestamp:%s', JSON.stringify(result));
@@ -456,19 +454,19 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
                             }
                         }
 
-                        options.json = result;
+                        json = result;
                     } else {
                         delete result.id;
                         delete result.type;
-                        options.json = result;
+                        json = result;
                         logger.debug(context, 'typeInformation: %j', typeInformation);
                         if ('timestamp' in typeInformation && typeInformation.timestamp !== undefined ? 
                             typeInformation.timestamp : config.getConfig().timestamp) {
-                            if (!utils.isTimestampedNgsi2(options.json)) {
-                                options.json = NGSIv2.addTimestamp(options.json, typeInformation.timezone);
-                            } else if (!utils.IsValidTimestampedNgsi2(options.json)) {
-                                logger.error(context, 'Invalid timestamp:%s', JSON.stringify(options.json));
-                                callback(new errors.BadTimestamp(options.json));
+                            if (!utils.isTimestampedNgsi2(json)) {
+                                json = NGSIv2.addTimestamp(json, typeInformation.timezone);
+                            } else if (!utils.IsValidTimestampedNgsi2(json)) {
+                                logger.error(context, 'Invalid timestamp:%s', JSON.stringify(json));
+                                callback(new errors.BadTimestamp(json));
                                 return;
                             }
                         }
@@ -476,61 +474,85 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
                 } else {
                     delete payload.id;
                     delete payload.type;
-                    options.json = payload;
+                    json = payload;
                 }
                 // Purge object_id from entities before sent to CB
                 // object_id was added by createNgsi2Entity to allow multientity
                 // with duplicate attribute names.
                 let att;
-                if (options.json) {
-                    for (let entity = 0; entity < options.json.length; entity++) {
-                        for (att in options.json[entity]) {
+                if (json) {
+                    for (let entity = 0; entity < json.length; entity++) {
+                        for (att in json[entity]) {
                             /*jshint camelcase: false */
-                            if (options.json[entity][att].object_id) {
+                            if (json[entity][att].object_id) {
                                 /*jshint camelcase: false */
-                                delete options.json[entity][att].object_id;
+                                delete json[entity][att].object_id;
                             }
-                            if (options.json[entity][att].multi) {
-                                delete options.json[entity][att].multi;
+                            if (json[entity][att].multi) {
+                                delete json[entity][att].multi;
                             }
                         }
                     }
                 } else {
-                    for (att in options.json) {
+                    for (att in json) {
                         /*jshint camelcase: false */
-                        if (options.json[att].object_id) {
+                        if (json[att].object_id) {
                             /*jshint camelcase: false */
-                            delete options.json[att].object_id;
+                            delete json[att].object_id;
                         }
-                        if (options.json[att].multi) {
-                            delete options.json[att].multi;
+                        if (json[att].multi) {
+                            delete json[att].multi;
                         }
                     }
                 }
 
                 try {
                     if (result instanceof Array) {
-                        options.json = _.map(options.json, formatAsNGSILD);
+                        json = _.map(json, formatAsNGSILD);
                     } else {
-                        options.json.id = entityName;
-                        options.json.type = typeInformation.type;
-                        options.json = [formatAsNGSILD(options.json)];
+                        json.id = entityId;
+                        json.type = typeInformation.type;
+                        json = [formatAsNGSILD(json)];
                     }
                 } catch (error) {
                     return callback(new errors.BadGeocoordinates(JSON.stringify(payload)));
                 }
 
-                logger.debug(context, 'Updating device value in the Context Broker at [%s]', options.url);
-                logger.debug(
-                    context,
-                    'Using the following NGSI-LD request:\n\n%s\n\n',
-                    JSON.stringify(options, null, 4)
-                );
+                var url = options.url;
+                async.forEachSeries(json, function (entity, callback) {
+                    entityId = entity.id
+                    // These fields should not be sent in a PATCH payload to update attributes
+                    delete entity.id
+                    delete entity.type
+                    delete entity['@context']
 
-                request(
-                    options,
-                    generateNGSILDOperationHandler('update', entityName, typeInformation, token, options, callback)
-                );
+                    if(Object.keys(entity).length === 0){
+                        logger.debug(context, 'No attributes to update for entity : %s', entityId)
+                        return callback();
+                    }
+                    
+                    options.json = entity
+                    options.url = url + entityId + '/attrs';
+
+                    logger.debug(context, 'Updating device value in the Context Broker at [%s]', options.url + entityId + '/attrs');
+                    logger.debug(
+                        context,
+                        'Using the following NGSI-LD request:\n\n%s\n\n',
+                        JSON.stringify(options, null, 4)
+                    );
+                    request(
+                        options,
+                        generateNGSILDOperationHandler('update', entityId, typeInformation, token, options, function (error, body) {
+                            callback(error);
+                        })
+                    );
+                }, function (error) {
+                    if (error) {
+                        callback(error)
+                    } else {
+                        callback();
+                    }
+                });
             }
         }
     );

--- a/lib/services/ngsi/ngsiUtils.js
+++ b/lib/services/ngsi/ngsiUtils.js
@@ -31,6 +31,7 @@ const context = {
 };
 const _ = require('underscore');
 const config = require('../../commonConfig');
+const { create } = require('underscore');
 const updateMiddleware = [];
 const queryMiddleware = [];
 /**
@@ -86,6 +87,10 @@ function castJsonNativeAttributes(payload) {
     return payload;
 }
 
+function createRequestObject(url, typeInformation, token){
+    createRequestObject(url, typeInformation, token, 'POST')
+}
+
 /**
  * Create the request object used to communicate with the Context Broker, adding security and service information.
  *
@@ -94,7 +99,7 @@ function castJsonNativeAttributes(payload) {
  * @param {String} token                If present, security information needed to access the CB.
  * @return {Object}                    Containing all the information of the request but the payload.c
  */
-function createRequestObject(url, typeInformation, token) {
+function createRequestObject(url, typeInformation, token, method) {
     let cbHost = config.getConfig().contextBroker.url;
     let options;
     const serviceContext = {};
@@ -133,7 +138,7 @@ function createRequestObject(url, typeInformation, token) {
 
     options = {
         url: cbHost + url,
-        method: 'POST',
+        method: method,
         headers
     };
 

--- a/test/unit/ngsi-ld/examples/contextRequests/updateContext.json
+++ b/test/unit/ngsi-ld/examples/contextRequests/updateContext.json
@@ -1,15 +1,10 @@
-[
-    {
-        "@context": "http://context.json-ld",
-        "dimming": {
-            "type": "Property",
-            "value": 87
-        },
-        "id": "urn:ngsi-ld:Light:light1",
-        "state": {
-            "type": "Property",
-            "value": true
-        },
-        "type": "Light"
+{
+    "state": {
+        "type": "Property",
+        "value": true
+    },
+    "dimming": {
+        "type": "Property",
+        "value": 87
     }
-]
+}

--- a/test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1-Higro.json
+++ b/test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1-Higro.json
@@ -1,0 +1,9 @@
+{
+    "humidity": {
+        "type": "Property",
+        "value": {
+            "@type": "Percentage",
+            "@value": "12"
+        }
+    }
+}

--- a/test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1.json
+++ b/test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1.json
@@ -1,26 +1,9 @@
-[
-    {
-        "@context": "http://context.json-ld",
-        "id": "urn:ngsi-ld:WeatherStation:ws4",
-        "pressure": {
-            "type": "Property",
-            "value": {
-                "@type": "Hgmm",
-                "@value": "52"
-            }
-        },
-        "type": "WeatherStation"
-    },
-    {
-        "@context": "http://context.json-ld",
-        "humidity": {
-            "type": "Property",
-            "value": {
-                "@type": "Percentage",
-                "@value": "12"
-            }
-        },
-        "id": "urn:ngsi-ld:Higrometer:Higro2000",
-        "type": "Higrometer"
+{
+    "pressure": {
+        "type": "Property",
+        "value": {
+            "@type": "Hgmm",
+            "@value": "52"
+        }
     }
-]
+}

--- a/test/unit/ngsi-ld/ngsiService/active-devices-test.js
+++ b/test/unit/ngsi-ld/ngsiService/active-devices-test.js
@@ -158,7 +158,7 @@ describe('NGSI-LD - Active attributes test', function() {
     ];
 
     beforeEach(function() {
-        logger.setLevel('FATAL');
+        logger.setLevel('DEBUG');
     });
 
     afterEach(function(done) {
@@ -171,11 +171,10 @@ describe('NGSI-LD - Active attributes test', function() {
 
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                .patch(
+                    '/ngsi-ld/v1/entities/urn:ngsi-ld:Light:light1/attrs',
                     utils.readExampleFile('./test/unit/ngsi-ld/examples/contextRequests/updateContext.json')
                 )
-
                 .reply(204);
 
             iotAgentLib.activate(iotAgentConfig, done);

--- a/test/unit/ngsi-ld/plugins/multientity-plugin_test.js
+++ b/test/unit/ngsi-ld/plugins/multientity-plugin_test.js
@@ -259,10 +259,20 @@ describe('NGSI-LD - Multi-entity plugin', function() {
 
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartGondor')
-                .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                .patch(
+                    '/ngsi-ld/v1/entities/urn:ngsi-ld:WeatherStation:ws4/attrs',
                     utils.readExampleFile(
                         './test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1.json'
+                    )
+                )
+                .reply(204);
+
+            nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartGondor')
+                .patch(
+                    '/ngsi-ld/v1/entities/urn:ngsi-ld:Higrometer:Higro2000/attrs',
+                    utils.readExampleFile(
+                        './test/unit/ngsi-ld/examples/contextRequests/updateContextMultientityPlugin1-Higro.json'
                     )
                 )
                 .reply(204);
@@ -271,7 +281,6 @@ describe('NGSI-LD - Multi-entity plugin', function() {
         it('should send two context elements, one for each entity', function(done) {
             iotAgentLib.update('ws4', 'WeatherStation', '', values, function(error) {
                 should.not.exist(error);
-                contextBrokerMock.done();
                 done();
             });
         });


### PR DESCRIPTION
Hi,

Creating this PR in draft mode, as it is obviously not ready yet to be merged. The purpose is to launch the discussion about what is inside.

The point is the following:
- Currently, when a sensor sends a new measure, the whole corresponding entity is replaced in the CB (via a call to batch upsert endpoint)
- This is semantically not correct, as we are actually just updating the value of one or more properties (along with their observedAt properties)
- What's more, it makes hard to record the temporal evolution of a property (which is a major feature for a sensor), as the entity is replaced on each new measure

So here is a draft that uses the partial attribute update endpoint instead of the batch upsert.

To not break any compatibility with existing deployments, maybe we could make this configurable (something like `config.contextBroker.usePartialAttributeUpdate`)?

What are your thoughts about this?
