### PR TITLE
Update package.json: fix colors dep

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- FIX: use colors 1.4.0 to avoid wrong dep
 - FIX: try get group by type using current type if no type is provided (#1155)
 - ADD: allow update polling device field (iota-json#602)
 - Fix: replace request obsolete library by got (#858)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "query-string": "6.5.0",
     "revalidator": "~0.3.1",
     "underscore": "~1.12.1",
-    "uuid": "~3.3.2"
+    "uuid": "~3.3.2",
+    "colors": "1.4.0"
   },
   "devDependencies": {
     "coveralls": "~3.1.0",


### PR DESCRIPTION
https://snyk.io/blog/open-source-npm-packages-colors-faker/
Neither 1.4.1 and 1.4.2 versions are good to be used.