### PR TITLE
check data in fillService facility

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: check access to data in fillService facility
 - Fix: ensure service of groups, device and commands is stored in mongo in lowercase (#1023)
 - Add: add getTypeSilently for device group and use in device registration to avoid false mongo alarm
 - Fix: group command is not provisioned in device when entity_type is different (#1011)

--- a/lib/services/common/domain.js
+++ b/lib/services/common/domain.js
@@ -195,11 +195,11 @@ function finishSouthboundTransaction(callback) {
  * @return {Object}             New context containing service information.
  */
 function fillService(context, data) {
-    if (data.service) {
+    if (data && data.service) {
         context.srv = data.service;
     }
 
-    if (data.subservice) {
+    if (data && data.subservice) {
         context.subsrv = data.subservice;
     }
 


### PR DESCRIPTION
time=2021-05-04T11:25:36.533Z | lvl=FATAL | corr=n/a | trans=n/a | op=IoTAgentNG
SI.Global | from=n/a | srv=n/a | subsrv=n/a | msg=An unexpected exception has be
en raised. Ignoring: TypeError: Cannot read property 'service' of undefined
    at fillService (/opt/iotaul/node_modules/iotagent-node-lib/lib/services/comm
on/domain.js:198:14)
    at saveHandler (/opt/iotaul/node_modules/iotagent-node-lib/lib/services/devi
ces/deviceRegistryMongoDB.js:72:26)
    at /opt/iotaul/node_modules/mongoose/lib/model.js:4598:16
    at /opt/iotaul/node_modules/mongoose/lib/utils.js:256:11
    at /opt/iotaul/node_modules/mongoose/lib/model.js:468:16
    at /opt/iotaul/node_modules/kareem/index.js:246:48
    at next (/opt/iotaul/node_modules/kareem/index.js:167:27)
    at next (/opt/iotaul/node_modules/kareem/index.js:169:9)
    at Kareem.execPost (/opt/iotaul/node_modules/kareem/index.js:217:3)
    at _handleWrapError (/opt/iotaul/node_modules/kareem/index.js:245:21)
    at _cb (/opt/iotaul/node_modules/kareem/index.js:304:16)
    at /opt/iotaul/node_modules/mongoose/lib/model.js:324:9
    at /opt/iotaul/node_modules/kareem/index.js:135:16
    at processTicksAndRejections (internal/process/task_queues.js:79:11) | comp=
IoTAgent

IMHO is happen since we updated to nodejs 12 fro node 10