### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - ADD: support both WARN and WARNING log levels (#1146)
 - FIX: JEXL NGSI-LD null processing extended to remove invalid calculated values (#1164)
 - FIX: Remove preprocess stripping of explicitAttrs (#1151)
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "got": "~11.8.2",
     "jexl": "2.3.0",
     "jison": "0.4.18",
-    "logops": "2.1.0",
+    "logops": "2.1.2",
     "moment": "~2.24.0",
     "moment-timezone": "~0.5.25",
     "mongodb": "3.6.8",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/