### PR TITLE
log details when device group not found

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Fix: log device group error detail when group not found
 FIX: fix and use fillService to fix logs in provision
 Fix some ngsi service log levels
 Fix: Listing service groups returns only a single service group (#894)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -146,7 +146,8 @@ module.exports = {
     DeviceGroupNotFound: function(fields, values) {
         this.name = 'DEVICE_GROUP_NOT_FOUND';
         if (values && fields) {
-            this.message = 'Couldn\t find device group for fields: ' + JSON.stringify(fields) + ' and values: ' + JSON.stringify(values);
+            this.message = 'Couldn\t find device group for fields: ' + JSON.stringify(fields) +
+                ' and values: ' + JSON.stringify(values);
         } else if (fields) {
             this.message = 'Couldn\t find device group for fields: ' + JSON.stringify(fields);
         } else {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -146,9 +146,9 @@ module.exports = {
     DeviceGroupNotFound: function(fields, values) {
         this.name = 'DEVICE_GROUP_NOT_FOUND';
         if (values && fields) {
-            this.message = 'Couldn\t find device group for fields: ' + fields + ' and values: ' + values;
+            this.message = 'Couldn\t find device group for fields: ' + JSON.stringify(fields) + ' and values: ' + JSON.stringify(values);
         } else if (fields) {
-            this.message = 'Couldn\t find device group for fields: ' + fields;
+            this.message = 'Couldn\t find device group for fields: ' + JSON.stringify(fields);
         } else {
             this.message = 'Couldn\t find device group';
         }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -147,6 +147,8 @@ module.exports = {
         this.name = 'DEVICE_GROUP_NOT_FOUND';
         if (values && fields) {
             this.message = 'Couldn\t find device group for fields: ' + fields + ' and values: ' + values;
+        } else if (fields) {
+            this.message = 'Couldn\t find device group for fields: ' + fields;
         } else {
             this.message = 'Couldn\t find device group';
         }

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -235,7 +235,7 @@ function findBy(fields) {
             } else {
                 logger.debug(context, 'Device group for fields [%j] not found: [%j]', fields, queryObj);
 
-                callback(new errors.DeviceGroupNotFound(fields));
+                callback(new errors.DeviceGroupNotFound(fields, queryObj));
             }
         });
     };


### PR DESCRIPTION
When this error applies, only this log is printer.
```
iot-iota-json               | time=2020-09-11T07:59:14.361Z | lvl=ERROR | corr=n/a | trans=n/a | op=IoTAgentNGSI.Alarms | srv=smartcity | subsrv=/ | msg=Raising [MONGO-ALARM]: {"name":"DEVICE_GROUP_NOT_FOUND","message":"Couldn\t find device group","code":404} | comp=IoTAgent
```

More details is desirable.


https://github.com/telefonicaid/iotagent-node-lib/blob/master/lib/services/groups/groupRegistryMongoDB.js#L167

https://github.com/telefonicaid/iotagent-node-lib/blob/master/lib/services/groups/groupRegistryMongoDB.js#L238
