### PR TITLE
[WIP] fix error log when get group from type registering a device

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Add: add getTypeSilently for device group and use in device registration to avoid false mongo alarm
 - Fix: group command is not provisioned in device when entity_type is different (#1011)
 - Hotfix: avoid automatic conversion from geo:xxxx ('xxxx' diferent from 'json') to geo:json (reverts the work done in PR  #854)
 - Add: use getDeviceSilently in checkDuplicates to avoid raise a false mongo alarm.

--- a/lib/services/groups/groupRegistryMemory.js
+++ b/lib/services/groups/groupRegistryMemory.js
@@ -293,6 +293,7 @@ exports.findSilently = intoTrans(context, findBy(['service', 'subservice']));
 exports.get = intoTrans(context, getSingleGroup);
 exports.getSilently = intoTrans(context, getSingleGroup);
 exports.getType = intoTrans(context, getSingleGroupType);
+exports.getTypeSilently = intoTrans(context, getSingleGroupType);
 exports.update = intoTrans(context, update);
 exports.remove = intoTrans(context, remove);
 exports.clear = intoTrans(context, clear);

--- a/lib/services/groups/groupRegistryMongoDB.js
+++ b/lib/services/groups/groupRegistryMongoDB.js
@@ -313,6 +313,7 @@ exports.findBy = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy));
 exports.get = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['resource', 'apikey'])));
 exports.getSilently = intoTrans(context, findBy(['resource', 'apikey']));
 exports.getType = alarmsInt(constants.MONGO_ALARM, intoTrans(context, findBy(['type'])));
+exports.getTypeSilently = intoTrans(context, findBy(['type']));
 exports.update = alarmsInt(constants.MONGO_ALARM, intoTrans(context, update));
 exports.remove = alarmsInt(constants.MONGO_ALARM, intoTrans(context, remove));
 exports.clear = alarmsInt(constants.MONGO_ALARM, intoTrans(context, clear));

