### PR TITLE
 ensure registrationId is updated when a device with commans is updated

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Fix: ensure registrationId is updated when defice with commands is updated 
 Add: return apikey in GET device if device was provisioned with explicit apikey (#977)
 Add: allow update device `apikey` using Update (put) API (#978)
 Fix: use null instead of ' ' as default attribute value in entity provisioned (#938)

--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -289,6 +289,7 @@ function update(device, callback) {
             data.name = device.name;
             data.type = device.type;
             data.apikey = device.apikey;
+            data.registrationId = device.registrationId;
             data.explicitAttrs = device.explicitAttrs;
             data.ngsiVersion = device.ngsiVersion;
 


### PR DESCRIPTION
SInce latest iotagent and node-lib verison (from master), when a device with a command is updated a new registrationId is performed (deleting previous one) but no registrationId is properly stored. 

This bug is not reproduced with iotagent 1.16.0 which uses iota-node-lib 2.14.0

