### PR TITLE
BugFix: NGSI-LD commands are invalid.

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -6,4 +6,5 @@
 - ADD: support both WARN and WARNING log levels (#1146)
 - FIX: JEXL NGSI-LD null processing extended to remove invalid calculated values (#1164)
 - FIX: Remove preprocess stripping of explicitAttrs (#1151)
+- FIX: NGSI-LD commands are invalid. (#1185)
 - Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -55,7 +55,7 @@ const NGSI_LD_URN = 'urn:ngsi-ld:';
  *                                   format
  */
 
-function convertNGSIv2ToLD(attr) {
+function convertAttrNGSILD(attr) {
     // eslint eqeqeq - deliberate double equals to include undefined.
     if (attr.value == null || Number.isNaN(attr.value)) {
         return undefined;
@@ -179,7 +179,7 @@ function convertNGSIv2ToLD(attr) {
                     obj.unitCode = attr.metadata[key].value;
                     break;
                 default:
-                    obj[key] = convertNGSIv2ToLD(attr.metadata[key]);
+                    obj[key] = convertAttrNGSILD(attr.metadata[key]);
             }
         });
         delete obj.TimeInstant;
@@ -215,7 +215,7 @@ function formatAsNGSILD(json) {
                 // element for NSGI-LD.
                 break;
             default:
-                obj[key] = convertNGSIv2ToLD(json[key]);
+                obj[key] = convertAttrNGSILD(json[key]);
         }
     });
 
@@ -629,6 +629,7 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
     );
 }
 
+exports.convertAttrNGSILD = convertAttrNGSILD;
 exports.formatAsNGSILD = formatAsNGSILD;
 exports.sendUpdateValue = sendUpdateValueNgsiLD;
 exports.sendQueryValue = sendQueryValueNgsiLD;

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -40,6 +40,7 @@ const context = {
 const updateContextTemplateNgsiLD = require('../../templates/updateContextNgsiLD.json');
 const notificationTemplateNgsiLD = require('../../templates/notificationTemplateNgsiLD.json');
 const contextServerUtils = require('./contextServerUtils');
+const ngsiLD = require('../ngsi/entities-NGSI-LD');
 
 const updatePaths = ['/ngsi-ld/v1/entities/:entity/attrs/:attr'];
 const queryPaths = ['/ngsi-ld/v1/entities/:entity'];
@@ -250,13 +251,14 @@ function defaultQueryHandlerNgsiLD(id, type, service, subservice, attributes, ca
                     attributeType = lazyAttribute.type;
                 }
 
+
                 contextElement[attributes[i]] = {
                     type: attributeType,
                     value: ''
                 };
             }
 
-            callback(null, contextElement);
+            callback(null, ngsiLD.formatAsNGSILD(contextElement));
         }
     });
 }

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -252,13 +252,13 @@ function defaultQueryHandlerNgsiLD(id, type, service, subservice, attributes, ca
                 }
 
 
-                contextElement[attributes[i]] = {
+                contextElement[attributes[i]] = ngsiLD.convertAttrNGSILD({
                     type: attributeType,
                     value: ''
-                };
+                });
             }
 
-            callback(null, ngsiLD.formatAsNGSILD(contextElement));
+            callback(null, contextElement);
         }
     });
 }


### PR DESCRIPTION
NGSI-LD Command query is  returning  attributes in NGSI-v2 format

See: https://github.com/FIWARE/context.Orion-LD/issues/919#issuecomment-1025308901

#### NSGI-v2

```json
{
  "on": {
    "type": "command",
    "value": ""
  },
  "off": {
    "type": "command",
    "value": ""
  }
}
```

#### NSGI-LD


```json
{
  "on": {
    "type": "Property",
    "value": {
      "@type": "command",
      "@value": ""
    }
  },
  "off": {
    "type": "Property",
    "value": {
      "@type": "command",
      "@value": ""
    }
  }
}
```
