### PR TITLE
fix: do not provide context-type for DELETE and GET http requests

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,3 @@
-- FIX: Do not provide content-type to delete and get http request (since none body is provided)
 - FIX: try get group by type using current type if no type is provided (#1155)
 - ADD: allow update polling device field (iota-json#602)
 - Fix: replace request obsolete library by got (#858)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- FIX: Do not provide content-type to delete registrations (since none body is provided)
 - FIX: try get group by type using current type if no type is provided (#1155)
 - ADD: allow update polling device field (iota-json#602)
 - Fix: replace request obsolete library by got (#858)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- FIX: Do not provide content-type to delete registrations (since none body is provided)
+- FIX: Do not provide content-type to delete and get http request (since none body is provided)
 - FIX: try get group by type using current type if no type is provided (#1155)
 - ADD: allow update polling device field (iota-json#602)
 - Fix: replace request obsolete library by got (#858)

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -711,7 +711,8 @@ the custom IoT Agent to import its own additional request library
     -   `headers`
     -   `responseType` - either `text` or `json`. `json` is the default
     -   `json` - a supplied JSON object as the request body
-    -   `body` - any ASCII text as the request body
+    -   `body` - any ASCII text as the request body. It takes precedence over `json` if both are
+        provided at the same time (not recommended).
     -   `url` - the request URL
     -   `uri` - alternative alias for the request URL.
 -   callback: The callback currently returns an `error` Object, the `response` and `body`. The `body` is parsed to a

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -60,7 +60,7 @@ function getOptions(options) {
     // Thus, se are enforcing our own precedence with the "else if" chain below.
     // Behaviour is consistent with the one described at usermanual.md#iotagentlibrequest
 
-    if (options.method !== 'GET' || options.method === 'HEAD' || options.method === 'OPTIONS') {
+    if (options.method === 'GET' || options.method === 'HEAD' || options.method === 'OPTIONS') {
         // Do nothing - Never add a body
     } else if (options.body) {
         // body takes precedence over json or form

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,7 +55,7 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET' && (Object.keys(options.body).length === 0 && Object.getPrototypeOf(options.body) === Object.prototype) {
+    if (options.method !== 'GET' && options.body !== '') {
         httpOptions.json = options.json;
         httpOptions.body = options.body;
     }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -57,7 +57,7 @@ function getOptions(options) {
 
     // got library is not properly documented, so it is not clear which takes precedence
     // among body, json and form (see https://stackoverflow.com/q/70754880/1485926).
-    // Thus, se are enforcing our own precedence with the "else if" chain below.
+    // Thus, we are enforcing our own precedence with the "else if" chain below.
     // Behaviour is consistent with the one described at usermanual.md#iotagentlibrequest
 
     if (options.method === 'GET' || options.method === 'HEAD' || options.method === 'OPTIONS') {

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,7 +55,7 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET' && options.method !== 'DELETE') {
+    if (options.method !== 'GET') {
         httpOptions.json = options.json;
         httpOptions.body = options.body;
     }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,7 +55,7 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET' && options.body !== '') {
+    if (options.method !== 'GET') {
         httpOptions.json = options.json;
         httpOptions.body = options.body;
     }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,7 +55,7 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET') {
+    if (options.method !== 'GET' && options.method !== 'DELETE') {
         httpOptions.json = options.json;
         httpOptions.body = options.body;
     }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,7 +55,7 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET') {
+    if (options.method !== 'GET' && (Object.keys(options.body).length === 0 && Object.getPrototypeOf(options.body) === Object.prototype) {
         httpOptions.json = options.json;
         httpOptions.body = options.body;
     }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -55,9 +55,23 @@ function getOptions(options) {
         responseType: options.responseType || 'json'
     };
 
-    if (options.method !== 'GET') {
-        httpOptions.json = options.json;
+    // got library is not properly documented, so it is not clear which takes precedence
+    // among body, json and form (see https://stackoverflow.com/q/70754880/1485926).
+    // Thus, se are enforcing our own precedence with the "else if" chain below.
+    // Behaviour is consistent with the one described at usermanual.md#iotagentlibrequest
+
+    if (options.method !== 'GET' || options.method === 'HEAD' || options.method === 'OPTIONS') {
+        // Do nothing - Never add a body
+    } else if (options.body) {
+        // body takes precedence over json or form
         httpOptions.body = options.body;
+    } else if (options.json) {
+        // json takes precedence over form
+        httpOptions.json = options.json;
+    } else if (options.form) {
+        // Note that we don't consider 'form' part of the function API (check usermanual.md#iotagentlibrequest)
+        // but we are preparing the code anyway as a safe measure
+        httpOptions.form = options.form;
     }
 
     return httpOptions;

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -176,7 +176,6 @@ function sendUnregistrationsNgsiLD(deviceData, callback) {
     const options = {
         url: cbHost + '/ngsi-ld/v1/csourceRegistrations/' + deviceData.registrationId,
         method: 'DELETE',
-        json: true,
         headers: {
             'fiware-service': deviceData.service,
             'fiware-servicepath': deviceData.subservice,

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -136,7 +136,6 @@ function sendUnregistrationsNgsi2(deviceData, callback) {
     const options = {
         url: cbHost + '/v2/registrations/' + deviceData.registrationId,
         method: 'DELETE',
-        json: true,
         headers: {
             'fiware-service': deviceData.service,
             'fiware-servicepath': deviceData.subservice

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -330,7 +330,6 @@ function sendQueryValueNgsiLD(entityName, attributes, typeInformation, token, ca
 
     const options = NGSIUtils.createRequestObject(url, typeInformation, token);
     options.method = 'GET';
-    options.json = true;
 
     if (!typeInformation || !typeInformation.type) {
         callback(new errors.TypeNotFound(null, entityName));

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -291,7 +291,6 @@ function sendQueryValueNgsi2(entityName, attributes, typeInformation, token, cal
 
     const options = NGSIUtils.createRequestObject(url, typeInformation, token);
     options.method = 'GET';
-    options.json = true;
 
     if (!typeInformation || !typeInformation.type) {
         callback(new errors.TypeNotFound(null, entityName));

--- a/test/unit/ngsi-ld/lazyAndCommands/lazy-devices-test.js
+++ b/test/unit/ngsi-ld/lazyAndCommands/lazy-devices-test.js
@@ -232,7 +232,6 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function () {
                 iotAgentConfig.server.port +
                 '/ngsi-ld/v1/entities/urn:ngsi-ld:Light:light1?attrs=dimming',
             method: 'GET',
-            json: true,
             headers: {
                 'fiware-service': 'smartgondor',
                 'fiware-servicepath': 'gardens'
@@ -301,7 +300,6 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function () {
                 iotAgentConfig.server.port +
                 '/ngsi-ld/v1/entities/urn:ngsi-ld:Light:light1?attrs=dimming',
             method: 'GET',
-            json: true,
             headers: {
                 'fiware-service': 'smartgondor',
                 'fiware-servicepath': 'gardens'
@@ -354,7 +352,6 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function () {
         const options = {
             url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities/urn:ngsi-ld:Light:light1',
             method: 'GET',
-            json: true,
             headers: {
                 'fiware-service': 'smartgondor',
                 'fiware-servicepath': 'gardens'
@@ -420,7 +417,6 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function () {
                 iotAgentConfig.server.port +
                 '/ngsi-ld/v1/entities/urn:ngsi-ld:Motion:motion1?attrs=moving,location',
             method: 'GET',
-            json: true,
             headers: {
                 'fiware-service': 'smartgondor',
                 'fiware-servicepath': 'gardens'
@@ -486,7 +482,6 @@ describe('NGSI-LD - IoT Agent Lazy Devices', function () {
                 iotAgentConfig.server.port +
                 '/ngsi-ld/v1/entities/urn:ngsi-ld:Light:light1?attrs=temperature',
             method: 'GET',
-            json: true,
             headers: {
                 'fiware-service': 'smartgondor',
                 'fiware-servicepath': 'gardens'


### PR DESCRIPTION
Since delete regisration has no body


(with latest iota-ul)

time=2022-01-14T10:51:29.231Z | lvl=DEBUG | corr=10fec9c1-ca32-4311-a0c6-9331112fb416 | trans=10fec9c1-ca32-4311-a0c6-9331112fb416 | op=IoTAgentNGSI.Request | from=n/a | srv=iota0030103 | subsrv=/ | msg=Options: {
    "url": "http://iot-orion:1026/v2/registrations/61e155adc7ddee5d5a405971",
    "method": "DELETE",
    "json": true,
    "headers": {
        "fiware-service": "iota0030103",
        "fiware-servicepath": "/"
    }
} | comp=IoTAgent
time=2022-01-14T10:51:29.236Z | lvl=DEBUG | corr=10fec9c1-ca32-4311-a0c6-9331112fb416 | trans=10fec9c1-ca32-4311-a0c6-9331112fb416 | op=IoTAgentNGSI.Request | from=n/a | srv=iota0030103 | subsrv=/ | msg=Response {
    "orionError": {
        "code": "501",
        "reasonPhrase": "Not Implemented",
        "details": "Request Treat function not implemented"
    }
} | comp=IoTAgent
time=2022-01-14T10:51:29.236Z | lvl=ERROR | corr=10fec9c1-ca32-4311-a0c6-9331112fb416 | trans=10fec9c1-ca32-4311-a0c6-9331112fb416 | op=IoTAgentNGSI.Registration | from=n/a | srv=iota0030103 | subsrv=/ | msg=Registration error connecting to the Context Broker: 501 | comp=IoTAgent

telefonicaiot/fiware-orion                latest           1ec76c60e6d5   3 weeks ago     382MB
orion logs: @fgalan 

time=2022-01-14T10:51:29.234Z | lvl=WARN | corr=ed9d710a-7527-11ec-8491-0242ac11000f | trans=1642154216-420-00000000252 | from=172.17.0.22 | srv=iota0030103 | subsrv=/ | comp=Orion | op=AlarmManager.cpp[496]:badInput | msg=Raising alarm BadInput 172.17.0.22: {"orionError":{"code":"501","reasonPhrase":"Not Implemented","details":"Request Treat function not implemented"}}
time=2022-01-14T10:51:29.234Z | lvl=INFO | corr=ed9d710a-7527-11ec-8491-0242ac11000f | trans=1642154216-420-00000000252 | from=172.17.0.22 | srv=iota0030103 | subsrv=/ | comp=Orion | op=logTracing.cpp[97]:logInfoRequestWithoutPayload | msg=Request received: DELETE /v2/registrations/61e155adc7ddee5d5a405971, response code: 501

