### PR TITLE
Fix secrets for RedHat systems.

### DIFF
--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -34,8 +34,25 @@ var config = {},
     commandRegistry,
     securityService;
 
-const secrets = require('@cloudreach/docker-secrets');
+const fs   = require('fs');
 const path = require('path');
+const SECRETS_DIR =  process.env.SECRETS_DIR || '/run/secrets';
+const secrets = {};
+
+if (fs.existsSync(SECRETS_DIR)) {
+  const files = fs.readdirSync(SECRETS_DIR);
+  files.forEach(function(file, index) {
+    const fullPath = path.join(SECRETS_DIR, file);
+    const key = file;
+    try {
+        const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
+        secrets[key] = data;
+    } catch (e) {
+        logger.error(e.message);
+    }
+  });
+}
+
 
 function anyIsSet(variableSet) {
     for (var i = 0; i < variableSet.length; i++) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
-    "@cloudreach/docker-secrets": "~1.0.3",
     "async": "2.6.2",
     "body-parser": "~1.19.0",
     "command-shell-lib": "1.0.0",


### PR DESCRIPTION
Remove   @cloudreach/docker-secrets replace with custom code.

- Add try/catch
- Make Secrets locations configurable