### PR TITLE
Fix merge conflicts again again.

### DIFF
--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -80,7 +80,10 @@ function createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback) {
         // Handling different response codes for batch entity upsert in NGSI-LD specification:
         // - In v1.2.1, response code is 200
         // - In v1.3.1, response code is 201 if some created entities, 204 if just updated existing
-        else if (response && (response.statusCode === 200 || response.statusCode == 201 || response.statusCode == 204)) {
+        else if (
+            response &&
+            (response.statusCode === 200 || response.statusCode === 201 || response.statusCode === 204)
+        ) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Initial entity created successfully.');
             callback(null, newDevice);
@@ -126,7 +129,7 @@ function updateEntityHandlerNgsiLD(deviceData, updatedDevice, callback) {
         // Handling different response codes for batch entity upsert in NGSI-LD specification:
         // - In v1.2.1, response code is 200
         // - In v1.3.1, response code is 204 (not handling 201 as entities already previously created)
-        else if (response && (response.statusCode === 200 || response.statusCode == 204)) {
+        else if (response && (response.statusCode === 200 || response.statusCode === 204)) {
             alarms.release(constants.ORION_ALARM);
             logger.debug(context, 'Entity updated successfully.');
             callback(null, updatedDevice);
@@ -165,7 +168,7 @@ function createInitialEntityNgsiLD(deviceData, newDevice, callback) {
     jsonConcat(json, NGSIv2.formatCommands(deviceData.commands));
 
     if (
-        ('timestamp' in deviceData && deviceData.timestamp !== undefined ? 
+        ('timestamp' in deviceData && deviceData.timestamp !== undefined ?
             deviceData.timestamp : config.getConfig().timestamp) && !utils.isTimestampedNgsi2(json)
     ) {
         logger.debug(context, 'config.timestamp %s %s', deviceData.timestamp, config.getConfig().timestamp);

--- a/test/unit/ngsi-ld/ngsiService/active-devices-test.js
+++ b/test/unit/ngsi-ld/ngsiService/active-devices-test.js
@@ -539,7 +539,7 @@ describe('NGSI-LD - Active attributes test', function() {
                     '/ngsi-ld/v1/entityOperations/upsert/',
                     utils.readExampleFile('./test/unit/ngsi-ld/examples/contextRequests/updateContext.json')
                 )
-                .reply(207, {"notUpdated": "someEntities"});
+                .reply(207, {'notUpdated': 'someEntities'});
 
             iotAgentLib.activate(iotAgentConfig, done);
         });

--- a/test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js
@@ -623,7 +623,8 @@ describe('NGSI-LD - Device provisioning API: Provision devices', function() {
             request(options, function(error, response, body) {
                 should.not.exist(error);
                 response.body.name.should.equal('ENTITY_GENERIC_ERROR');
-                response.body.message.should.equal('Error accesing entity data for device: MicroLight1 of type: MicroLights');
+                response.body.message.should.equal('Error accesing entity data for device:' + 
+                    ' MicroLight1 of type: MicroLights');
                 response.statusCode.should.equal(200);
 
                 done();
@@ -674,7 +675,8 @@ describe('NGSI-LD - Device provisioning API: Provision devices', function() {
             const options = {
                 url: 'http://localhost:' + iotAgentConfig.server.port + '/iot/devices',
                 method: 'POST',
-                json: utils.readExampleFile('./test/unit/examples/deviceProvisioningRequests/provisionMinimumDevice.json'),
+                json: utils.readExampleFile('./test/unit/examples/deviceProvisioningRequests/' + 
+                    'provisionMinimumDevice.json'),
                 headers: {
                     'fiware-service': 'smartGondor',
                     'fiware-servicepath': '/gardens'


### PR DESCRIPTION
Fixing Linting failure from merge of #887 

```text
lib/services/devices/devices-NGSI-LD.js: line 83, col 121, Line is too long.
lib/services/devices/devices-NGSI-LD.js: line 83, col 84, Expected '===' and instead saw '=='.
lib/services/devices/devices-NGSI-LD.js: line 83, col 114, Expected '===' and instead saw '=='.
lib/services/devices/devices-NGSI-LD.js: line 129, col 84, Expected '===' and instead saw '=='.

test/unit/ngsi-ld/ngsiService/active-devices-test.js: line 542, col 42, Strings must use singlequote.
test/unit/ngsi-ld/ngsiService/active-devices-test.js: line 542, col 58, Strings must use singlequote.
test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js: line 626, col 126, Line is too long.
test/unit/ngsi-ld/provisioning/device-provisioning-api_test.js: line 677, col 123, Line is too long.
```

