### PR TITLE
check access to errorField

### DIFF
--- a/lib/services/ngsi/entities-NGSI-v1.js
+++ b/lib/services/ngsi/entities-NGSI-v1.js
@@ -86,7 +86,12 @@ function generateNGSIOperationHandler(operationName, entityName, typeInformation
                     errorField
                 );
 
-                if (errorField.code && errorField.code === '404' && errorField.details.includes(typeInformation.type)) {
+                if (
+                    errorField.code &&
+                    errorField.code === '404' &&
+                    errorField.details &&
+                    errorField.details.includes(typeInformation.type)
+                ) {
                     callback(new errors.DeviceNotFound(entityName));
                 } else if (errorField.code && errorField.code === '404') {
                     callback(new errors.AttributeNotFound());

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -235,11 +235,7 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
             logger.error(context, 'Operation ' + operationName + ' error connecting to the Context Broker: %j', body);
 
             const errorField = NGSIUtils.getErrorFieldV2(body);
-            if (
-                response.statusCode &&
-                response.statusCode === 404 &&
-                errorField !== undefined)
-            ) {
+            if (response.statusCode && response.statusCode === 404 && errorField !== undefined) {
                 callback(new errors.DeviceNotFound(entityName));
             } else if (errorField.code && errorField.code === '404') {
                 callback(new errors.AttributeNotFound());

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -238,8 +238,7 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
             if (
                 response.statusCode &&
                 response.statusCode === 404 &&
-                errorField &&
-                errorField.toString().includes(typeInformation.type)
+                errorField !== undefined)
             ) {
                 callback(new errors.DeviceNotFound(entityName));
             } else if (errorField.code && errorField.code === '404') {

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -234,12 +234,12 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
 
             logger.error(context, 'Operation ' + operationName + ' error connecting to the Context Broker: %j', body);
 
-            const errorField = NGSIUtils.getErrorField(body);
+            const errorField = NGSIUtils.getErrorFieldV2(body);
             if (
                 response.statusCode &&
                 response.statusCode === 404 &&
-                errorField.details &&
-                errorField.details.includes(typeInformation.type)
+                errorField &&
+                errorField.includes(typeInformation.type)
             ) {
                 callback(new errors.DeviceNotFound(entityName));
             } else if (errorField.code && errorField.code === '404') {

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -239,7 +239,7 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
                 response.statusCode &&
                 response.statusCode === 404 &&
                 errorField &&
-                errorField.includes(typeInformation.type)
+                errorField.toString().includes(typeInformation.type)
             ) {
                 callback(new errors.DeviceNotFound(entityName));
             } else if (errorField.code && errorField.code === '404') {

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -238,6 +238,7 @@ function generateNGSI2OperationHandler(operationName, entityName, typeInformatio
             if (
                 response.statusCode &&
                 response.statusCode === 404 &&
+                errorField.details &&
                 errorField.details.includes(typeInformation.type)
             ) {
                 callback(new errors.DeviceNotFound(entityName));

--- a/lib/services/ngsi/ngsiUtils.js
+++ b/lib/services/ngsi/ngsiUtils.js
@@ -234,7 +234,7 @@ function getMetaData(typeInformation, name, metadata) {
 }
 
 /**
- * Given a NGSI Body, determines whether it contains any NGSI error.
+ * Given a NGSI v1 Body, determines whether it contains any NGSI error.
  *
  * @param {String} body             String representing a NGSI body in JSON format.
  * @return {Number|*}
@@ -250,6 +250,20 @@ function getErrorField(body) {
         }
     }
 
+    return errorField;
+}
+
+/**
+ * Given a NGSI v2 Body, determines whether it contains any NGSI error.
+ *
+ * @param {String} body             String representing a NGSI body in JSON format.
+ * @return {Number|*}
+ */
+function getErrorFieldV2(body) {
+    let errorField = body.error;
+    if (body.description) {
+        errorField += ':' + body.description;
+    }
     return errorField;
 }
 

--- a/lib/services/ngsi/ngsiUtils.js
+++ b/lib/services/ngsi/ngsiUtils.js
@@ -256,8 +256,8 @@ function getErrorField(body) {
 /**
  * Given a NGSI v2 Body, determines whether it contains any NGSI error.
  *
- * @param {String} body             String representing a NGSI body in JSON format.
- * @return {Number|*}
+ * @param {Object} body             Object representing a NGSI body in JSON format.
+ * @return {String|undefined}       String with the error and description or undefined if body is not a NGSIv2 error response
  */
 function getErrorFieldV2(body) {
     let errorField = body.error;


### PR DESCRIPTION
fiware-iot-agent |  | comp=IoTAgent
fiware-iot-agent | time=2021-05-27T07:57:21.337Z | lvl=ERROR | corr=a7bd07b1-cecc-40a5-9412-16477e68d5bd | trans=a7bd07b1-cecc-40a5-9412-16477e68d5bd | op=IoTAgentNGSI.Entities-v2 | from=n/a | srv=tests | subsrv=/ | msg=Operation update error connecting to the Context Broker: {"error":"NotFound","description":"The entity does not have such an attribute"} | comp=IoTAgent
fiware-iot-agent | time=2021-05-27T07:57:21.344Z | lvl=ERROR | corr=a7bd07b1-cecc-40a5-9412-16477e68d5bd | trans=a7bd07b1-cecc-40a5-9412-16477e68d5bd | op=IoTAgentNGSI.DomainControl | from=n/a | srv=tests | subsrv=/ | msg=TypeError: Cannot read property 'details' of undefined
fiware-iot-agent |     at Request._callback (/opt/iotagent-json/node_modules/iotagent-node-lib/lib/services/ngsi/entities-NGSI-v2.js:241:28)
fiware-iot-agent |     at Request.self.callback (/opt/iotagent-json/node_modules/request/request.js:185:22)
fiware-iot-agent |     at Request.emit (events.js:314:20)
fiware-iot-agent |     at Request.EventEmitter.emit (domain.js:506:15)
fiware-iot-agent |     at Request.<anonymous> (/opt/iotagent-json/node_modules/request/request.js:1161:10)
fiware-iot-agent |     at Request.emit (events.js:314:20)
fiware-iot-agent |     at Request.EventEmitter.emit (domain.js:506:15)
fiware-iot-agent |     at IncomingMessage.<anonymous> (/opt/iotagent-json/node_modules/request/request.js:1083:12)
fiware-iot-agent |     at Object.onceWrapper (events.js:420:28)
fiware-iot-agent |     at IncomingMessage.emit (events.js:326:22)
fiware-iot-agent |     at IncomingMessage.EventEmitter.emit (domain.js:506:15)
fiware-iot-agent |     at endReadableNT (_stream_readable.js:1241:12)
fiware-iot-agent |     at processTicksAndRejections (internal/process/task_queues.js:84:21) {
fiware-iot-agent |   domainThrown: true