### PR TITLE
Fix issues with Markdown Lint GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![FIWARE IoT Agents](https://nexus.lab.fiware.org/static/badges/chapters/iot-agents.svg)](https://www.fiware.org/developers/catalogue/)
 [![License: APGL](https://img.shields.io/github/license/telefonicaid/iotagent-node-lib.svg)](https://opensource.org/licenses/AGPL-3.0)
-[![Support badge](https://nexus.lab.fiware.org/repository/raw/public/badges/stackoverflow/iot-agents.svg)](https://stackoverflow.com/questions/tagged/fiware+iot)
+[![Support badge](https://img.shields.io/badge/tag-fiware+iot-orange.svg?logo=stackoverflow)](https://stackoverflow.com/questions/tagged/fiware+iot)
 <br/>
 [![Documentation badge](https://img.shields.io/readthedocs/iotagent-node-lib.svg)](http://iotagent-node-lib.readthedocs.org/en/latest/?badge=latest)
-[![CI](https://github.com/telefonicaid/iotagent-json/workflows/CI/badge.svg)](https://github.com/telefonicaid/iotagent-json/actions?query=workflow%3ACI)
+[![CI](https://github.com/telefonicaid/iotagent-node-lib/workflows/CI/badge.svg)](https://github.com/telefonicaid/iotagent-node-lib/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/telefonicaid/iotagent-node-lib/badge.svg?branch=master)](https://coveralls.io/github/telefonicaid/iotagent-node-lib?branch=master)
 ![Status](https://nexus.lab.fiware.org/static/badges/statuses/iot-node-lib.svg)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -30,7 +30,7 @@ The IoT Agents provide two means to define those service groups:
 
 -   Static **Type Configuration**: configuring the `ngsi.types` attribute within the `config.js` file.
 -   Dynamic **Configuration API**: making use of the API URLs in the configuration URI, `/iot/services`. Please, note
-    that the configuration API manage servers under an URL that requires the `server.name` parameter to be set (the name
+    that the configuration API manage servers under a URL that requires the `server.name` parameter to be set (the name
     of the IoT Agent we are using). If no name is configured `default` is taken as the default one.
 
 Both approaches provide the same configuration information for the types and end up in the same configuration

--- a/doc/development.md
+++ b/doc/development.md
@@ -88,7 +88,7 @@ npm run clean
 
 ### Documentation Markdown validation
 
-Checks the markdown documentation for consistency
+Checks the Markdown documentation for consistency
 
 ```bash
 # Use git-bash on Windows
@@ -97,7 +97,7 @@ npm run lint:md
 
 ### Documentation Spell-checking
 
-Uses the provided `.textlintrc` flag file. To check the markdown documentation for spelling and grammar errors, dead
+Uses the provided `.textlintrc` flag file. To check the Markdown documentation for spelling and grammar errors, dead
 links & etc.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "should": "13.2.3",
     "sinon": "~9.0.2",
     "textlint": "~11.7.6",
+    "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-common-misspellings": "~1.0.1",
     "textlint-rule-no-dead-link": "~4.7.0",
     "textlint-rule-terminology": "~2.1.4",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "should": "13.2.3",
     "sinon": "~9.0.2",
     "textlint": "~11.7.6",
-    "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-filter-rule-comments": "~1.2.2",
     "textlint-rule-common-misspellings": "~1.0.1",
     "textlint-rule-no-dead-link": "~4.7.0",
     "textlint-rule-terminology": "~2.1.4",


### PR DESCRIPTION
Add missing text-lint package. The latest text-lint complains if you add something like *comments* in the config, but don't include the module.