### PR TITLE
fix: Lower case headers for NGSILD Tenant and NGSILD Path

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: allow use JEXL expresions in explicitAttrs for conditional propagation of measures (reopen #1179, for Devices)
 - Fix: avoid raising mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 
+- Fix: Change NGSILD-Tenant and NGSILD-Path headers to lower case

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
 - Fix: allow use JEXL expresions in explicitAttrs for conditional propagation of measures (reopen #1179, for Devices)
 - Fix: avoid raising mongo alarm (DEVICE_GROUP_NOT_FOUND) before launch op against CB 
-- Fix: Change NGSILD-Tenant and NGSILD-Path headers to lower case
+- Fix: fix issue with unrecognized NGSILD-Tenant and NGSILD-Path headers

--- a/lib/services/northBound/contextServerUtils.js
+++ b/lib/services/northBound/contextServerUtils.js
@@ -41,8 +41,8 @@ const commands = require('../commands/commandService');
  * @return {String}                 The Tenant decribed in the request headers
  */
 function getLDTenant(req) {
-    if (req.headers['NGSILD-Tenant']) {
-        return req.headers['NGSILD-Tenant'];
+    if (req.headers['ngsild-tenant']) {
+        return req.headers['ngsild-tenant'];
     } else if (req.headers['fiware-service']) {
         return req.headers['fiware-service'];
     }
@@ -56,8 +56,8 @@ function getLDTenant(req) {
  * obliged to offer service headers - this is still being defined in the NGSI-LD specifications.
  */
 function getLDPath(req) {
-    if (req.headers['NGSILD-Path']) {
-        return req.headers['NGSILD-Path'];
+    if (req.headers['ngsild-path']) {
+        return req.headers['ngsild-path'];
     } else if (req.headers['fiware-servicepath']) {
         return req.headers['fiware-servicepath'];
     }

--- a/lib/services/northBound/contextServerUtils.js
+++ b/lib/services/northBound/contextServerUtils.js
@@ -41,10 +41,10 @@ const commands = require('../commands/commandService');
  * @return {String}                 The Tenant decribed in the request headers
  */
 function getLDTenant(req) {
-    if (req.headers['ngsild-tenant']) {
-        return req.headers['ngsild-tenant'];
-    } else if (req.headers['fiware-service']) {
-        return req.headers['fiware-service'];
+    if (req.header('NGSILD-Tenant')) {
+        return req.header('NGSILD-Tenant');
+    } else if (req.header('fiware-service')) {
+        return req.header('fiware-service');
     }
     return config.getConfig().contextBroker.fallbackTenant;
 }
@@ -56,10 +56,10 @@ function getLDTenant(req) {
  * obliged to offer service headers - this is still being defined in the NGSI-LD specifications.
  */
 function getLDPath(req) {
-    if (req.headers['ngsild-path']) {
-        return req.headers['ngsild-path'];
-    } else if (req.headers['fiware-servicepath']) {
-        return req.headers['fiware-servicepath'];
+    if (req.header('NGSILD-Path')) {
+        return req.header('NGSILD-path');
+    } else if (req.header('fiware-servicepath')) {
+        return req.header('fiware-servicepath');
     }
     return config.getConfig().contextBroker.fallbackPath;
 }


### PR DESCRIPTION
req.headers only contains lowercased headers.
Calling req.headers["NGSILD-Tenant"] will always return undefined. The lib cannot have the expected comportement.
Replacing key with "ngsild-tenant" is fixing the problem. I tested it with iot-agent-json lib ( custom image wiikip/iot-agent-json )