### PR TITLE
Cache Mongo-DB calls.

### DIFF
--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -21,18 +21,45 @@
  * please contact with::daniel.moranjimenez@telefonica.com
  */
 
-var logger = require('logops'),
-    dbService = require('../../model/dbConn'),
-    config = require('../../commonConfig'),
-    fillService = require('./../common/domain').fillService,
-    alarmsInt = require('../common/alarmManagement').intercept,
-    errors = require('../../errors'),
-    constants = require('../../constants'),
-    Device = require('../../model/Device'),
-    async = require('async'),
-    context = {
-        op: 'IoTAgentNGSI.MongoDBDeviceRegister'
-    };
+const logger = require('logops');
+const dbService = require('../../model/dbConn');
+const config = require('../../commonConfig');
+const fillService = require('./../common/domain').fillService;
+const alarmsInt = require('../common/alarmManagement').intercept;
+const errors = require('../../errors');
+const constants = require('../../constants');
+const Device = require('../../model/Device');
+const async = require('async');
+const cacheManager = require('cache-manager');
+const memoryCache = cacheManager.caching({store: 'memory', max: 1000, ttl: 10/*seconds*/});
+let context = {
+    op: 'IoTAgentNGSI.MongoDBDeviceRegister'
+};
+
+const attributeList = [
+    'id',
+    'type',
+    'name',
+    'service',
+    'subservice',
+    'lazy',
+    'commands',
+    'staticAttributes',
+    'active',
+    'registrationId',
+    'internalId',
+    'internalAttributes',
+    'resource',
+    'apikey',
+    'protocol',
+    'endpoint',
+    'transport',
+    'polling',
+    'timestamp',
+    'autoprovision',
+    'explicitAttrs',
+    'expressionLanguage'
+];
 
 /**
  * Generates a handler for the save device operations. The handler will take the customary error and the saved device
@@ -58,14 +85,11 @@ function saveDeviceHandler(callback) {
  * @param {Object} newDevice           Device object to be stored
  */
 function storeDevice(newDevice, callback) {
-    var deviceObj = new Device.model(),
-        attributeList = ['id', 'type', 'name', 'service', 'subservice', 'lazy', 'commands', 'staticAttributes',
-            'active', 'registrationId', 'internalId', 'internalAttributes', 'resource', 'apikey', 'protocol',
-            'endpoint', 'transport', 'polling', 'timestamp', 'autoprovision', 'explicitAttrs', 'expressionLanguage'];
+    const deviceObj = new Device.model();
 
-    for (var i = 0; i < attributeList.length; i++) {
-        deviceObj[attributeList[i]] = newDevice[attributeList[i]];
-    }
+    attributeList.forEach((key) => {
+        deviceObj[key] = newDevice[key];
+    });
 
     // Ensure protocol is in newDevice
     if ( !newDevice.protocol && config.getConfig().iotManager && config.getConfig().iotManager.protocol) {
@@ -99,7 +123,7 @@ function storeDevice(newDevice, callback) {
  * @param {String} subservice   Subservice inside the service for the removed device.
  */
 function removeDevice(id, service, subservice, callback) {
-    var condition = {
+    const condition = {
         id: id,
         service: service,
         subservice: subservice
@@ -114,7 +138,7 @@ function removeDevice(id, service, subservice, callback) {
             callback(new errors.InternalDbError(error));
         } else {
             logger.debug(context, 'Device [%s] successfully removed.', id);
-
+            clearCache();
             callback(null);
         }
     });
@@ -130,8 +154,8 @@ function removeDevice(id, service, subservice, callback) {
  * @param {Number} offset       Number of entries to skip for pagination.
  */
 function listDevices(type, service, subservice, limit, offset, callback) {
-    var condition = {},
-        query;
+    const condition = {};
+    let query;
 
     if (type) {
         condition.type = type;
@@ -174,32 +198,36 @@ function listDevices(type, service, subservice, limit, offset, callback) {
  * @param {String} subservice   Division inside the service (optional).
  */
 function getDeviceById(id, service, subservice, callback) {
-    var query,
-        queryParams = {
-            id: id,
-            service: service,
-            subservice: subservice
-        };
+    let query;
+    const queryParams = {
+        id: id,
+        service: service,
+        subservice: subservice
+    };
     context = fillService(context, queryParams);
     logger.debug(context, 'Looking for device with id [%s].', id);
 
-    query = Device.model.findOne(queryParams);
-    query.select({__v: 0});
+    memoryCache.wrap(JSON.stringify(queryParams), function (cacheCallback) {
+        query = Device.model.findOne(queryParams);
+        query.select({__v: 0});
 
-    query.exec(function handleGet(error, data) {
-        if (error) {
-            logger.debug(context, 'Internal MongoDB Error getting device: %s', error);
+        query.exec(function handleGet(error, data) {
+            if (error) {
+                logger.debug(context, 'Internal MongoDB Error getting device: %s', error);
 
-            callback(new errors.InternalDbError(error));
-        } else if (data) {
-            context = fillService(context, data);
-            logger.debug(context, 'Device data found: %j', data);
-            callback(null, data);
-        } else {
-            logger.debug(context, 'Device [%s] not found.', id);
+                cacheCallback(new errors.InternalDbError(error));
+            } else if (data) {
+                context = fillService(context, data);
+                logger.debug(context, 'Device data found: %j', data);
+                cacheCallback(null, data);
+            } else {
+                logger.debug(context, 'Device [%s] not found.', id);
 
-            callback(new errors.DeviceNotFound(id));
-        }
+                cacheCallback(new errors.DeviceNotFound(id));
+            }
+        });
+    }, (error, data) => {
+        callback(error, data);
     });
 }
 
@@ -222,7 +250,7 @@ function getDevice(id, service, subservice, callback) {
 }
 
 function getByName(name, service, servicepath, callback) {
-    var query;
+    let query;
     context = fillService(context, { service: service, subservice: servicepath});
     logger.debug(context, 'Looking for device with name [%s].', name);
 
@@ -250,8 +278,9 @@ function getByName(name, service, servicepath, callback) {
 }
 
 /**
- * Updates the given device into the database. Only the following attributes: lazy, active and internalId will be
- * updated.
+ * Updates the given device into the database. Only the following attributes: 
+ * lazy, active and internalId, commanda, endpoint, name, type, explicitAttrs
+ * will be updated.
  *
  * @param {Object} device       Device object with the new values to write.
  */
@@ -260,6 +289,7 @@ function update(device, callback) {
         if (error) {
             callback(error);
         } else {
+            clearCache();
             data.lazy = device.lazy;
             data.active = device.active;
             data.internalId = device.internalId;
@@ -269,7 +299,6 @@ function update(device, callback) {
             data.name = device.name;
             data.type = device.type;
             data.explicitAttrs = device.explicitAttrs;
-
             data.save(saveDeviceHandler(callback));
         }
     });
@@ -291,8 +320,8 @@ function itemToObject(i) {
 }
 
 function getDevicesByAttribute(name, value, service, subservice, callback) {
-    var query,
-        filter = {};
+    let query;
+    const filter = {};
 
     if (service) {
         filter.service = service;
@@ -324,6 +353,10 @@ function getDevicesByAttribute(name, value, service, subservice, callback) {
     });
 }
 
+function clearCache(){
+    memoryCache.reset();
+}
+
 exports.getDevicesByAttribute = alarmsInt(constants.MONGO_ALARM, getDevicesByAttribute);
 exports.store = alarmsInt(constants.MONGO_ALARM, storeDevice);
 exports.update = alarmsInt(constants.MONGO_ALARM, update);
@@ -333,3 +366,4 @@ exports.get = alarmsInt(constants.MONGO_ALARM, getDevice);
 exports.getSilently = getDevice;
 exports.getByName = alarmsInt(constants.MONGO_ALARM, getByName);
 exports.clear = alarmsInt(constants.MONGO_ALARM, clear);
+exports.clearCache = clearCache;

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -24,18 +24,42 @@
  */
 'use strict';
 
-var logger = require('logops'),
-    dbService = require('../../model/dbConn'),
-    intoTrans = require('../common/domain').intoTrans,
-    fillService = require('./../common/domain').fillService,
-    alarmsInt = require('../common/alarmManagement').intercept,
-    constants = require('../../constants'),
-    errors = require('../../errors'),
-    Group = require('../../model/Group'),
-    async = require('async'),
-    context = {
-        op: 'IoTAgentNGSI.MongoDBGroupRegister'
-    };
+const logger = require('logops');
+const dbService = require('../../model/dbConn');
+const intoTrans = require('../common/domain').intoTrans;
+const fillService = require('./../common/domain').fillService;
+const alarmsInt = require('../common/alarmManagement').intercept;
+const constants = require('../../constants');
+const errors = require('../../errors');
+const Group = require('../../model/Group');
+const async = require('async');
+const cacheManager = require('cache-manager');
+const memoryCache = cacheManager.caching({store: 'memory', max: 100, ttl: 10/*seconds*/});
+let context = {
+    op: 'IoTAgentNGSI.MongoDBGroupRegister'
+};
+
+const attributeList = [
+    'url',
+    'resource',
+    'apikey',
+    'type',
+    'service',
+    'subservice',
+    'description',
+    'trust',
+    'cbHost',
+    'timezone',
+    'timestamp',
+    'commands',
+    'lazy',
+    'attributes',
+    'staticAttributes',
+    'internalAttributes',
+    'autoprovision',
+    'explicitAttrs',
+    'expressionLanguage'
+];
 
 /**
  * Generates a handler for the save device group operations. The handler will take the customary error and the saved
@@ -56,32 +80,10 @@ function saveGroupHandler(groupDAO, callback) {
 }
 
 function createGroup(group, callback) {
-    var groupObj = new Group.model(),
-        attributeList = [
-            'url',
-            'resource',
-            'apikey',
-            'type',
-            'service',
-            'subservice',
-            'description',
-            'trust',
-            'cbHost',
-            'timezone',
-            'timestamp',
-            'commands',
-            'lazy',
-            'attributes',
-            'staticAttributes',
-            'internalAttributes',
-            'autoprovision',
-            'explicitAttrs',
-            'expressionLanguage'
-        ];
-
-    for (var i = 0; i < attributeList.length; i++) {
-        groupObj[attributeList[i]] = group[attributeList[i]];
-    }
+    var groupObj = new Group.model();
+    attributeList.forEach((key) => {
+        groupObj[key] = group[key];
+    });
 
     logger.debug(context, 'Storing device group with id [%s], type [%s], apikey [%s] and resource [%s]',
         groupObj._id, groupObj.type, groupObj.apikey, groupObj.resource);
@@ -220,24 +222,28 @@ function findBy(fields) {
         callback = arguments[i];
         context = fillService(context, { service: 'n/a', subservice: 'n/a'});
         logger.debug(context, 'Looking for group params %j with queryObj %j', fields, queryObj);
-        query = Group.model.findOne(queryObj);
+        
 
-        query.select({__v: 0});
+        memoryCache.wrap(JSON.stringify(queryObj), function (cacheCallback) {
+            query = Group.model.findOne(queryObj);
+            query.select({__v: 0});
+            query.exec(function handleGet(error, data) {
+                if (error) {
+                    logger.debug(context, 'Internal MongoDB Error getting group: %s', error);
+                    cacheCallback(new errors.InternalDbError(error));
+                } else if (data) {
+                    context = fillService(context, data);
+                    logger.debug(context, 'Device group data found: %j', data.toObject());
+                    cacheCallback(null, data.toObject());
 
-        query.exec(function handleGet(error, data) {
-            if (error) {
-                logger.debug(context, 'Internal MongoDB Error getting group: %s', error);
-                callback(new errors.InternalDbError(error));
-            } else if (data) {
-                context = fillService(context, data);
-                logger.debug(context, 'Device group data found: %j', data.toObject());
-                callback(null, data.toObject());
+                } else {
+                    logger.debug(context, 'Device group for fields [%j] not found: [%j]', fields, queryObj);
 
-            } else {
-                logger.debug(context, 'Device group for fields [%j] not found: [%j]', fields, queryObj);
-
-                callback(new errors.DeviceGroupNotFound(fields, queryObj));
-            }
+                    cacheCallback(new errors.DeviceGroupNotFound(fields, queryObj));
+                }
+            });
+        }, (error, data) => {
+            callback(error, data);
         });
     };
 }
@@ -248,32 +254,12 @@ function update(id, body, callback) {
         if (error) {
             callback(error);
         } else {
-            var attributes = [
-                'url',
-                'apikey',
-                'type',
-                'service',
-                'subservice',
-                'description',
-                'trust',
-                'cbHost',
-                'timezone',
-                'timestamp',
-                'commands',
-                'lazy',
-                'attributes',
-                'staticAttributes',
-                'internalAttributes',
-                'explicitAttrs',
-                'expressionLanguage'
-            ];
-
-            for (var i = 0; i < attributes.length; i++) {
-                if (body[attributes[i]] !== undefined) {
-                    group[attributes[i]] = body[attributes[i]];
+            attributeList.forEach((key) => {
+                if (body[key] !== undefined) {
+                    group[key] = body[key];
                 }
-            }
-
+            });
+            clearCache();
             group.isNew = false;
             group.save(saveGroupHandler(group, callback));
         }
@@ -294,7 +280,7 @@ function remove(id, callback) {
                     callback(new errors.InternalDbError(error));
                 } else {
                     logger.debug(context, 'Device [%s] successfully removed.', id);
-
+                    clearCache();
                     callback(null, deviceGroup);
                 }
             });
@@ -308,6 +294,10 @@ function init(newConfig, callback) {
 
 function clear(callback) {
     dbService.db.db.dropDatabase(callback);
+}
+
+function clearCache(){
+    memoryCache.reset();
 }
 
 exports.create = alarmsInt(constants.MONGO_ALARM, intoTrans(context, createGroup));
@@ -324,3 +314,4 @@ exports.getType = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['t
 exports.update = alarmsInt(constants.MONGO_ALARM, intoTrans(context, update));
 exports.remove = alarmsInt(constants.MONGO_ALARM, intoTrans(context, remove));
 exports.clear = alarmsInt(constants.MONGO_ALARM, intoTrans(context, clear));
+exports.clearCache = clearCache;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "async": "2.6.2",
     "body-parser": "~1.19.0",
+    "cache-manager": "3.4.0",
     "command-shell-lib": "1.0.0",
     "express": "~4.16.4",
     "jexl": "2.1.1",

--- a/test/unit/lazyAndCommands/polling-commands-test.js
+++ b/test/unit/lazyAndCommands/polling-commands-test.js
@@ -23,6 +23,7 @@
 'use strict';
 
 var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
+    deviceRegistryMongoDB = require('../../../lib/services/devices/deviceRegistryMongoDB'),
     utils = require('../../tools/utils'),
     should = require('should'),
     logger = require('logops'),
@@ -155,6 +156,7 @@ describe('NGSI-v1 - Polling commands', function() {
                     nock.cleanAll();
                     iotAgentLib.setDataUpdateHandler();
                     iotAgentLib.setCommandHandler();
+                    deviceRegistryMongoDB.clearCache();
                     done();
                 });
             });

--- a/test/unit/mongodb/mongodb-group-registry-test.js
+++ b/test/unit/mongodb/mongodb-group-registry-test.js
@@ -28,6 +28,7 @@
 
 var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
     _ = require('underscore'),
+    groupRegistryMongoDB = require('../../../lib/services/groups/groupRegistryMongoDB'),
     utils = require('../../tools/utils'),
     async = require('async'),
     request = require('request'),
@@ -193,6 +194,7 @@ describe('MongoDB Group Registry test', function() {
     afterEach(function(done) {
         iotAgentLib.deactivate(function() {
             iotAgentDb.close(function(error) {
+                groupRegistryMongoDB.clearCache();
                 mongoUtils.cleanDbs(done);
             });
         });

--- a/test/unit/mongodb/mongodb-registry-test.js
+++ b/test/unit/mongodb/mongodb-registry-test.js
@@ -23,6 +23,7 @@
 'use strict';
 
 var iotAgentLib = require('../../../lib/fiware-iotagent-lib'),
+    deviceRegistryMongoDB = require('../../../lib/services/devices/deviceRegistryMongoDB'),
     utils = require('../../tools/utils'),
     should = require('should'),
     logger = require('logops'),
@@ -202,6 +203,7 @@ describe('MongoDB Device Registry', function() {
         iotAgentLib.deactivate(function(error) {
             iotAgentDb.db().collection('devices').deleteOne(function(error) {
                 iotAgentDb.close(function(error) {
+                    deviceRegistryMongoDB.clearCache();
                     mongoUtils.cleanDbs(done);
                 });
             });

--- a/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
+++ b/test/unit/ngsiv2/lazyAndCommands/polling-commands-test.js
@@ -25,6 +25,7 @@
 'use strict';
 
 var iotAgentLib = require('../../../../lib/fiware-iotagent-lib'),
+    deviceRegistryMongoDB = require('../../../../lib/services/devices/deviceRegistryMongoDB'),
     utils = require('../../../tools/utils'),
     should = require('should'),
     logger = require('logops'),
@@ -151,6 +152,7 @@ describe('NGSI-v2 - Polling commands', function() {
                     nock.cleanAll();
                     iotAgentLib.setDataUpdateHandler();
                     iotAgentLib.setCommandHandler();
+                    deviceRegistryMongoDB.clearCache();
                     done();
                 });
             });


### PR DESCRIPTION
Mongo-DB access is **slow**.  This PR minimizes the need to make database calls, by caching the last 1000 device calls and 100 group calls in a refreshable [cache](https://www.npmjs.com/package/cache-manager). This in turn reduces network traffic and increases maximum throughput.

-  Add [cache-manager](https://www.npmjs.com/package/cache-manager)
-  Wrap mongo-db GET calls
-  Bust cache on any provisioning updates/deletes
-  Update unit tests.