### PR TITLE
Add lax validation mode for OPC-UA IoT Agent

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 Fix: Static attributes from service not applied if device has static attributes (#757)
 Move Docker secret support inside the Node Application - remove Entrypoint (#885)
 Fix: IOTA_EXPLICIT_ATTRS env var was not working
-Add lax validation mode for OPC-UA IoT Agent using IOTA_RELAX_TEMPLATE_VALIDATION (#920)
+Add lax validation mode using IOTA_RELAX_TEMPLATE_VALIDATION (#920)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 Fix: Static attributes from service not applied if device has static attributes (#757)
 Move Docker secret support inside the Node Application - remove Entrypoint (#885)
 Fix: IOTA_EXPLICIT_ATTRS env var was not working
+Add lax validation mode for OPC-UA IoT Agent using IOTA_RELAX_TEMPLATE_VALIDATION (#920)

--- a/doc/installationguide.md
+++ b/doc/installationguide.md
@@ -238,7 +238,11 @@ used for the same purpose. For instance:
 
 -   **explicitAttrs**: if this flag is activated, only provisioned attributes will be processed to Context Broker.
     This flag is overwritten by `explicitAttrs` flag in group or device provision.
--   **relaxTemplateValidation**: if this flag is activated, `objectIds` for incoming devices are not validated and may include characters such as semi-colons.
+-   **relaxTemplateValidation**: if this flag is activated, `objectId` attributes for incoming devices are not validated,
+    and may exceptionally include characters (such as semi-colons) which are
+    [forbidden](https://fiware-orion.readthedocs.io/en/master/user/forbidden_characters/index.html) according to the NGSI
+    specification.  When provisioning devices, it is necessary that the developer provides valid  `objectId`-`name` mappings
+    whenever relaxed mode is used, to prevent the consumption of forbidden characters.
 
 ### Configuration using environment variables
 

--- a/doc/installationguide.md
+++ b/doc/installationguide.md
@@ -233,11 +233,12 @@ used for the same purpose. For instance:
     [Cluster](https://nodejs.org/api/cluster.html) module in Node.js and
     [this section](howto.md#iot-agent-in-multi-thread-mode) of the library documentation.
 -   **defaultExpressionLanguage**: the default expression language used to
-    compute expressions, possible values are: `legacy` or `jexl`. When not set or 
+    compute expressions, possible values are: `legacy` or `jexl`. When not set or
     wrongly set, `legacy` is used as default value.
 
--   **explicitAttrs**: if this flag is activated, only provisioned attributes will be processed to Context Broker. 
+-   **explicitAttrs**: if this flag is activated, only provisioned attributes will be processed to Context Broker.
     This flag is overwritten by `explicitAttrs` flag in group or device provision.
+-   **relaxTemplateValidation**: if this flag is activated, `objectIds` for incoming devices are not validated and may include characters such as semi-colons.
 
 ### Configuration using environment variables
 
@@ -297,3 +298,4 @@ overrides.
 | IOTA_MULTI_CORE           | `multiCore`                     |
 | IOTA_DEFAULT_EXPRESSION_LANGUAGE | defaultExpressionLanguage    |
 | IOTA_EXPLICIT_ATTRS       | `explicitAttrs`                 |
+| IOTA_RELAX_TEMPLATE_VALIDATION   | `relaxTemplateValidation`    |

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -464,6 +464,8 @@ function processEnvironmentVariables() {
     }
     if(process.env.IOTA_RELAX_TEMPLATE_VALIDATION){
         config.relaxTemplateValidation = process.env.IOTA_RELAX_TEMPLATE_VALIDATION === 'true';
+    } else {
+        config.relaxTemplateValidation = config.relaxTemplateValidation === true;
     }
 }
 

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -163,7 +163,8 @@ function processEnvironmentVariables() {
             'IOTA_POLLING_EXPIRATION',
             'IOTA_POLLING_DAEMON_FREQ',
             'IOTA_MULTI_CORE',
-            'IOTA_DEFAULT_EXPRESSION_LANGUAGE'
+            'IOTA_DEFAULT_EXPRESSION_LANGUAGE',
+            'IOTA_RELAX_TEMPLATE_VALIDATION'
         ],
         iotamVariables = [
             'IOTA_IOTAM_URL',
@@ -460,6 +461,9 @@ function processEnvironmentVariables() {
     if (process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE) {
         config.defaultExpressionLanguage =
             process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE;
+    }
+    if(process.env.IOTA_RELAX_TEMPLATE_VALIDATION){
+        config.relaxTemplateValidation = process.env.IOTA_RELAX_TEMPLATE_VALIDATION === 'true';
     }
 }
 

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -462,7 +462,7 @@ function processEnvironmentVariables() {
         config.defaultExpressionLanguage =
             process.env.IOTA_DEFAULT_EXPRESSION_LANGUAGE;
     }
-    if(process.env.IOTA_RELAX_TEMPLATE_VALIDATION){
+    if (process.env.IOTA_RELAX_TEMPLATE_VALIDATION) {
         config.relaxTemplateValidation = process.env.IOTA_RELAX_TEMPLATE_VALIDATION === 'true';
     } else {
         config.relaxTemplateValidation = config.relaxTemplateValidation === true;

--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -30,14 +30,15 @@ var async = require('async'),
     logger = require('logops'),
     errors = require('../../errors'),
     _ = require('underscore'),
+    config = require('../../commonConfig'),
     context = {
         op: 'IoTAgentNGSI.DeviceProvisioning'
     },
     apply = async.apply,
     provisioningHandler,
     removeDeviceHandler,
-    updateDeviceTemplate = require('../../templates/updateDevice.json'),
-    createDeviceTemplate = require('../../templates/createDevice.json'),
+    updateDeviceTemplate,
+    createDeviceTemplate,
     mandatoryHeaders = [
         'fiware-service',
         'fiware-servicepath'
@@ -64,6 +65,15 @@ var async = require('async'),
         autoprovision: 'autoprovision',
         explicitAttrs: 'explicitAttrs'
     };
+
+
+if(config.relaxTemplateValidation){
+    updateDeviceTemplate = require('../../templates/updateDeviceLax.json');
+    createDeviceTemplate = require('../../templates/createDeviceLax.json');
+} else {
+    updateDeviceTemplate = require('../../templates/updateDevice.json');
+    createDeviceTemplate = require('../../templates/createDevice.json');
+}
 
 /**
  * Express middleware to handle incoming device provisioning requests. Every request is validated and handled to the

--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -65,7 +65,10 @@ var async = require('async'),
         explicitAttrs: 'explicitAttrs'
     };
 
-
+/**
+ * Load the templates for validating provisioning requests. The introduction of "Lax Mode" enables the addition of 
+ * characters which valid in the OPU-UA IoT Agent (e.g. semi-colons) but are usually forbidden by other IoT Agents
+ */
 function setConfiguration(config){
     if (config.relaxTemplateValidation) {
         updateDeviceTemplate = require('../../templates/updateDeviceLax.json');

--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -67,7 +67,7 @@ var async = require('async'),
     };
 
 
-if(config.relaxTemplateValidation){
+if (config.relaxTemplateValidation) {
     updateDeviceTemplate = require('../../templates/updateDeviceLax.json');
     createDeviceTemplate = require('../../templates/createDeviceLax.json');
 } else {

--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -30,7 +30,6 @@ var async = require('async'),
     logger = require('logops'),
     errors = require('../../errors'),
     _ = require('underscore'),
-    config = require('../../commonConfig'),
     context = {
         op: 'IoTAgentNGSI.DeviceProvisioning'
     },
@@ -67,12 +66,14 @@ var async = require('async'),
     };
 
 
-if (config.relaxTemplateValidation) {
-    updateDeviceTemplate = require('../../templates/updateDeviceLax.json');
-    createDeviceTemplate = require('../../templates/createDeviceLax.json');
-} else {
-    updateDeviceTemplate = require('../../templates/updateDevice.json');
-    createDeviceTemplate = require('../../templates/createDevice.json');
+function setConfiguration(config){
+    if (config.relaxTemplateValidation) {
+        updateDeviceTemplate = require('../../templates/updateDeviceLax.json');
+        createDeviceTemplate = require('../../templates/createDeviceLax.json');
+    } else {
+        updateDeviceTemplate = require('../../templates/updateDevice.json');
+        createDeviceTemplate = require('../../templates/createDevice.json');
+    }
 }
 
 /**
@@ -259,7 +260,7 @@ function handleRemoveDevice(req, res, next) {
                 } else {
                     callback(new errors.DeviceNotFound(deviceId));
                 }
-            });        
+            });
     }
 
     function applyRemoveDeviceHandler(device, callback) {
@@ -375,6 +376,7 @@ function clear(callback) {
     callback();
 }
 
+exports.setConfiguration = setConfiguration;
 exports.loadContextRoutes = intoTrans(context, loadContextRoutes);
 exports.setProvisioningHandler = intoTrans(context, setProvisioningHandler);
 exports.setRemoveDeviceHandler = intoTrans(context, setRemoveDeviceHandler);

--- a/lib/services/northBound/northboundServer.js
+++ b/lib/services/northBound/northboundServer.js
@@ -40,6 +40,9 @@ var http = require('http'),
     bodyParser = require('body-parser');
 
 function start(config, callback) {
+
+    deviceProvisioning.setConfiguration(config);
+
     var baseRoot = '/',
         iotaInformation;
 

--- a/lib/templates/createDeviceLax.json
+++ b/lib/templates/createDeviceLax.json
@@ -1,0 +1,172 @@
+{
+  "title": "Device",
+  "description": "Payload for device provisioning",
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+    "devices": {
+      "type": "array",
+      "id": "devices",
+      "required": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "device_id": {
+            "description": "Device ID of the physical device",
+            "type": "string"
+          },
+          "entity_name": {
+            "description": "Name of the target entity",
+            "type": "string"
+          },
+          "entity_type": {
+            "description": "Type of the target entity",
+            "type": "string",
+            "required": false
+          },
+          "timezone": {
+            "description": "Time zone where the device is located",
+            "type": "string"
+          },
+          "protocol": {
+            "description": "Protocol the device is using to communicate with the platform",
+            "type": "string"
+          },
+          "transport": {
+            "description": "Transport protocol used by the platform to communicate with the device",
+            "type": "string"
+          },
+          "lazy": {
+            "description": "list of lazy attributes of the devices",
+            "type": "array",
+            "id": "lazy",
+            "required": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "object_id": {
+                  "description": "ID of the attribute in the device",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "type": {
+                  "description": "Type of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                }
+              }
+            }
+          },
+          "attributes": {
+            "description": "list of active attributes of the devices",
+            "type": "array",
+            "id": "attributes",
+            "required": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "object_id": {
+                  "description": "ID of the attribute in the device",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "type": {
+                  "description": "Type of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "expression": {
+                  "description": "Optional expression for measurement transformation",
+                  "type": "string",
+                  "pattern": "^([^<>;'=]+)+$"
+                },
+                "entity_name": {
+                  "description": "Optional entity name for multientity updates",
+                  "type": "string",
+                  "pattern": "^([^<>;'=\"]+)+$"
+                },
+                "entity_type": {
+                  "description": "Optional entity type for multientity updatess",
+                  "type": "string",
+                  "pattern": "^([^<>;'=\"]+)+$"
+                },
+                "reverse": {
+                  "description": "Define the attribute as bidirectional",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "object_id": {
+                        "description": "ID of the attribute in the device",
+                        "type": "string"                      
+                      },
+                      "type": {
+                        "description": "Type of the attribute in the target entity",
+                        "type": "string",
+                        "pattern": "^([^<>();'=\"]+)+$"
+                      },
+                      "expression": {
+                        "description": "Optional expression for measurement transformation",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "commands": {
+            "description": "list of commands of the devices",
+            "type": "array",
+            "id": "lazy",
+            "required": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "object_id": {
+                  "description": "ID of the attribute in the device",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "type": {
+                  "description": "Type of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "value": {
+                  "description": "Value of the command (currently ignored)",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)*$"
+                }
+              }
+            }
+          },
+          "internal_attributes": {
+            "description": "Free form array of internal attributes for particular IOTAgents",
+            "type": "any"
+          },
+          "static_attributes": {
+            "description": "Free form array of data to be appended to the target entity",
+            "type": "array"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/templates/updateDeviceLax.json
+++ b/lib/templates/updateDeviceLax.json
@@ -1,0 +1,157 @@
+{
+  "title": "Device",
+  "description": "Payload to update a provisioned device",
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+    "device_id": {
+      "description": "Device ID of the physical device",
+      "type": "string"
+    },
+    "entity_name": {
+      "description": "Name of the target entity",
+      "type": "string"
+    },
+    "entity_type": {
+      "description": "Type of the target entity",
+      "type": "string"
+    },
+    "timezone": {
+      "description": "Time zone where the device is located",
+      "type": "string"
+    },
+    "protocol": {
+      "description": "Protocol the device is using to communicate with the platform",
+      "type": "string"
+    },
+    "endpoint": {
+      "description": "Endpoint for the commands targeting this device",
+      "type": "string"
+    },
+    "lazy": {
+      "description": "list of lazy attributes of the devices",
+      "type": "array",
+      "id": "lazy",
+      "required": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "object_id": {
+            "description": "ID of the attribute in the device",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          },
+          "type": {
+            "description": "Type of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          }
+        }
+      }
+    },
+    "attributes": {
+      "description": "list of active attributes of the devices",
+      "type": "array",
+      "id": "attributes",
+      "required": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "object_id": {
+            "description": "ID of the attribute in the device",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          },
+          "type": {
+            "description": "Type of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          },
+          "expression": {
+            "description": "Optional expression for measurement transformation",
+            "type": "string",
+            "pattern": "^([^<>;'=]+)+$"
+          },
+          "entity_name": {
+            "description": "Optional entity name for multientity updates",
+            "type": "string",
+            "pattern": "^([^<>;'=\"]+)+$"
+          },
+          "entity_type": {
+            "description": "Optional entity type for multientity updatess",
+            "type": "string",
+            "pattern": "^([^<>;'=\"]+)+$"
+          },
+          "reverse": {
+            "description": "Define the attribute as bidirectional",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "object_id": {
+                  "description": "ID of the attribute in the device",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type of the attribute in the target entity",
+                  "type": "string",
+                  "pattern": "^([^<>();'=\"]+)+$"
+                },
+                "expression": {
+                  "description": "Optional expression for measurement transformation",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "commands": {
+      "description": "list of commands of the devices",
+      "type": "array",
+      "id": "lazy",
+      "required": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "object_id": {
+            "description": "ID of the attribute in the device",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          },
+          "type": {
+            "description": "Type of the attribute in the target entity",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)+$"
+          },
+          "value": {
+            "description": "Value of the command (currently ignored)",
+            "type": "string",
+            "pattern": "^([^<>();'=\"]+)*$"
+          }
+        }
+      }
+    },
+    "static_attributes": {
+      "description": "Free form array of data to be appended to the target entity",
+      "type": "array"
+    }
+  }
+}


### PR DESCRIPTION
- Add IOTA_RELAX_TEMPLATE_VALIDATION env.
- Add switch for Lax/Strict ObjectId templating
- Amend documentation.

@gabrieledeluca - would this work for you?