### PR TITLE
Exclude processing all attrs expression when current attr to update is of type commandStatus of commandResult

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-Add: do not process attr expressions when current attr update is of type 'commandStatus' or 'commandInfo'
+Add: do not process attr expressions when current attr update is of type 'commandStatus' or 'commandResult'
 Add: add expressions, payloadType and contentType to commands models
 Fix: bad query searching for group using resource instead of type by executeUpdateSideEffects (commands) (#1216)
 Upgrade mongodb dep from 3.6.8 to 3.6.12

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Add: do not process attr expressions when current attr update is of type 'commandStatus' or 'commandInfo'
 Add: add expressions, payloadType and contentType to commands models
 Fix: bad query searching for group using resource instead of type by executeUpdateSideEffects (commands) (#1216)
 Upgrade mongodb dep from 3.6.8 to 3.6.12

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -359,15 +359,18 @@ use three kinds of attributes:
 -   An attribute will be used as the _input attribute_ (the attribute registered in the Context Provider). This input
     attribute can be thought of as a command issued to the IoTAgent (from here the name of the scenario) whose value is
     the set of arguments of the command. Only updateContext operations will be used to interact with this attributes.
+    Typically this attribute is of type `command`.
 
 -   Another attribute will be used as the _result attribute_. This attribute will be updated from the IoTAgent, and its
     value stored in the Context Broker. This attribute will contain the result of the command (this result can be
     information in case the command was a "information retrieval" command or the result of an action if it was an
     "actuator command"). Typically, the name of this attribute will be the same of the input attribute, with an
-    additional sufix (`_info`) and the type is `commandResult`
+    additional sufix (`_info`) and the type is `commandResult`.
 
 -   Another attribute with the same characteristics as the later will be used to indicate whether the command has ended
-    successfully or whether an error has been reported.
+    successfully or whether an error has been reported. Typically, the name of this attribute will be the same of the
+    input attribute, with an additional sufix (`_status`) and the type is `commandStatus`. The possible values of this
+    attribute are: `ERROR`, `EXPIRED`, `PENDING`, `DELIVERED`, `UNKNOWN`
 
 In this scenario, the interaction is also initiated by the User. The user starts the scenario by sending an update
 request P1 to the Context Broker, to the input attribute (1). The Context Broker redirects this same payload to the

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -364,13 +364,21 @@ use three kinds of attributes:
 -   Another attribute will be used as the _result attribute_. This attribute will be updated from the IoTAgent, and its
     value stored in the Context Broker. This attribute will contain the result of the command (this result can be
     information in case the command was a "information retrieval" command or the result of an action if it was an
-    "actuator command"). Typically, the name of this attribute will be the same of the input attribute, with an
-    additional sufix (`_info`) and the type is `commandResult`.
+    "actuator command"). Initially its value is empty. Typically, the name of this attribute will be the same of the
+    input attribute, with an additional sufix (`_info`) and the type is `commandResult`.
 
 -   Another attribute with the same characteristics as the later will be used to indicate whether the command has ended
     successfully or whether an error has been reported. Typically, the name of this attribute will be the same of the
     input attribute, with an additional sufix (`_status`) and the type is `commandStatus`. The possible values of this
-    attribute are: `ERROR`, `EXPIRED`, `PENDING`, `DELIVERED`, `UNKNOWN`
+    attribute are: `ERROR`, `EXPIRED`, `PENDING`, `DELIVERED`, `UNKNOWN` with the following meanings:
+    -   ERROR: There is a kind of error.
+    -   EXPIRED: This meens that pull command has been expired without be delivered to device according with
+        `pollingExpiration` time defined by config.
+    -   PENDING: In a PUSH command means that command has been sent to device but not device has still not respond. In a
+        PULL command means that command has been stored and device still has no ask for it.
+    -   DELIVERED: The command has been delivered to phisical device.
+    -   OK: The command has been delivered and device has respond.
+    -   UNKNOWN: This is the initial value.
 
 In this scenario, the interaction is also initiated by the User. The user starts the scenario by sending an update
 request P1 to the Context Broker, to the input attribute (1). The Context Broker redirects this same payload to the

--- a/doc/northboundinteractions.md
+++ b/doc/northboundinteractions.md
@@ -163,16 +163,15 @@ The equivalent **NGSI-LD** payload is associated to an update operation (PATCH `
 
 ```json
 {
-     "temperature":  {
-          "type": "Property",
-          "value": "23"
-      },
-      "pressure" :{
-          "type": "Property",
-          "value": "720"
-      }
+    "temperature": {
+        "type": "Property",
+        "value": "23"
+    },
+    "pressure": {
+        "type": "Property",
+        "value": "720"
+    }
 }
-
 ```
 
 #### R1 - UpdateContext (response)
@@ -285,7 +284,8 @@ This is an **NGSI-LD** response to `/ngsi-ld/v1/entities/<entity>`
 ```
 
 In this case, the response to the QueryContext is a list of responses, one for each requested entity, indicating whether
-the information has been retrieved successfully (in the HTTP Status code) and the requested Context information in the body of the response.
+the information has been retrieved successfully (in the HTTP Status code) and the requested Context information in the
+body of the response.
 
 Application level errors can be specified for each entity in this payload.
 
@@ -305,7 +305,7 @@ Context Element, but with the request as a whole.
 
 ### Scenario 1: active attributes
 
-![General ](./img/scenario1.png "Scenario 1: active attributes")
+![General ](./img/scenario1.png 'Scenario 1: active attributes')
 
 In this scenario, the interaction is started by the device, that is going to actively send a piece of data to the
 platform. When the IoTAgent receives the data, it sends it to the Context Broker through a P1 request. The Context
@@ -319,7 +319,7 @@ updating process, and can occur at any time (they are to completely different pr
 
 ### Scenario 2: lazy attributes
 
-![General ](./img/scenario2.png "Scenario 2: lazy attributes")
+![General ](./img/scenario2.png 'Scenario 2: lazy attributes')
 
 This scenario requires that the attributes that are going to be requested are marked as provided by the IoT Agent,
 through a registration process (NGSIv9). Examples of this registration process will be provided in the practical section
@@ -345,7 +345,7 @@ queries (and thus P2 and R2 payloads).
 
 ### Scenario 3: commands
 
-![General ](./img/scenario3.png "Scenario 3: commands")
+![General ](./img/scenario3.png 'Scenario 3: commands')
 
 This scenario requires that the attributes that are going to be requested are marked as provided by the IoT Agent,
 through a registration process (NGSIv9). Examples of this registration process will be provided in the practical section
@@ -364,7 +364,7 @@ use three kinds of attributes:
     value stored in the Context Broker. This attribute will contain the result of the command (this result can be
     information in case the command was a "information retrieval" command or the result of an action if it was an
     "actuator command"). Typically, the name of this attribute will be the same of the input attribute, with an
-    additional sufix (`_info`).
+    additional sufix (`_info`) and the type is `commandResult`
 
 -   Another attribute with the same characteristics as the later will be used to indicate whether the command has ended
     successfully or whether an error has been reported.
@@ -835,7 +835,6 @@ The IoT Agent detects the selected attribute is a command, and replies to the Co
 ```json
 [
     {
-
         "type": "device",
         "id": "Dev0001",
         "switch": {
@@ -854,7 +853,6 @@ The Context Broker, forwards the same response to the user, thus replying the or
 ```json
 [
     {
-
         "type": "device",
         "id": "Dev0001",
         "switch": {
@@ -882,11 +880,11 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
             "isPattern": "false",
             "id": "Dev0001",
             "switch_info": {
-                "type": "command_info",
+                "type": "commandResult",
                 "value": "Switched successfully!"
             },
             "switch_status": {
-                "type": "command_status",
+                "type": "commandStatus",
                 "value": "OK"
             }
         }
@@ -906,11 +904,11 @@ The Context Broker replies to the IoT Agent with a R1 payload (200 OK):
         "type": "device",
         "id": "Dev0001",
         "switch_info": {
-            "type": "command_info",
+            "type": "commandResult",
             "value": ""
         },
-        "switch_status":  {
-            "type": "command_status",
+        "switch_status": {
+            "type": "commandStatus",
             "value": ""
         }
     }
@@ -936,8 +934,8 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
         }
     ],
     "attributes": [
-    	"switch_info",
-    	"switch_status"
+        "switch_info",
+        "switch_status"
     ]
 }' "https://<platform-ip>:10027/v2/op/query"
 ```
@@ -947,20 +945,18 @@ The Context Broker replies with all the desired data, in R2 format (200 OK):
 ```json
 [
     {
-
         "type": "device",
         "id": "Dev0001",
         "switch_info": {
-            "type": "command_info",
+            "type": "commandResult",
             "value": "Switched successfully!"
         },
         "switch_status": {
-            "type": "command_status",
+            "type": "commandStatus",
             "value": "OK"
         }
     }
 ]
-
 ```
 
 ### Scenario 3: commands (error)
@@ -978,11 +974,11 @@ curl -X POST -H "Content-Type: application/json" -H "Accept: application/json" -
             "isPattern": "false",
             "id": "Dev0001",
             "switch_info":{
-                "type": "command_info",
+                "type": "commandResult",
                 "value": "The switch could not be switched due to the following error: switch blocked"
             },
             "switch_status":{
-                "type": "command_status",
+                "type": "commandStatus",
                 "value": "ERROR"
             }
         }
@@ -999,11 +995,11 @@ In this case, the Context Broker reply with the following response (200 OK):
         "type": "device",
         "id": "Dev0001",
         "switch_info": {
-            "type": "command_info",
+            "type": "commandResult",
             "value": ""
         },
         "switch_status": {
-            "type": "command_status",
+            "type": "commandStatus",
             "value": ""
         }
     }

--- a/doc/usermanual.md
+++ b/doc/usermanual.md
@@ -209,8 +209,8 @@ function setCommandResult(entityName, resource, apikey, commandName, commandResu
 ###### Description
 
 Update the result of a command in the Context Broker. The result of the command has two components: the result of the
-command itself will be represented with the suffix `_result` in the entity while the status is updated in the attribute
-with the `_info` suffix.
+command itself will be represented with the suffix `_info` in the entity while the status is updated in the attribute
+with the `_status` suffix.
 
 ###### Params
 

--- a/lib/plugins/expressionPlugin.js
+++ b/lib/plugins/expressionPlugin.js
@@ -31,6 +31,7 @@ const config = require('../commonConfig');
 /* eslint-disable no-unused-vars */
 const logger = require('logops');
 const errors = require('../errors');
+const constants = require('../constants');
 const context = {
     op: 'IoTAgentNGSI.expressionPlugin'
 };
@@ -134,7 +135,7 @@ function update(entity, typeInformation, callback) {
         let attsArray = utils.extractAttributesArrayFromNgsi2Entity(entity);
         // Exclude processing all attr expressions when current attr is of type 'commandStatus' or 'commandResult'
         const attsArrayFiltered = attsArray.filter((obj) => {
-            return !['commandStatus', 'commandResult'].includes(obj.type);
+            return ![constants.COMMAND_STATUS, constants.COMMAND_RESULT].includes(obj.type);
         });
         if (attsArrayFiltered.length > 0) {
             attsArray = processEntityUpdateNgsi2(attsArrayFiltered);

--- a/lib/plugins/expressionPlugin.js
+++ b/lib/plugins/expressionPlugin.js
@@ -132,9 +132,9 @@ function update(entity, typeInformation, callback) {
     try {
         logger.debug(context, 'expressionPlugin entity %j', entity);
         let attsArray = utils.extractAttributesArrayFromNgsi2Entity(entity);
-        // Exclude processing all attrs expression when current attr is of type 'commandStatus'
+        // Exclude processing all attr expressions when current attr is of type 'commandStatus' or 'commandInfo'
         const attsArrayFiltered = attsArray.filter((obj) => {
-            return obj.type !== 'commandStatus';
+            return !['commandStatus', 'commandResult'].includes(obj.type);
         });
         if (attsArrayFiltered.length > 0) {
             attsArray = processEntityUpdateNgsi2(attsArrayFiltered);

--- a/lib/plugins/expressionPlugin.js
+++ b/lib/plugins/expressionPlugin.js
@@ -30,6 +30,7 @@ const jexlParser = require('./jexlParser');
 const config = require('../commonConfig');
 /* eslint-disable no-unused-vars */
 const logger = require('logops');
+const errors = require('../errors');
 const context = {
     op: 'IoTAgentNGSI.expressionPlugin'
 };
@@ -131,7 +132,13 @@ function update(entity, typeInformation, callback) {
     try {
         logger.debug(context, 'expressionPlugin entity %j', entity);
         let attsArray = utils.extractAttributesArrayFromNgsi2Entity(entity);
-        attsArray = processEntityUpdateNgsi2(attsArray);
+        // Exclude processing all attrs expression when current attr is of type 'commandStatus'
+        const attsArrayFiltered = attsArray.filter((obj) => {
+            return obj.type !== 'commandStatus';
+        });
+        if (attsArrayFiltered.length > 0) {
+            attsArray = processEntityUpdateNgsi2(attsArrayFiltered);
+        }
         entity = utils.createNgsi2Entity(entity.id, entity.type, attsArray, true);
 
         callback(null, entity, typeInformation);

--- a/lib/plugins/expressionPlugin.js
+++ b/lib/plugins/expressionPlugin.js
@@ -132,7 +132,7 @@ function update(entity, typeInformation, callback) {
     try {
         logger.debug(context, 'expressionPlugin entity %j', entity);
         let attsArray = utils.extractAttributesArrayFromNgsi2Entity(entity);
-        // Exclude processing all attr expressions when current attr is of type 'commandStatus' or 'commandInfo'
+        // Exclude processing all attr expressions when current attr is of type 'commandStatus' or 'commandResult'
         const attsArrayFiltered = attsArray.filter((obj) => {
             return !['commandStatus', 'commandResult'].includes(obj.type);
         });

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -177,7 +177,7 @@ function executeWithDeviceInformation(operationFunction) {
 
 /**
  * Update the result of a command in the Context Broker. The result of the command has two components: the result
- * of the command itself will be represented with the sufix '_result' in the entity while the status is updated in the
+ * of the command itself will be represented with the sufix '_info' in the entity while the status is updated in the
  * attribute with the '_status' sufix.
  *
  * @param {String} entityName           Name of the entity holding the command.


### PR DESCRIPTION
Due to some expressions of attributes could not be executed in a non measure context (i.e. command response from a device), resulting in errors or filling nulls in attrs

- [x] And the same for commandResult type

This PRs enables commands of devices with another attributes using expressions could transit to PENDING and DELIVERED status