### PR TITLE
Add common NGSI-LD constants

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -23,9 +23,7 @@
  * Modified by: Daniel Calvo - ATOS Research & Innovation
  */
 
-const LOCATION_TYPE = 'geo:point';
 const LOCATION_DEFAULT = '0, 0';
-const DATETIME_TYPE = 'DateTime';
 const DATETIME_DEFAULT = '1970-01-01T00:00:00.000Z';
 const ATTRIBUTE_DEFAULT = ' ';
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -36,10 +36,18 @@ const ATTRIBUTE_DEFAULT = ' ';
  * @return     {String}              A default value to use in the entity
  */
 function getInitialValueForType(type) {
-    switch (type) {
-        case LOCATION_TYPE:
+    switch (type.toLowerCase()) {
+        case 'geoproperty':
             return LOCATION_DEFAULT;
-        case DATETIME_TYPE:
+        case 'point':
+            return LOCATION_DEFAULT;
+        case 'geo:point':
+            return LOCATION_DEFAULT;
+        case 'datetime':
+            return DATETIME_DEFAULT;
+        case 'date':
+            return DATETIME_DEFAULT;
+        case 'time':
             return DATETIME_DEFAULT;
         default:
             return ATTRIBUTE_DEFAULT;


### PR DESCRIPTION
Add GeoProperty, Point , Date and Time types since GeoJSON is native in NGSI-LD. 

### NGSI-v2

The following provisioning statement is valid:

```console
curl -L -X POST 'http://localhost:4041/iot/services' \
-H 'fiware-service: openiot' \
-H 'fiware-servicepath: /' \
--data-raw '{
  "services": [
    {
      "apikey": "4jggokgpepnvsb2uv4s40d59ov",
      "cbroker": "http://orion:1026",
      "entity_type": "Device",
      "resource": "/iot/d",
      "attributes": [
        {
          "object_id":"bpm",
          "type":"Float",
          "name": "heartRate"
        },
        {
          "object_id": "s",
          "name": "status",
          "type": "String"
        },
        {
          "object_id": "gps",
          "name": "location",
          "type": "geo:point"
        }
      ]
    }
  ]
}'
```

### NGSI-LD

The following *equivalent* provisioning statement *should* be valid for NGSI-LD:

```console
curl -L -X POST 'http://localhost:4041/iot/services' \
-H 'fiware-service: openiot' \
-H 'fiware-servicepath: /' \
--data-raw '{
  "services": [
    {
      "apikey": "4jggokgpepnvsb2uv4s40d59ov",
      "cbroker": "http://orion:1026",
      "entity_type": "Device",
      "resource": "/iot/d",
      "attributes": [
        {
          "object_id":"bpm",
          "type":"Property",
          "name": "heartRate"
        },
        {
          "object_id": "s",
          "name": "status",
          "type": "Property"
        },
        {
          "object_id": "gps",
          "name": "location",
          "type": "GeoProperty"
        }
      ]
    }
  ]
}'
```

but currently fails since `GeoProperty` is not defined as an exception and the default `string` value `" "` is not valid GeoJSON.