### PR TITLE
Bug fix - command result.

### DIFF
--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -385,10 +385,10 @@ function handleQueryNgsiLD(req, res, next) {
                     callback(error);
                 } else if (innerDevice.count) {
                     callback(null, results);
-                } else if (Array.isArray(results) && results.length > 0) {
+                } else if (Array.isArray(results) && results.length > 1) {
                     callback(null, results);
                 } else {
-                    callback(null, results);
+                    callback(null, results[0]);
                 }
             });
         });

--- a/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationResponse.json
+++ b/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationResponse.json
@@ -1,10 +1,8 @@
-[
-    {
-        "dimming": {
-            "type": "Percentage",
-            "value": 19
-        },
-        "id": "Light:light1",
-        "type": "Light"
-    }
-]
+{
+    "dimming": {
+        "type": "Percentage",
+        "value": 19
+    },
+    "id": "Light:light1",
+    "type": "Light"
+}

--- a/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationResponseEmptyAttributes.json
+++ b/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationResponseEmptyAttributes.json
@@ -1,10 +1,8 @@
-[
-    {
-        "id": "Light:light1",
-        "temperature": {
-            "type": "centigrades",
-            "value": 19
-        },
-        "type": "Light"
-    }
-]
+{
+    "id": "Light:light1",
+    "temperature": {
+        "type": "centigrades",
+        "value": 19
+    },
+    "type": "Light"
+}

--- a/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationStaticAttributesResponse.json
+++ b/test/unit/ngsi-ld/examples/contextProviderResponses/queryInformationStaticAttributesResponse.json
@@ -1,14 +1,12 @@
-[
-    {
-        "id": "Motion:motion1",
-        "location": {
-            "type": "Vector",
-            "value": "(123,523)"
-        },
-        "moving": {
-            "type": "Boolean",
-            "value": true
-        },
-        "type": "Motion"
-    }
-]
+{
+    "id": "Motion:motion1",
+    "location": {
+        "type": "Vector",
+        "value": "(123,523)"
+    },
+    "moving": {
+        "type": "Boolean",
+        "value": true
+    },
+    "type": "Motion"
+}

--- a/test/unit/ngsi-ld/lazyAndCommands/lazy-devices-test.js
+++ b/test/unit/ngsi-ld/lazyAndCommands/lazy-devices-test.js
@@ -336,7 +336,7 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function() {
         it('should return the empty value', function(done) {
             request(options, function(error, response, body) {
                 const entities = body;
-                entities[0].dimming.value.should.equal('');
+                entities.dimming.value.should.equal('');
                 done();
             });
         });


### PR DESCRIPTION
When updating an actuator and then querying the result, the response from the IoT Agent was invalid.

The forwarded query:

```console
curl -iX GET  'http://localhost:4041/ngsi-ld/v1/entities/urn:ngsi-ld:Device:water001?attrs=on,off'
```

was returning an array:

```json
[
  {
    "type": "Device",
    "id": "urn:ngsi-ld:Device:water001",
    "on": {
      "type": "command",
      "value": ""
    },
    "off": {
      "type": "command",
      "value": ""
    }
  }
]
```

It should have returned a single entity:

```json
{
  "type": "Device",
  "id": "urn:ngsi-ld:Device:water001",
  "on": {
    "type": "command",
    "value": ""
  },
  "off": {
    "type": "command",
    "value": ""
  }
}
```

Note that currently only single entities (e.g. `/urn:ngsi-ld:Device:water001`) can be *requested* and returned, however the code to deal with multiple entities (e.g. `/?type=Device`)still exists, because the full definition of context-forwarding to actutators is remains to be fully defined. It is on the proposals for inclusion in the next ESTI specification.