### PR TITLE
Fix/suppong warn log level

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- ADD: support both WARN and WARNING log levels (#1146)

--- a/lib/services/common/genericMiddleware.js
+++ b/lib/services/common/genericMiddleware.js
@@ -71,7 +71,7 @@ function traceRequest(req, res, next) {
 
 /* eslint-disable-next-line  no-unused-vars */
 function changeLogLevel(req, res, next) {
-    const levels = ['INFO', 'ERROR', 'FATAL', 'DEBUG', 'WARNING'];
+    const levels = ['INFO', 'ERROR', 'FATAL', 'DEBUG', 'WARN', 'WARNING'];
 
     if (!req.query.level) {
         res.status(400).json({
@@ -82,7 +82,11 @@ function changeLogLevel(req, res, next) {
             error: 'invalid log level'
         });
     } else {
-        logger.setLevel(req.query.level.toUpperCase());
+        let newLevel = req.query.level.toUpperCase();
+        if (newLevel === 'WARNING') {
+            newLevel = 'WARN';
+        }
+        logger.setLevel(newLevel);
         res.status(200).send('');
     }
 }


### PR DESCRIPTION
logops dep only wupport WARN log level
We need to provide backward compatibility for WARNING log level

https://github.com/telefonicaid/iotagent-node-lib/issues/1146