### PR TITLE
revert check_ngsi2 function

### DIFF
--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -516,6 +516,20 @@ function ngsiVersion() {
 }
 
 /**
+ * It checks if the configuration file states the use of NGSIv2
+ * Returns the supported NGSI format
+ *
+ *
+ * @return     {boolean}  Result of the checking
+ */
+function checkNgsi2() {
+    if (ngsiVersion() === 'v2') {
+        return true;
+    }
+    return false;
+}
+
+/**
  * It checks if the configuration file states a non-legacy format,
  * either v2, LD or mixed.
  *

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -521,6 +521,7 @@ function ngsiVersion() {
  *
  * @return     {boolean}  Result of the checking
  */
+/* eslint-disable-next-line no-unused-vars */
 function checkNgsi2() {
     if (ngsiVersion() === 'v2') {
         return true;

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -519,7 +519,6 @@ function ngsiVersion() {
  * It checks if the configuration file states the use of NGSIv2
  * Returns the supported NGSI format
  *
- *
  * @return     {boolean}  Result of the checking
  */
 function checkNgsi2() {

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -519,6 +519,10 @@ function ngsiVersion() {
  * It checks if the configuration file states the use of NGSIv2
  * Returns the supported NGSI format
  *
+ * FIXME: this function was removed in https://github.com/telefonicaid/iotagent-node-lib/pull/947. However
+ * it is used by IOTAs code (e.g. https://github.com/telefonicaid/iotagent-ul/blob/c59bcb21f7408a6c7cc3b50d1d0c4e38fc7478c3/lib/iotaUtils.js#L327)
+ * We re-introduce this function to fix CI e2e test but a definitive fix should probably done (in the IOTAs code maybe)
+ *
  * @return     {boolean}  Result of the checking
  */
 /* eslint-disable-next-line no-unused-vars */


### PR DESCRIPTION
Introduced by https://github.com/telefonicaid/iotagent-node-lib/pull/947

All these CI test are failing:
```
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_JSON and HTTP binding -- @1.1 2 min 17 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_JSON and HTTP binding -- @1.2 2 min 19 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_JSON and HTTP binding -- @1.3 2 min 21 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_JSON and HTTP binding -- @1.4 2 min 30 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_JSON and HTTP binding -- @1.1 2 min 27 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_JSON and HTTP binding -- @1.2 2 min 33 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_JSON and HTTP binding -- @1.3 2 min 17 sec 3
>>> features.TS02_iotaflows.004_iotajsonhttp2cb.IOT-iota004 IOTA_JSON with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_JSON and HTTP binding -- @1.4 2 min 52 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_UL and HTTP binding -- @1.1 2 min 34 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_UL and HTTP binding -- @1.2 2 min 12 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_UL and HTTP binding -- @1.3 2 min 23 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_1 Simple measure received thought IOTA_UL and HTTP binding -- @1.4 2 min 16 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_UL and HTTP binding -- @1.1 2 min 15 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_UL and HTTP binding -- @1.2 2 min 22 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_UL and HTTP binding -- @1.3 2 min 14 sec 3
>>> features.TS02_iotaflows.001_iotaulhttp2cb.IOT-iota001 IOTA_UL with HTTP binding to CB through IOTA.SC_2 Multiple measure received thought IOTA_UL and HTTP binding -- @1.4
```


```
iot-iota-ul                 | time=2020-12-04T09:53:11.185Z | lvl=FATAL | corr=n/a | trans=n/a | op=IoTAgentNGSI.Global | from=n/a | srv=n/a | subsrv=n/a | msg=An unexpected exception has been raised. Ignoring: TypeError: iotAgentLib.configModule.checkNgsi2 is not a function | comp=IoTAgent
```

Used by current iotas (ul, json...)
Backward compatibility is a must.