### PR TITLE
type point (and others) should not translated to geo:json

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Hotfix: avoid automatic conversion from geo:xxxx ('xxxx' diferent from 'json') to geo:json (reverts the work done in PR  #854)

--- a/doc/advanced-topics.md
+++ b/doc/advanced-topics.md
@@ -46,7 +46,7 @@ curl http://${KEYSTONE_HOST}/v3/OS-TRUST/trusts \
 Apart from the generation of the trust, the use of secured Context Brokers should be transparent to the user of the IoT
 Agent.
 
-### GeoJSON support
+### GeoJSON support (this only applies for NGSI-LD, not for NGSIv1 and NGSIv2)
 
 The defined `type` of any GeoJSON attribute can be any set to any of the standard NGSI-v2 GeoJSON types - (e.g.
 `geo:json`, `geo:point`). NGSI-LD formats such as `GeoProperty`, `Point` and `LineString` are also accepted `type`
@@ -69,19 +69,17 @@ values. If the latitude and longitude are received as separate measures, the
 }
 ```
 
+For `attributes` and `static_attributes` which need to be formatted as GeoJSON values, three separate input formats are
+accepted. Provided the `type` is provisioned correctly, the `value` may be defined using any of the following formats:
 
-For `attributes` and `static_attributes` which need to be formatted as GeoJSON values, three separate input
-formats are accepted. Provided the `type` is provisioned correctly, the `value` may be defined using any of
-the following formats:
-
--  a comma delimited string
+-   a comma delimited string
 
 ```json
 {
-  "name": "location",
-  "value": "23, 12.5"
+    "name": "location",
+    "value": "23, 12.5"
 }
-````
+```
 
 -   an array of numbers
 
@@ -185,11 +183,12 @@ Other unrecognised `type` attributes will be passed as NGSI-LD data using the fo
     }
 ```
 
-
 ### NGSI-LD Linked Data support
 
-`static_attributes` may be supplied with an additional `link` data element when provisioning an IoT Agent to ensure that active attributes from the provisioned IoT Device may be maintained in parallel with a linked data entity . Take for example a temperature gauge placed within a building.
-The **Device** data model literally represents the IoT device itself, but the `temperature` attribute also needs to be shared with the **Building** entity
+`static_attributes` may be supplied with an additional `link` data element when provisioning an IoT Agent to ensure that
+active attributes from the provisioned IoT Device may be maintained in parallel with a linked data entity . Take for
+example a temperature gauge placed within a building. The **Device** data model literally represents the IoT device
+itself, but the `temperature` attribute also needs to be shared with the **Building** entity
 
 A `link` between them can be provisioned as shown:
 
