### PR TITLE
Remove checkNgsi2 after compatibility fixes

### DIFF
--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -525,15 +525,13 @@ function ngsiVersion() {
  * It checks if the configuration file states the use of NGSIv2
  * Returns the supported NGSI format
  *
- * FIXME: this function was removed in https://github.com/telefonicaid/iotagent-node-lib/pull/947. However
- * it is used by IOTAs code (e.g. https://github.com/telefonicaid/iotagent-ul/blob/c59bcb21f7408a6c7cc3b50d1d0c4e38fc7478c3/lib/iotaUtils.js#L327)
- * We re-introduce this function to fix CI e2e test but a definitive fix should probably done (in the IOTAs code maybe)
- *
  * @return     {boolean}  Result of the checking
  */
-/* eslint-disable-next-line no-unused-vars */
 function checkNgsi2() {
-    if (ngsiVersion() === 'v2') {
+    if (ngsiVersion() === 'mixed') {
+        logger.warn('use of checkNgsi2() is unpredictable in mixed mode');
+        return true;
+    } else if (ngsiVersion() === 'v2') {
         return true;
     }
     return false;

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -522,22 +522,6 @@ function ngsiVersion() {
 }
 
 /**
- * It checks if the configuration file states the use of NGSIv2
- * Returns the supported NGSI format
- *
- * @return     {boolean}  Result of the checking
- */
-function checkNgsi2() {
-    if (ngsiVersion() === 'mixed') {
-        logger.warn('use of checkNgsi2() is unpredictable in mixed mode');
-        return true;
-    } else if (ngsiVersion() === 'v2') {
-        return true;
-    }
-    return false;
-}
-
-/**
  * It checks if the configuration file states a non-legacy format,
  * either v2, LD or mixed.
  *
@@ -577,8 +561,6 @@ exports.getGroupRegistry = getGroupRegistry;
 exports.setCommandRegistry = setCommandRegistry;
 exports.getCommandRegistry = getCommandRegistry;
 exports.ngsiVersion = ngsiVersion;
-// FIXME: We re-introduce this function to fix CI e2e test but a definitive fix should probably done (in the IOTAs code maybe)
-exports.checkNgsi2 = checkNgsi2;
 exports.checkNgsiLD = checkNgsiLD;
 exports.isCurrentNgsi = isCurrentNgsi;
 exports.setSecurityService = setSecurityService;


### PR DESCRIPTION
Related https://github.com/telefonicaid/iotagent-node-lib/issues/963

 `checkNgsi2()` is superceded by `isCurrentNgsi()` which in turn can be removed once NGSI-v1 backwards compatibility is dropped in the IoT Agents