### PR TITLE
prevent to update an entity v2 with an empty payload

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Add: Prevent to update an entity with an empty payload
 - Fix: check expression context before apply it in entity_name (#1040)
 - Fix: Do not transform attribute value using attribute type after apply expression plugin JEXL (#1036)
 - Fix: check entityId is valid after apply expression in multientity plugin (#1039)

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -484,6 +484,13 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                         options,
                         generateNGSI2OperationHandler('update', entityName, typeInformation, token, options, callback)
                     );
+                } else {
+                    logger.debug(
+                        context,
+                        'Not updating device value in the Context Broker at [%s] due to empty payload \n\n[%s]\n\n',
+                        options.url,
+                        JSON.stringify(options, null, 4)
+                    );
                 }
             }
         }

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -471,17 +471,20 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     }
                 }
 
-                logger.debug(context, 'Updating device value in the Context Broker at [%s]', options.url);
-                logger.debug(
-                    context,
-                    'Using the following NGSI v2 request:\n\n%s\n\n',
-                    JSON.stringify(options, null, 4)
-                );
+                // Prevent to update an entity with an empty payload
+                if (Object.keys(options.json).length > 0) {
+                    logger.debug(context, 'Updating device value in the Context Broker at [%s]', options.url);
+                    logger.debug(
+                        context,
+                        'Using the following NGSI v2 request:\n\n%s\n\n',
+                        JSON.stringify(options, null, 4)
+                    );
 
-                request(
-                    options,
-                    generateNGSI2OperationHandler('update', entityName, typeInformation, token, options, callback)
-                );
+                    request(
+                        options,
+                        generateNGSI2OperationHandler('update', entityName, typeInformation, token, options, callback)
+                    );
+                }
             }
         }
     );


### PR DESCRIPTION


time=2021-05-25T09:59:34.816Z | lvl=DEBUG | corr=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | trans=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | op=IoTAgentNGSI.Entities-v2 | from=n/a | srv=smartcity | subsrv=/aa | msg=Updating device value in the Context Broker at [http://iot-orion:1026/v2/entities/thing:disp7/attrs?type=thing] | comp=IoTAgent
time=2021-05-25T09:59:34.816Z | lvl=DEBUG | corr=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | trans=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | op=IoTAgentNGSI.Entities-v2 | from=n/a | srv=smartcity | subsrv=/aa | msg=Using the following NGSI v2 request:

{
    "url": "http://iot-orion:1026/v2/entities/thing:disp7/attrs?type=thing",
    "method": "POST",
    "headers": {
        "fiware-service": "smartcity",
        "fiware-servicepath": "/aa"
    },
    "json": {}
}






time=2021-05-25T10:08:35.835Z | lvl=INFO | corr=2b166fe0-bd41-11eb-86e2-0242ac110011 | trans=1621930579-709-00000000024 | from=172.17.0.21 | srv=smartcity | subsrv=/aa | comp=Orion | op=logTracing.cpp[130]:logInfoRequestWithPayload | msg=Request received: POST /v2/entities/thing:disp7/attrs?type=thing, request payload (2 bytes): {}, response code: 400




time=2021-05-25T10:08:35.835Z | lvl=DEBUG | corr=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | trans=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | op=IoTAgentNGSI.Entities-v2 | from=n/a | srv=smartcity | subsrv=/aa | msg=Unknown error executing update operation | comp=IoTAgent
time=2021-05-25T10:08:35.835Z | lvl=DEBUG | corr=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | trans=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | op=IOTAUL.HTTP.Binding | from=n/a | srv=smartcity | subsrv=/aa | msg=Error [ENTITY_GENERIC_ERROR] handing request: Error accesing entity data for device: thing:disp7 of type: thing | comp=IoTAgent
time=2021-05-25T10:08:35.837Z | lvl=ERROR | corr=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | trans=9a35a73c-3e57-4932-b5b3-b6e059ce4272 | op=IOTAUL.HTTP.Binding | from=n/a | srv=smartcity | subsrv=/aa | msg=MEASURES-002: Couldn't send the updated values to the Context Broker due to an error: {"name":"ENTITY_GENERIC_ERROR","message":"Error accesing entity data for device: thing:disp7 of type: thing","details":{"error":"BadRequest","description":"empty payload"},"code":400} | comp=IoTAgent