--- a/lib/services/northBound/restUtils.js
+++ b/lib/services/northBound/restUtils.js
@@ -228,7 +228,7 @@ function isTimestampedNgsi2(payload) {
  */
 function executeWithSecurity(requestOptions, deviceData, callback) {
     logger.debug(context, 'executeWithSecurity');
-    config.getGroupRegistry().getType(deviceData.type, function (error, deviceGroup) {
+    config.getGroupRegistry().getTypeSilently(deviceData.type, function (error, deviceGroup) {
         let typeInformation;
         if (error) {
             logger.debug(context, 'error %j in get group device', error);


### PR DESCRIPTION
fix for https://github.com/telefonicaid/iotagent-node-lib/issues/1003#issuecomment-815630818


time=2021-04-09T07:49:27.026Z | lvl=DEBUG | corr=46eb979e-c1d1-44de-93cb-d913b841a22b | trans=46eb979e-c1d1-44de-93cb-d913b841a22b | op=IoTAgentNGSI.GenericMiddlewares | from=n/a | srv=smartcity | subsrv=/ | msg=Request for path [/iot/devices] from [localhost:18082] | comp=IoTAgent
time=2021-04-09T07:49:27.026Z | lvl=DEBUG | corr=46eb979e-c1d1-44de-93cb-d913b841a22b | trans=46eb979e-c1d1-44de-93cb-d913b841a22b | op=IoTAgentNGSI.GenericMiddlewares | from=n/a | srv=smartcity | subsrv=/ | msg=Body:

{
    "devices": [
        {
            "device_id": "sensor002",
            "entity_name": "sensor002_entity",
            "entity_type": "Sensor",
            "timezone": "Europe/Berlin",
            "attributes": [
                {
                    "object_id": "temperature",
                    "name": "temperature",
                    "type": "number"
                }
            ],
            "autoprovision": false,
            "protocol": "IoTA-UL"
        }
    ]
}

 | comp=IoTAgent
time=2021-04-09T07:49:27.027Z | lvl=DEBUG | corr=46eb979e-c1d1-44de-93cb-d913b841a22b | trans=46eb979e-c1d1-44de-93cb-d913b841a22b | op=IoTAgentNGSI.DeviceProvisioning | from=n/a | srv=smartcity | subsrv=/ | msg=Handling device provisioning request. | comp=IoTAgent
time=2021-04-09T07:49:27.027Z | lvl=DEBUG | corr=46eb979e-c1d1-44de-93cb-d913b841a22b | trans=46eb979e-c1d1-44de-93cb-d913b841a22b | op=IoTAgentNGSI.MongoDBDeviceRegister | from=n/a | srv=smartcity | subsrv=/ | msg=Looking for device with id [sensor002]. | comp=IoTAgent
time=2021-04-09T07:49:27.032Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.MongoDBDeviceRegister | from=n/a | srv=smartcity | subsrv=/ | msg=Device [sensor002] not found. | comp=IoTAgent
time=2021-04-09T07:49:27.032Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=n/a | subsrv=n/a | msg=Looking for group params ["service","subservice","apikey"] with queryObj {"service":"smartcity","subservice":"/"} | comp=IoTAgent
time=2021-04-09T07:49:27.035Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=smartcity | subsrv=/ | msg=Device group data found: {"_id":"6059c2fa3ac19c577da6ed1e","commands":[{"name":"MiOtrocommand","type":"command","value":""}],"staticAttributes":[],"attributes":[],"resource":"/iot/d","apikey":"0pbjm5q950pfcrbs8e407ysfk","type":"thing","service":"smartcity","subservice":"/","description":"UL2","timestamp":true,"internalAttributes":[],"lazy":[]} | comp=IoTAgent
time=2021-04-09T07:49:27.035Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.DeviceService | from=n/a | srv=n/a | subsrv=n/a | msg=deviceData before merge with conf: {"id":"sensor002","type":"Sensor","name":"sensor002_entity","service":"smartcity","subservice":"/","active":[{"object_id":"temperature","name":"temperature","type":"number"}],"timezone":"Europe/Berlin","protocol":"IoTA-UL","internalId":null,"autoprovision":false,"explicitAttrs":false} | comp=IoTAgent
time=2021-04-09T07:49:27.035Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.DeviceService | from=n/a | srv=n/a | subsrv=n/a | msg=deviceData after merge with conf: {"id":"sensor002","type":"Sensor","name":"sensor002_entity","service":"smartcity","subservice":"/","active":[{"object_id":"temperature","name":"temperature","type":"number"}],"staticAttributes":[],"lazy":[],"commands":[{"name":"MiOtrocommand","type":"command","value":"","object_id":"MiOtrocommand"}],"timezone":"Europe/Berlin","protocol":"IoTA-UL","internalId":null,"autoprovision":false,"explicitAttrs":false,"subscriptions":[]} | comp=IoTAgent
time=2021-04-09T07:49:27.035Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.DeviceService | from=n/a | srv=n/a | subsrv=n/a | msg=Registering device into NGSI Service:
{
    "id": "sensor002",
    "type": "Sensor",
    "name": "sensor002_entity",
    "service": "smartcity",
    "subservice": "/",
    "active": [
        {
            "object_id": "temperature",
            "name": "temperature",
            "type": "number"
        }
    ],
    "staticAttributes": [],
    "lazy": [],
    "commands": [
        {
            "name": "MiOtrocommand",
            "type": "command",
            "value": "",
            "object_id": "MiOtrocommand"
        }
    ],
    "timezone": "Europe/Berlin",
    "protocol": "IoTA-UL",
    "internalId": null,
    "autoprovision": false,
    "explicitAttrs": false,
    "subscriptions": []
} | comp=IoTAgent
time=2021-04-09T07:49:27.036Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.Registration | from=n/a | srv=n/a | subsrv=n/a | msg=Sending v2 device registrations to Context Broker at [http://iot-orion:1026/v2/registrations] | comp=IoTAgent
time=2021-04-09T07:49:27.036Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.Registration | from=n/a | srv=n/a | subsrv=n/a | msg=Using the following request:

{
    "url": "http://iot-orion:1026/v2/registrations",
    "method": "POST",
    "json": {
        "dataProvided": {
            "entities": [
                {
                    "type": "Sensor",
                    "id": "sensor002_entity"
                }
            ],
            "attrs": [
                "MiOtrocommand"
            ]
        },
        "provider": {
            "http": {
                "url": "http://172.17.0.1:4061"
            }
        }
    },
    "headers": {
        "fiware-service": "smartcity",
        "fiware-servicepath": "/"
    }
}

 | comp=IoTAgent
time=2021-04-09T07:49:27.036Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.RestUtils | from=n/a | srv=n/a | subsrv=n/a | msg=executeWithSecurity | comp=IoTAgent
time=2021-04-09T07:49:27.036Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=n/a | subsrv=n/a | msg=Looking for group params ["type"] with queryObj {"type":"Sensor"} | comp=IoTAgent
time=2021-04-09T07:49:27.039Z | lvl=DEBUG | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=n/a | subsrv=n/a | msg=Device group for fields [["type"]] not found: [{"type":"Sensor"}] | comp=IoTAgent
time=2021-04-09T07:49:27.039Z | lvl=ERROR | corr=826dc472-1b20-4ccd-b902-3807384fad83 | trans=826dc472-1b20-4ccd-b902-3807384fad83 | op=IoTAgentNGSI.Alarms | from=n/a | srv=smartcity | subsrv=/ | msg=Raising [MONGO-ALARM]: {"name":"DEVICE_GROUP_NOT_FOUND","message":"Couldn\t find device group for fields: [\"type\"] and values: {\"type\":\"Sensor\"}","code":404} | comp=IoTAgent