### PR TITLE
Task/add apikey device update

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Add apikey to device update
 Use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
 Add basic NGSI-LD support as experimental feature (#842)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Allow update device `apikey` using Update API (put)
+Allow update device `apikey` using Update (put) API (#978)
 Use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
 Add basic NGSI-LD support as experimental feature (#842)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,7 +1,7 @@
-Allow update device `apikey` using Update (put) API (#978)
-Use null instead of ' ' as default attribute value in entity provisioned (#938)
+Add: allow update device `apikey` using Update (put) API (#978)
+Fix: use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
-Add basic NGSI-LD support as experimental feature (#842)
+Add: basic NGSI-LD support as experimental feature (#842)
 - Active measures
 - GeoJSON and DateTime, unitCode and observedAt NGSI-LD support
     -  The NGSI v2 `TimeInstant` element has been mapped onto the NGSI-LD `observedAt` property
@@ -15,8 +15,8 @@ Update codebase to use ES6
 -  Add esLint using standard tamia presets
 -  Replace var with let/const
 -  Fix or disable eslint errors
-Add prettier code formatting
-Add husky and lint-staged
+Add: prettier code formatting
+Add: husky and lint-staged
 Fix: Add support for lazy and internal_attributes in service notifications to Manager (#768)
 Fix: combine multi-entity and expressions with duplicate attribute name, by enabling expression over object_id (which are not duplicated in a attribute mapping contrary to name) (#941)
 Fix: bug in legacy and JEXL expression that was not converting "0" to 0

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Add apikey to device update
+Allow update device `apikey` using Update API (put)
 Use null instead of ' ' as default attribute value in entity provisioned (#938)
 Add: defaultEntityNameConjunction config (env var IOTA_DEFAULT_ENTITY_NAME_CONJUNCTION) and configuration group API field for default entity_name conjunction (#944)
 Add basic NGSI-LD support as experimental feature (#842)

--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -269,12 +269,13 @@ function getByName(name, service, servicepath, callback) {
 }
 
 /**
- * Updates the given device into the database. Only the following attributes: lazy, active and internalId will be
+ * Updates the given device into the database.
  * updated.
  *
  * @param {Object} device       Device object with the new values to write.
  */
 function update(device, callback) {
+    logger.debug(context, 'Storing updated values for device [%s]:\n%s', device.id, JSON.stringify(device, null, 4));
     getDeviceById(device.id, device.service, device.subservice, function (error, data) {
         if (error) {
             callback(error);
@@ -287,6 +288,7 @@ function update(device, callback) {
             data.endpoint = device.endpoint;
             data.name = device.name;
             data.type = device.type;
+            data.apikey = device.apikey;
             data.explicitAttrs = device.explicitAttrs;
             data.ngsiVersion = device.ngsiVersion;
 


### PR DESCRIPTION
Currently a device could be provisioned with a explicit apikey (i.e. different to group service).
https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/api.md#device-model

But there is no way to update device apikey using PUT update API
https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/api.md#put-iotdevicesdeviceid
This PR fixes it

issue https://github.com/telefonicaid/iotagent-node-lib/issues/978