### PR TITLE
clean service and subservice when cleanDomain

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Clean service and subservice domain fields when clean domain (#1201)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-- Clean service and subservice domain fields when clean domain (#1201)
+- Fix: clean service and subservice domain fields when clean domain so logs now show correct serv= and subserv=  (#1201)

--- a/lib/services/common/domain.js
+++ b/lib/services/common/domain.js
@@ -47,6 +47,8 @@ function cleanDomain(domainToClean) {
     delete domainToClean.from;
     delete domainToClean.op;
     delete domainToClean.path;
+    delete domainToClean.service;
+    delete domainToClean.subservice;
     domainToClean.exit();
 }
 
@@ -139,8 +141,10 @@ function ensureSouthboundTransaction(context, callback) {
         reqDomain.corr = reqDomain.trans;
     }
 
-    if (context && context.op) {
-        reqDomain.op = context.op;
+    if (context) {
+        if (context.op) {
+            reqDomain.op = context.op;
+        }
 
         if (context.srv) {
             reqDomain.service = context.srv;


### PR DESCRIPTION
cleanDomain is called by requestDomain which is called by northbound of iotagents and iotagent-manager

issue https://github.com/telefonicaid/iotagent-node-lib/issues/1201

Similar was done in pep:
https://github.com/telefonicaid/fiware-pep-steelskin/blob/0c7bb57a1f2cf3a22e92d9d94e7298af4870f68a/lib/middleware/domain.js#L73-L87