### PR TITLE
revert simplification of entities

### DIFF
--- a/lib/plugins/multiEntity.js
+++ b/lib/plugins/multiEntity.js
@@ -251,6 +251,8 @@ function updateAttribute(entity, typeInformation, callback) {
             const newCes = generateNewCEsNgsi2(entity, newEntities, multiEntityAttributes);
             entities = [resultAttributes].concat(newCes);
             propagateTimestamp(entity, entities);
+        } else {
+            entities = entity;
         }
     }
     callback(null, entities, typeInformation);


### PR DESCRIPTION
The improvement was introduced in https://github.com/telefonicaid/iotagent-node-lib/pull/1128/commits/875e46c1069c1d206d5d958d880177a8fdf692b1

But in order keep entity in an array of entties iotagent-json and iotagent-ul tests cases (so many) should be updated.