### PR TITLE
Fully Remove Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     strategy:
       matrix:
         node-version:
+          # FIXME: node v10 has been deprecated, but we are going to keep its regression for a while
+          - 10.x
           - 12.x
           - 14.x
     steps:

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -42,4 +42,4 @@ The following table provides information about the last iotagent-node-lib versio
 | Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018                 |
 | Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                      |
 | Support to Node.js v8  | 2.12.0                                                | April 7th, 2020                    |
-| Support to Node.js v10 | 2.15.0   | February 18th 2021                |
+| Support to Node.js v10 | 2.15.0   | February 18th, 2021                |

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -42,4 +42,4 @@ The following table provides information about the last iotagent-node-lib versio
 | Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018                 |
 | Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                      |
 | Support to Node.js v8  | 2.12.0                                                | April 7th, 2020                    |
-| Support to Node.js v10 | February 18th 2021     | 2.15.0               |
+| Support to Node.js v10 | 2.15.0   | February 18th 2021                |

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -16,7 +16,7 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v4 in iotagent-node-lib 2.8.1 (finally removed in 2.9.0)
 -   Support to Node.js v6 in iotagent-node-lib 2.9.0 (finally removed in 2.10.0)
 -   Support to Node.js v8 in iotagent-node-lib 2.12.0 (finally removed in 2.13.0)
--   Support to Node.js v10 in iotagent-node-lib 2.15.0.
+-   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 
 The use of Node.js v12 is highly recommended.
 
@@ -42,4 +42,4 @@ The following table provides information about the last iotagent-node-lib versio
 | Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018                 |
 | Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                      |
 | Support to Node.js v8  | 2.12.0                                                | April 7th, 2020                    |
-| Support to Node.js v10 | Not defined but it will completed before May 2021     | Not yet defined               |
+| Support to Node.js v10 | February 18th 2021     | 2.15.0               |

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "main": "lib/fiware-iotagent-lib",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",


### PR DESCRIPTION
With the release of 2.15.0, Node 10 can be fully removed for the next release. No rush to merge this, just raising it whilst I remember to do it.