### PR TITLE
Add  colorization parameter to test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint:text": "textlint '*.md' 'doc/*.md'",
     "prettier": "prettier --config .prettierrc.json --write '**/**/**/**/*.js' '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "prettier:text": "prettier 'README.md' 'doc/*.md' 'doc/**/*.md' --no-config --tab-width 4 --print-width 120 --write --prose-wrap always",
-    "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit",
+    "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 5000 --ui bdd --exit --color true",
     "test:coverage": "nyc --reporter=lcov mocha -- --recursive 'test/**/*.js' --reporter spec --timeout 5000 --exit",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "test:watch": "npm run test -- -w ./lib",


### PR DESCRIPTION
Trivial change to `package.json` - adding ` --color true` enables the GitHub Action to display colorfully.

### Before

![Screenshot 2020-12-10 at 10 59 05](https://user-images.githubusercontent.com/3439249/101757165-1afb7980-3ad7-11eb-9827-c7a90c190001.png)

### After

![Screenshot 2020-12-10 at 10 58 48](https://user-images.githubusercontent.com/3439249/101757180-2058c400-3ad7-11eb-8884-2e68b5cd6b89.png)
