### PR TITLE
update configmap and entrypoint

### DIFF
--- a/docker/Mosquitto/Dockerfile
+++ b/docker/Mosquitto/Dockerfile
@@ -3,6 +3,8 @@ FROM centos:7.9.2009
 COPY aclfile /root/
 COPY startMosquitto.sh /bin
 
+ENV CONGIF_FROM_ENV true
+
 RUN yum update -y && yum install -y wget \
   && yum install -y epel-release \
   && yum update -y epel-release \
@@ -10,16 +12,8 @@ RUN yum update -y && yum install -y wget \
   && chmod 755 /bin/startMosquitto.sh \
   && mkdir /var/log/mosquitto \
   && chown mosquitto:mosquitto /var/log/mosquitto \
-  && touch /etc/mosquitto/pwfile \
-  && sed -i '$ i acl_file /etc/mosquitto/aclfile\npassword_file /etc/mosquitto/pwfile' /etc/mosquitto/mosquitto.conf \
-  && echo "log_timestamp true" >> /etc/mosquitto/mosquitto.conf \
-  && echo "log_timestamp_format %Y-%m-%dT%H:%M:%S" >> /etc/mosquitto/mosquitto.conf \
-  && echo 'listener 9001' >> /etc/mosquitto/mosquitto.conf \
-  && echo 'protocol websockets' >> /etc/mosquitto/mosquitto.conf \
-  && echo 'listener 1883' >> /etc/mosquitto/mosquitto.conf \
-  && echo 'protocol mqtt' >> /etc/mosquitto/mosquitto.conf \
-  && mv /root/aclfile /etc/mosquitto/aclfile \
   && yum clean all
+
 
 EXPOSE 1883
 EXPOSE 9001

--- a/docker/Mosquitto/startMosquitto.sh
+++ b/docker/Mosquitto/startMosquitto.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
 
-mosquitto_passwd -b /etc/mosquitto/pwfile iota ${IOTA_PASS}
+if [ "${CONGIF_FROM_ENV}" = true ] ; then
+    touch /etc/mosquitto/pwfile
+    sed -i '$ i acl_file /etc/mosquitto/aclfile\npassword_file /etc/mosquitto/pwfile' /etc/mosquitto/mosquitto.conf
+    echo "log_timestamp true" >> /etc/mosquitto/mosquitto.conf
+    echo "log_timestamp_format %Y-%m-%dT%H:%M:%S" >> /etc/mosquitto/mosquitto.conf
+    echo 'listener 9001' >> /etc/mosquitto/mosquitto.conf
+    echo 'protocol websockets' >> /etc/mosquitto/mosquitto.conf
+    echo 'listener 1883' >> /etc/mosquitto/mosquitto.conf
+    echo 'protocol mqtt' >> /etc/mosquitto/mosquitto.conf
+    mv /root/aclfile /etc/mosquitto/aclfile
+    mosquitto_passwd -b /etc/mosquitto/pwfile iota ${IOTA_PASS}
+fi
+
 /usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
Esta Pr hace opcional la creación/edición de los ficheros de configuración dentro del entrypoint. Esto es por que en algunos casos se puede requerir inyectar con un fichero directamente la configuración o x numero de usuarios propios.