### PR TITLE
fix group command in device when entity_type is not equal group entity_type

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: group command is not provisioned in device when entity_type is different (#1011)
 - Add: use getDeviceSilently in checkDuplicates to avoid raise a false mongo alarm.
 - Add: expose getConfigurationSilently to enable retrieve a configuration without raise a false mongo alarm (#1007)
 - Add: db uri and options in mongo connection log INFO trace

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -201,7 +201,7 @@ function findConfigurationGroup(deviceObj, callback) {
     } else {
         config
             .getGroupRegistry()
-            .findTypeSilently(deviceObj.service, deviceObj.subservice, deviceObj.apikey, handlerGroupFind);
+            .findSilently(deviceObj.service, deviceObj.subservice, deviceObj.apikey, handlerGroupFind);
     }
 }
 

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -201,13 +201,7 @@ function findConfigurationGroup(deviceObj, callback) {
     } else {
         config
             .getGroupRegistry()
-            .findTypeSilently(
-                deviceObj.service,
-                deviceObj.subservice,
-                deviceObj.type,
-                deviceObj.apikey,
-                handlerGroupFind
-            );
+            .findTypeSilently(deviceObj.service, deviceObj.subservice, deviceObj.apikey, handlerGroupFind);
     }
 }
 
@@ -225,15 +219,19 @@ function findConfigurationGroup(deviceObj, callback) {
  */
 function registerDevice(deviceObj, callback) {
     function checkDuplicates(deviceObj, innerCb) {
-        config.getRegistry().getSilently(deviceObj.id, deviceObj.service, deviceObj.subservice, 
-                                         /* eslint-disable-next-line no-unused-vars */
-                                         function (error, device) {
-            if (!error) {
-                innerCb(new errors.DuplicateDeviceId(deviceObj.id));
-            } else {
-                innerCb();
+        config.getRegistry().getSilently(
+            deviceObj.id,
+            deviceObj.service,
+            deviceObj.subservice,
+            /* eslint-disable-next-line no-unused-vars */
+            function (error, device) {
+                if (!error) {
+                    innerCb(new errors.DuplicateDeviceId(deviceObj.id));
+                } else {
+                    innerCb();
+                }
             }
-        });
+        );
     }
 
     function prepareDeviceData(deviceObj, configuration, callback) {

--- a/lib/services/groups/groupRegistryMemory.js
+++ b/lib/services/groups/groupRegistryMemory.js
@@ -289,6 +289,7 @@ exports.find = intoTrans(context, find);
 exports.findBy = intoTrans(context, findBy);
 exports.findType = intoTrans(context, findBy(['service', 'subservice', 'type']));
 exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type']));
+exports.findSilently = intoTrans(context, findBy(['service', 'subservice']));
 exports.get = intoTrans(context, getSingleGroup);
 exports.getSilently = intoTrans(context, getSingleGroup);
 exports.getType = intoTrans(context, getSingleGroupType);

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -303,8 +303,11 @@ exports.create = alarmsInt(constants.MONGO_ALARM, intoTrans(context, createGroup
 exports.list = alarmsInt(constants.MONGO_ALARM, intoTrans(context, listGroups));
 exports.init = alarmsInt(constants.MONGO_ALARM, intoTrans(context, init));
 exports.find = alarmsInt(constants.MONGO_ALARM, intoTrans(context, find));
-exports.findType = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['service', 'subservice', 'apikey'])));
-exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'apikey']));
+exports.findType = alarmsInt(
+    constants.MONGO_ALARM,
+    intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']))
+);
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']));
 exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -303,11 +303,8 @@ exports.create = alarmsInt(constants.MONGO_ALARM, intoTrans(context, createGroup
 exports.list = alarmsInt(constants.MONGO_ALARM, intoTrans(context, listGroups));
 exports.init = alarmsInt(constants.MONGO_ALARM, intoTrans(context, init));
 exports.find = alarmsInt(constants.MONGO_ALARM, intoTrans(context, find));
-exports.findType = alarmsInt(
-    constants.MONGO_ALARM,
-    intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']))
-);
-exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']));
+exports.findType = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['service', 'subservice', 'apikey'])));
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'apikey']));
 exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -307,7 +307,8 @@ exports.findType = alarmsInt(
     constants.MONGO_ALARM,
     intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']))
 );
-exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'apikey']));
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']));
+exports.findSilently = intoTrans(context, findBy(['service', 'subservice', 'apikey']));
 exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -307,7 +307,7 @@ exports.findType = alarmsInt(
     constants.MONGO_ALARM,
     intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']))
 );
-exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'type', 'apikey']));
+exports.findTypeSilently = intoTrans(context, findBy(['service', 'subservice', 'apikey']));
 exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));


### PR DESCRIPTION
Fix for https://github.com/telefonicaid/iotagent-node-lib/issues/1011

Search by `apikey` should be enough since `apikey` is unique key in Group model. Ensure that also type match is not necessary.

