### PR TITLE
replace findType by findTypeSilently to avoid raise mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - Fix: allow use JEXL expresions in explicitAttrs for conditional propagation of measures (reopen #1179, for Devices)
-- Fix: avoid raise mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 
+- Fix: avoid raising mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
 - Fix: allow use JEXL expresions in explicitAttrs for conditional propagation of measures (reopen #1179, for Devices)
-- Fix: replace findType by findTypeSilently to avoid raise mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 
+- Fix: avoid raise mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: allow use JEXL expresions in explicitAttrs for conditional propagation of measures (reopen #1179, for Devices)
+- Fix: replace findType by findTypeSilently to avoid raise mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 

--- a/lib/services/ngsi/ngsiService.js
+++ b/lib/services/ngsi/ngsiService.js
@@ -133,7 +133,7 @@ function executeWithDeviceInformation(operationFunction) {
             deviceInformation
         );
         const currentType = type ? type : deviceInformation.type;
-        config.getGroupRegistry().getType(currentType, function (error, deviceGroup) {
+        config.getGroupRegistry().getTypeSilently(currentType, function (error, deviceGroup) {
             let typeInformation;
             const configDeviceInfo = config.getConfig().types[currentType];
             if (error) {


### PR DESCRIPTION
Probably fixes:

time=2022-05-12T06:04:16.927Z | lvl=ERROR | corr=n/a | trans=n/a | op=IoTAgentNGSI.Alarms | from=n/a | srv=n/a | subsrv=n/a | msg=Raising [MONGO-ALARM]: {"name":"DEVICE_GROUP_NOT_FOUND","message":"Couldn\t find device group for fields: [\"service\",\"subservice\",\"type\",\"apikey\"] and values: {\"service\":\"sc_vlci\",\"subservice\":\"/medioambiente_emt\",\"type\":\"Device\"}","code":404} | comp=IoTAgent
 