### PR TITLE
Fix #1021 - Add repository dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   lint-markdown:
     name: Lint Markdown
@@ -89,3 +90,18 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  dispatch:
+    needs: unit-test
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    strategy:
+      matrix:
+        repo: ['telefonicaid/iotagent-ul', 'telefonicaid/sigfox-iotagent', 'telefonicaid/iotagent-json', 'telefonicaid/lightweightm2m-iotagent']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: lib-update


### PR DESCRIPTION
Upstream fix for telefonicaid/iotagent-node-lib#1021

Uses https://github.com/peter-evans/repository-dispatch - you'll need to set up an organization-wide PAT as described below:

| Name | Description | Default |
| --- | --- | --- |
| `token` | (**required**) A `repo` scoped GitHub [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). See [token](#token) for further details. | |

Fully working example can be seen here: https://github.com/jason-fox/iotagent-node-lib/actions/runs/1232752364 - this triggered the following Sigfox test run: https://github.com/jason-fox/sigfox-iotagent/actions/runs/1232769234

Eventually this should be expanded to inform other organizations - for example https://github.com/FIWARE/iotagent-isoxml would like to be informed of library changes, and this could be done by creating a PAT on the FIWARE organization and adding a new step.