### PR TITLE
Fix typo in bidirectional example documentation

### DIFF
--- a/doc/advanced-topics.md
+++ b/doc/advanced-topics.md
@@ -432,14 +432,14 @@ When a device is provisioned with bidirectional attributes, the IoTAgent subscri
 change notification for that attribute arrives to the IoTA, it applies the transformation defined in the device
 provisioning payload to the notification, and calls the underlying notification handler with the transformed entity.
 
-The following `attributes` section shows an example of the plugin configuration:
+The following `attributes` section shows an example of the plugin configuration (using IOTA_AUTOCAST=false to avoid translation from geo:point to geo:json)
 
 ```json
       "attributes": [
         {
           "name":"location",
           "type":"geo:point",
-          "expression": "${latitude}, ${longitude}",
+          "expression": "${@latitude}, ${@longitude}",
           "reverse": [
             {
               "object_id":"longitude",


### PR DESCRIPTION
Fix typo in the expression of the attributes that miss `@` as prefix.

Add a note about using `IOTA_AUTOCAST=false` to make the example works in the reverse side which expect the attribute as geo:point and no geo:json that is converted with `AUTOCAST=true` by default.