### PR TITLE
Task/add find type silently for groups

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Add: include findTypeSilently for groups
 Add: include `description` field in group schema
 Add: include from in log context (#918)
 Fix: Update internal attributes in Group update (#917)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Add: include findTypeSilently for groups
+Add: include findTypeSilently for groups to log some false errors as debug instead of alarm 
 Add: include `description` field in group schema
 Add: include from in log context (#918)
 Fix: Update internal attributes in Group update (#917)

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -641,7 +641,7 @@ function findConfigurationGroup(deviceObj, callback) {
             deviceObj.subservice,
             handlerGroupFind);
     } else {
-        config.getGroupRegistry().findType(
+        config.getGroupRegistry().findTypeSilently(
             deviceObj.service,
             deviceObj.subservice,
             deviceObj.type,

--- a/lib/services/groups/groupRegistryMemory.js
+++ b/lib/services/groups/groupRegistryMemory.js
@@ -277,6 +277,7 @@ exports.init = intoTrans(context, init);
 exports.find = intoTrans(context, find);
 exports.findBy = intoTrans(context, findBy);
 exports.findType = intoTrans(context, findBy(['service', 'subservice', 'type']));
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type']));
 exports.get = intoTrans(context, getSingleGroup);
 exports.getSilently = intoTrans(context, getSingleGroup);
 exports.getType = intoTrans(context, getSingleGroupType);

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -316,6 +316,7 @@ exports.init = alarmsInt(constants.MONGO_ALARM, intoTrans(context, init));
 exports.find = alarmsInt(constants.MONGO_ALARM, intoTrans(context, find));
 exports.findType = alarmsInt(constants.MONGO_ALARM,
                              intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey'])));
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']));
 exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));


### PR DESCRIPTION
Comes from https://github.com/telefonicaid/iotagent-json/issues/500

To avoid false error logs:
```
time=2020-10-19T08:41:04.893Z | lvl=ERROR | corr=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | trans=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | op=IoTAgentNGSI.Alarms | srv=demo | subsrv=/test | msg=Raising [MONGO-ALARM]: {"name":"DEVICE_GROUP_NOT_FOUND","message":"Couldn\t find device group for fields: [\"service\",\"subservice\",\"type\",\"apikey\"] and values: {\"service\":\"demo\",\"subservice\":\"/test\",\"type\":\"thing\"}","code":404} | comp=IoTAgent
time=2020-10-19T08:41:04.893Z | lvl=DEBUG | corr=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | trans=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | op=IoTAgentNGSI.ContextServer | srv=demo | subsrv=/test | msg=Handling received set of attributes: ["auto"] | comp=IoTAgent
time=2020-10-19T08:41:04.893Z | lvl=DEBUG | corr=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | trans=3c225c01-3216-4ce9-8981-4ee1f1bbfa3a | op=IoTAgentNGSI.MongoDBDeviceRegister | srv=demo | subsrv=/test | msg=Looking for device with name [testR]. | comp=IoTAgent
time=2020-10-19T08:41:04.897Z | lvl=ERROR | corr=15b5728c-2e73-4092-a1d4-46bb26c8dbb4 | trans=15b5728c-2e73-4092-a1d4-46bb26c8dbb4 | op=IoTAgentNGSI.Alarms | srv=qa_smartvalencia | subsrv=/ | msg=Releasing [MONGO-ALARM] | comp=IoTAgent
```
produced when uses a group apikey but with different `type` entity