### PR TITLE
feat: use update mode of batch upsert when updating NGSI-LD entities

### DIFF
--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -213,7 +213,7 @@ function createInitialEntityNgsiLD(deviceData, newDevice, callback) {
  */
 function updateEntityNgsiLD(deviceData, updatedDevice, callback) {
     const options = {
-        url: config.getConfig().contextBroker.url + '/ngsi-ld/v1/entityOperations/upsert/',
+        url: config.getConfig().contextBroker.url + '/ngsi-ld/v1/entityOperations/upsert/?options=update',
         method: 'POST',
         json: {},
         headers: {
@@ -226,9 +226,9 @@ function updateEntityNgsiLD(deviceData, updatedDevice, callback) {
     };
 
     if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
-        options.url = deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/';
+        options.url = deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/?options=update';
     } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
-        options.url = 'http://' + deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/';
+        options.url = 'http://' + deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/?options=update';
     }
 
     /*if (deviceData.type) {

--- a/test/unit/ngsi-ld/provisioning/device-update-registration_test.js
+++ b/test/unit/ngsi-ld/provisioning/device-update-registration_test.js
@@ -171,7 +171,7 @@ describe('NGSI-LD - IoT Agent Device Update Registration', function() {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
                 .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    '/ngsi-ld/v1/entityOperations/upsert/?options=update',
                     utils.readExampleFile(
                         './test/unit/ngsi-ld/examples/contextRequests/updateProvisionActiveAttributes1.json'
                     )
@@ -216,7 +216,7 @@ describe('NGSI-LD - IoT Agent Device Update Registration', function() {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
                 .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    '/ngsi-ld/v1/entityOperations/upsert/?options=update',
                     utils.readExampleFile('./test/unit/ngsi-ld/examples/contextRequests/updateProvisionCommands1.json')
                 )
                 .reply(204);
@@ -266,7 +266,7 @@ describe('NGSI-LD - IoT Agent Device Update Registration', function() {
         beforeEach(function() {
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .post('/ngsi-ld/v1/entityOperations/upsert/')
+                .post('/ngsi-ld/v1/entityOperations/upsert/?options=update')
                 .reply(400);
         });
 

--- a/test/unit/ngsi-ld/provisioning/updateProvisionedDevices-test.js
+++ b/test/unit/ngsi-ld/provisioning/updateProvisionedDevices-test.js
@@ -167,7 +167,7 @@ describe('NGSI-LD - Device provisioning API: Update provisioned devices', functi
 
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
-                .post('/ngsi-ld/v1/entityOperations/upsert/')
+                .post('/ngsi-ld/v1/entityOperations/upsert/?options=update')
                 .reply(204);
 
             // FIXME: When https://github.com/telefonicaid/fiware-orion/issues/3007 is merged into master branch,
@@ -328,7 +328,7 @@ describe('NGSI-LD - Device provisioning API: Update provisioned devices', functi
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
                 .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    '/ngsi-ld/v1/entityOperations/upsert/?options=update',
                     utils.readExampleFile(
                         './test/unit/ngsi-ld/examples/contextRequests/updateProvisionMinimumDevice.json'
                     )
@@ -403,7 +403,7 @@ describe('NGSI-LD - Device provisioning API: Update provisioned devices', functi
             contextBrokerMock
                 .matchHeader('fiware-service', 'smartGondor')
                 .post(
-                    '/ngsi-ld/v1/entityOperations/upsert/',
+                    '/ngsi-ld/v1/entityOperations/upsert/?options=update',
                     utils.readExampleFile(
                         './test/unit/ngsi-ld/examples/contextRequests/updateProvisionDeviceStatic.json'
                     )


### PR DESCRIPTION
Hi all,

As discussed in https://github.com/telefonicaid/iotagent-node-lib/pull/888 (with a lot of delay, sorry for that), here is the PR to activate update mode when calling the batch upsert NGSI-LD API to update entities.

Default mode for batch upsert is to replace entities, which does not exactly match with what we want to do (basically updating a value measured by a sensor).