@@ -223,7 +222,8 @@ e.g.:
   }
 ```
 
-Whenever a `temperature` measure is received **Device** is updated,  and entity `urn:ngsi-ld:Building:001` is also updated as shown:
+Whenever a `temperature` measure is received **Device** is updated, and entity `urn:ngsi-ld:Building:001` is also
+updated as shown:
 
 ```json
 "temperature": {
@@ -292,7 +292,7 @@ The library provides some plugins out of the box, in the `dataPlugins` collectio
 use the `addQueryMiddleware` and `addUpdateMiddleware` functions with the selected plugin, as in the example:
 
 ```javascript
-var iotaLib = require("iotagent-node-lib");
+var iotaLib = require('iotagent-node-lib');
 
 iotaLib.addUpdateMiddleware(iotaLib.dataPlugins.compressTimestamp.update);
 iotaLib.addQueryMiddleware(iotaLib.dataPlugins.compressTimestamp.query);

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -55,37 +55,39 @@ function formatGeoAttrs(attr) {
         switch (attr.type.toLowerCase()) {
             // GeoProperties
             case 'geo:json':
-            case 'geoproperty':
-            //case 'point': // FIXME: #1012
-            case 'geo:point':
+                // FIXME: #1012
+                // case 'geoproperty':
+                // case 'point':
+                // case 'geo:point':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('Point', attr.value);
                 break;
-            //case 'linestring': // FIXME: #1012
-            case 'geo:linestring':
-                obj.type = 'geo:json';
-                obj.value = NGSIUtils.getLngLats('LineString', attr.value);
-                break;
-            //case 'polygon': // FIXME: #1012
-            case 'geo:polygon':
-                obj.type = 'geo:json';
-                obj.value = NGSIUtils.getLngLats('Polygon', attr.value);
-                break;
-            //case 'multipoint': // FIXME: #1012
-            case 'geo:multipoint':
-                obj.type = 'geo:json';
-                obj.value = NGSIUtils.getLngLats('MultiPoint', attr.value);
-                break;
-            //case 'multilinestring': // FIXME: #1012
-            case 'geo:multilinestring':
-                obj.type = 'geo:json';
-                obj.value = NGSIUtils.getLngLats('MultiLineString', attr.value);
-                break;
-            //case 'multipolygon': // FIXME: #1012
-            case 'geo:multipolygon':
-                obj.type = 'geo:json';
-                obj.value = NGSIUtils.getLngLats('MultiPolygon', attr.value);
-                break;
+            // FIXME: #1012
+            // case 'linestring':
+            // case 'geo:linestring':
+            //     obj.type = 'geo:json';
+            //     obj.value = NGSIUtils.getLngLats('LineString', attr.value);
+            //     break;
+            // case 'polygon':
+            // case 'geo:polygon':
+            //     obj.type = 'geo:json';
+            //     obj.value = NGSIUtils.getLngLats('Polygon', attr.value);
+            //     break;
+            // case 'multipoint':
+            // case 'geo:multipoint':
+            //     obj.type = 'geo:json';
+            //     obj.value = NGSIUtils.getLngLats('MultiPoint', attr.value);
+            //     break;
+            // case 'multilinestring':
+            // case 'geo:multilinestring':
+            //     obj.type = 'geo:json';
+            //     obj.value = NGSIUtils.getLngLats('MultiLineString', attr.value);
+            //     break;
+            // case 'multipolygon':
+            // case 'geo:multipolygon':
+            //     obj.type = 'geo:json';
+            //     obj.value = NGSIUtils.getLngLats('MultiPolygon', attr.value);
+            //     break;
         }
     }
     return obj;

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -56,32 +56,32 @@ function formatGeoAttrs(attr) {
             // GeoProperties
             case 'geo:json':
             case 'geoproperty':
-            case 'point':
+            //case 'point': // FIXME: #1012
             case 'geo:point':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('Point', attr.value);
                 break;
-            case 'linestring':
+            //case 'linestring': // FIXME: #1012
             case 'geo:linestring':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('LineString', attr.value);
                 break;
-            case 'polygon':
+            //case 'polygon': // FIXME: #1012
             case 'geo:polygon':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('Polygon', attr.value);
                 break;
-            case 'multipoint':
+            //case 'multipoint': // FIXME: #1012
             case 'geo:multipoint':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('MultiPoint', attr.value);
                 break;
-            case 'multilinestring':
+            //case 'multilinestring': // FIXME: #1012
             case 'geo:multilinestring':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('MultiLineString', attr.value);
                 break;
-            case 'multipolygon':
+            //case 'multipolygon': // FIXME: #1012
             case 'geo:multipolygon':
                 obj.type = 'geo:json';
                 obj.value = NGSIUtils.getLngLats('MultiPolygon', attr.value);

--- a/test/unit/ngsiv2/examples/contextRequests/createBidirectionalDevice.json
+++ b/test/unit/ngsiv2/examples/contextRequests/createBidirectionalDevice.json
@@ -2,13 +2,7 @@
   "id": "TheFirstLight",
   "type": "TheLightType",
   "location": {
-    "type": "geo:json",
-    "value": {
-        "coordinates": [
-            0,
-            0
-        ],
-        "type": "Point"
-    }   
+    "type": "geo:point",
+    "value": "0, 0"
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/createGeopointProvisionedDevice.json
+++ b/test/unit/ngsiv2/examples/contextRequests/createGeopointProvisionedDevice.json
@@ -4,6 +4,5 @@
   "location": {
     "type": "geo:point",
     "value": "0, 0"
-    }
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/createGeopointProvisionedDevice.json
+++ b/test/unit/ngsiv2/examples/contextRequests/createGeopointProvisionedDevice.json
@@ -2,13 +2,8 @@
   "id": "FirstMicroLight",
   "type": "MicroLights",
   "location": {
-    "type": "geo:json",
-    "value": {
-        "coordinates": [
-            0,
-            0
-        ],
-        "type": "Point"
+    "type": "geo:point",
+    "value": "0, 0"
     }
   }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributes.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextStaticAttributes.json
@@ -4,10 +4,7 @@
         "type": "boolean"
     },
     "location":{
-        "value":{
-            "type":"Point",
-            "coordinates":[153,523]
-        },
-        "type": "geo:json"
+        "value": "153,523",
+        "type": "geo:point"
     }
 }

--- a/test/unit/ngsiv2/ngsiService/geoproperties-test.js
+++ b/test/unit/ngsiv2/ngsiService/geoproperties-test.js
@@ -65,6 +65,7 @@ describe('NGSI-v2 - Geo-JSON types autocast test', function () {
         iotAgentLib.deactivate(done);
     });
 
+    // FIXME: #1012
     // describe(
     //     'When the IoT Agent receives new geo-information from a device.' +
     //         'Location with geo:json type and String value',

--- a/test/unit/ngsiv2/ngsiService/geoproperties-test.js
+++ b/test/unit/ngsiv2/ngsiService/geoproperties-test.js
@@ -65,361 +65,361 @@ describe('NGSI-v2 - Geo-JSON types autocast test', function () {
         iotAgentLib.deactivate(done);
     });
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with geo:json type and String value',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'geo:json',
-                    value: '23,12.5'
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with geo:json type and String value',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'geo:json',
+    //                 value: '23,12.5'
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with geo:json type and GeoJSON object value',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'geo:json',
-                    value: {
-                        type: 'Point',
-                        coordinates: [23, 12.5]
-                    }
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with geo:json type and GeoJSON object value',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'geo:json',
+    //                 value: {
+    //                     type: 'Point',
+    //                     coordinates: [23, 12.5]
+    //                 }
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe('When the IoT Agent receives new geo-information from a device. Location with Point type and Array value', function () {
-        const values = [
-            {
-                name: 'location',
-                type: 'Point',
-                value: [23, 12.5]
-            }
-        ];
+    // describe('When the IoT Agent receives new geo-information from a device. Location with Point type and Array value', function () {
+    //     const values = [
+    //         {
+    //             name: 'location',
+    //             type: 'Point',
+    //             value: [23, 12.5]
+    //         }
+    //     ];
 
-        beforeEach(function (done) {
-            nock.cleanAll();
+    //     beforeEach(function (done) {
+    //         nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
-                .matchHeader('fiware-service', 'smartGondor')
-                .post(
-                    '/v2/entities/light1/attrs',
-                    utils.readExampleFile(
-                        './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
-                    )
-                )
-                .query({ type: 'Light' })
-                .reply(204);
+    //         contextBrokerMock = nock('http://192.168.1.1:1026')
+    //             .matchHeader('fiware-service', 'smartGondor')
+    //             .post(
+    //                 '/v2/entities/light1/attrs',
+    //                 utils.readExampleFile(
+    //                     './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties1.json'
+    //                 )
+    //             )
+    //             .query({ type: 'Light' })
+    //             .reply(204);
 
-            iotAgentLib.activate(iotAgentConfig, done);
-        });
+    //         iotAgentLib.activate(iotAgentConfig, done);
+    //     });
 
-        it('should change the value of the corresponding attribute in the context broker', function (done) {
-            iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                should.not.exist(error);
-                contextBrokerMock.done();
-                done();
-            });
-        });
-    });
+    //     it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //         iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //             should.not.exist(error);
+    //             contextBrokerMock.done();
+    //             done();
+    //         });
+    //     });
+    // });
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with LineString type and Array value',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'LineString',
-                    value: [
-                        [23, 12.5],
-                        [22, 12.5]
-                    ]
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with LineString type and Array value',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'LineString',
+    //                 value: [
+    //                     [23, 12.5],
+    //                     [22, 12.5]
+    //                 ]
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties2.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties2.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with LineString type and Array of Strings',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'LineString',
-                    value: ['23,12.5', '22,12.5']
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with LineString type and Array of Strings',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'LineString',
+    //                 value: ['23,12.5', '22,12.5']
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties2.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties2.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe('When the IoT Agent receives new geo-information from a device. Location with None type', function () {
-        const values = [
-            {
-                name: 'location',
-                type: 'None',
-                value: 'null'
-            }
-        ];
+    // describe('When the IoT Agent receives new geo-information from a device. Location with None type', function () {
+    //     const values = [
+    //         {
+    //             name: 'location',
+    //             type: 'None',
+    //             value: 'null'
+    //         }
+    //     ];
 
-        beforeEach(function (done) {
-            nock.cleanAll();
+    //     beforeEach(function (done) {
+    //         nock.cleanAll();
 
-            contextBrokerMock = nock('http://192.168.1.1:1026')
-                .matchHeader('fiware-service', 'smartGondor')
-                .post(
-                    '/v2/entities/light1/attrs',
-                    utils.readExampleFile(
-                        './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties3.json'
-                    )
-                )
-                .query({ type: 'Light' })
-                .reply(204);
+    //         contextBrokerMock = nock('http://192.168.1.1:1026')
+    //             .matchHeader('fiware-service', 'smartGondor')
+    //             .post(
+    //                 '/v2/entities/light1/attrs',
+    //                 utils.readExampleFile(
+    //                     './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties3.json'
+    //                 )
+    //             )
+    //             .query({ type: 'Light' })
+    //             .reply(204);
 
-            iotAgentLib.activate(iotAgentConfig, done);
-        });
+    //         iotAgentLib.activate(iotAgentConfig, done);
+    //     });
 
-        it('should change the value of the corresponding attribute in the context broker', function (done) {
-            iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                should.not.exist(error);
-                contextBrokerMock.done();
-                done();
-            });
-        });
-    });
+    //     it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //         iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //             should.not.exist(error);
+    //             contextBrokerMock.done();
+    //             done();
+    //         });
+    //     });
+    // });
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with Polygon type - Array of coordinates',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'Polygon',
-                    value: [
-                        [23, 12.5],
-                        [22, 13.5],
-                        [22, 13.5]
-                    ]
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with Polygon type - Array of coordinates',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'Polygon',
+    //                 value: [
+    //                     [23, 12.5],
+    //                     [22, 13.5],
+    //                     [22, 13.5]
+    //                 ]
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties4.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties4.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe(
-        'When the IoT Agent receives new geo-information from a device.' +
-            'Location with Polygon type - list of coordinates',
-        function () {
-            const values = [
-                {
-                    name: 'location',
-                    type: 'Polygon',
-                    value: '23,12.5,22,13.5,22,13.5'
-                }
-            ];
+    // describe(
+    //     'When the IoT Agent receives new geo-information from a device.' +
+    //         'Location with Polygon type - list of coordinates',
+    //     function () {
+    //         const values = [
+    //             {
+    //                 name: 'location',
+    //                 type: 'Polygon',
+    //                 value: '23,12.5,22,13.5,22,13.5'
+    //             }
+    //         ];
 
-            beforeEach(function (done) {
-                nock.cleanAll();
+    //         beforeEach(function (done) {
+    //             nock.cleanAll();
 
-                contextBrokerMock = nock('http://192.168.1.1:1026')
-                    .matchHeader('fiware-service', 'smartGondor')
-                    .post(
-                        '/v2/entities/light1/attrs',
-                        utils.readExampleFile(
-                            './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties4.json'
-                        )
-                    )
-                    .query({ type: 'Light' })
-                    .reply(204);
+    //             contextBrokerMock = nock('http://192.168.1.1:1026')
+    //                 .matchHeader('fiware-service', 'smartGondor')
+    //                 .post(
+    //                     '/v2/entities/light1/attrs',
+    //                     utils.readExampleFile(
+    //                         './test/unit/ngsiv2/examples/contextRequests/updateContextGeoproperties4.json'
+    //                     )
+    //                 )
+    //                 .query({ type: 'Light' })
+    //                 .reply(204);
 
-                iotAgentLib.activate(iotAgentConfig, done);
-            });
+    //             iotAgentLib.activate(iotAgentConfig, done);
+    //         });
 
-            it('should change the value of the corresponding attribute in the context broker', function (done) {
-                iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                    should.not.exist(error);
-                    contextBrokerMock.done();
-                    done();
-                });
-            });
-        }
-    );
+    //         it('should change the value of the corresponding attribute in the context broker', function (done) {
+    //             iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //                 should.not.exist(error);
+    //                 contextBrokerMock.done();
+    //                 done();
+    //             });
+    //         });
+    //     }
+    // );
 
-    describe('When the IoT Agent receives new geo-information from a device. Location with a missing latitude', function () {
-        const values = [
-            {
-                name: 'location',
-                type: 'Point',
-                value: '23,12.5,22,13.5,22'
-            }
-        ];
+    // describe('When the IoT Agent receives new geo-information from a device. Location with a missing latitude', function () {
+    //     const values = [
+    //         {
+    //             name: 'location',
+    //             type: 'Point',
+    //             value: '23,12.5,22,13.5,22'
+    //         }
+    //     ];
 
-        beforeEach(function (done) {
-            nock.cleanAll();
-            iotAgentLib.activate(iotAgentConfig, done);
-        });
+    //     beforeEach(function (done) {
+    //         nock.cleanAll();
+    //         iotAgentLib.activate(iotAgentConfig, done);
+    //     });
 
-        it('should throw a BadGeocoordinates Error', function (done) {
-            iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                should.exist(error);
-                done();
-            });
-        });
-    });
+    //     it('should throw a BadGeocoordinates Error', function (done) {
+    //         iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //             should.exist(error);
+    //             done();
+    //         });
+    //     });
+    // });
 
-    describe('When the IoT Agent receives new geo-information from a device. Location invalid coordinates', function () {
-        const values = [
-            {
-                name: 'location',
-                type: 'Point',
-                value: '2016-04-30Z'
-            }
-        ];
+    // describe('When the IoT Agent receives new geo-information from a device. Location invalid coordinates', function () {
+    //     const values = [
+    //         {
+    //             name: 'location',
+    //             type: 'Point',
+    //             value: '2016-04-30Z'
+    //         }
+    //     ];
 
-        beforeEach(function (done) {
-            nock.cleanAll();
-            iotAgentLib.activate(iotAgentConfig, done);
-        });
+    //     beforeEach(function (done) {
+    //         nock.cleanAll();
+    //         iotAgentLib.activate(iotAgentConfig, done);
+    //     });
 
-        it('should throw a BadGeocoordinates Error', function (done) {
-            iotAgentLib.update('light1', 'Light', '', values, function (error) {
-                should.exist(error);
-                done();
-            });
-        });
-    });
+    //     it('should throw a BadGeocoordinates Error', function (done) {
+    //         iotAgentLib.update('light1', 'Light', '', values, function (error) {
+    //             should.exist(error);
+    //             done();
+    //         });
+    //     });
+    // });
 });


### PR DESCRIPTION
exclude to be translated to geo:json the following types:
geoproperty, point, geo:point, linestring, geo:linestring, polygon, geo:polygon, multipoint, geo:multipoint, multilinestring, geo:multilinestring, multipolygon, geo:multipolygon

keeping their previous type and ensuring backward compatibility with current integrations


hotfix https://github.com/telefonicaid/iotagent-node-lib/issues/1012