### PR TITLE
add device.apikey to provisioningAPITranslation

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Return apikey in GET device if device was provisioned with explicit apikey
 Use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
 Add basic NGSI-LD support as experimental feature (#842)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Return apikey in GET device if device was provisioned with explicit apikey
+Return apikey in GET device if device was provisioned with explicit apikey (#977)
 Use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
 Add basic NGSI-LD support as experimental feature (#842)

--- a/lib/services/northBound/deviceProvisioningServer.js
+++ b/lib/services/northBound/deviceProvisioningServer.js
@@ -43,6 +43,7 @@ const provisioningAPITranslation = {
     /* jshint camelcase:false */
 
     name: 'id',
+    apikey: 'apikey',
     service: 'service',
     service_path: 'subservice',
     entity_name: 'name',
@@ -194,6 +195,7 @@ function toProvisioningAPIFormat(device) {
     /* jshint camelcase:false */
     return {
         device_id: device.id,
+        apikey: device.apikey,
         service: device.service,
         service_path: device.subservice,
         entity_name: device.name,


### PR DESCRIPTION
Currently a GET device does not retrieve apikey if was provisioned at device level
This PR returns apikey with device provisioning data if was provisioned.

issue https://github.com/telefonicaid/iotagent-node-lib/issues/977