### PR TITLE
fix typo in the example of expression legacy

### DIFF
--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -104,13 +104,12 @@ E.g.: if a device with the following provisioning information is provisioned in 
 {
    "name":"location",
    "type":"geo:point",
-   "expression": "${latitude}, ${longitude}"
+   "expression": "${@latitude}, ${@longitude}"
 },
 {
    "name":"fillingLevel",
    "type":"Number",
    "expression": "${@level / 100}",
-   "cast": "Number"
 },
 ```
 


### PR DESCRIPTION
Fix the example where attributes in the expression miss the `@` and remove the `cast` parameter in the provision as it returns an error 400:
```
{
    "name": "WRONG_SYNTAX",
    "message": "Wrong syntax in request: Errors found validating request."
}
```
It seems to be an old parameter, it is not described in the documentation, and the cast function it is provided by default using the provide "type" parameter