### PR TITLE
upgrade async dep from 2.6.2 version to 2.6.4 due to security vulnerability (CWE-1321)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+Upgrade async dep from 2.6.2 to 2.6.4 due to security vulnerability (CWE-1321)
 Fix: exclude all attrs when explicitAttrs is an empty array (#1235)
 Add: do not process attr expressions when current attr update is of type 'commandStatus' or 'commandResult'
 Add: add expressions, payloadType and contentType to commands models

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "watch": "watch 'npm test && npm run lint' ./lib ./test"
   },
   "dependencies": {
-    "async": "2.6.2",
+    "async": "2.6.4",
     "body-parser": "~1.19.0",
     "express": "~4.16.4",
     "got": "~11.8.2",


### PR DESCRIPTION
A vulnerability exists in Async through 3.2.1 for 3.x and through 2.6.3 for 2.x (fixed in 3.2.2 and 2.6.4), which could let a malicious user obtain privileges via the mapValues() method.