### PR TITLE
Add NGSI-LD 1.6.1 PUT support

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -29,3 +29,4 @@
 - Upgrade textlint dev dependency from 11.7.6 to 12.2.1 
 - Upgrade textlint-rule-terminology dev dependency from 2.1.4 to 3.0.2
 - Upgrade textlint-rule-write-good dev dependency from 1.6.2 to 2.0.0
+- Add: NGSI-LD PUT support

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -42,6 +42,7 @@ const notificationTemplateNgsiLD = require('../../templates/notificationTemplate
 const contextServerUtils = require('./contextServerUtils');
 const ngsiLD = require('../ngsi/entities-NGSI-LD');
 
+const overwritePaths = ['/ngsi-ld/v1/entities/:entity/attrs/:attr'];
 const updatePaths = ['/ngsi-ld/v1/entities/:entity/attrs/:attr'];
 const queryPaths = ['/ngsi-ld/v1/entities/:entity'];
 
@@ -567,6 +568,15 @@ function loadContextRoutesNGSILD(router) {
     logger.info(context, 'Loading NGSI-LD Context server routes');
     for (i = 0; i < updatePaths.length; i++) {
         router.patch(updatePaths[i], [
+            middlewares.ensureType,
+            middlewares.validateJson(updateContextTemplateNgsiLD),
+            handleUpdateNgsiLD,
+            updateErrorHandlingNgsiLD
+        ]);
+    }
+
+    for (i = 0; i < overwritePaths.length; i++) {
+        router.put(overwritePaths[i], [
             middlewares.ensureType,
             middlewares.validateJson(updateContextTemplateNgsiLD),
             handleUpdateNgsiLD,


### PR DESCRIPTION
If you look at the latest [NGSI-LD_DRAFT specification](https://docbox.etsi.org/ISG/CIM/Open/drafts/ETSI_GS_CIM-0009_NGSI-LD_DRAFT-for-PUBLIC-COMMENT-V1.5.3.pdf) you will notice there are additional PATCH and PUT endpoints defined

<img width="663" alt="endpoints" src="https://user-images.githubusercontent.com/3439249/178434580-84b49ab1-1226-4d89-837b-2b71695a5070.png">

These additional endpoints will become standard across NGSI-LD brokers.

As far as IoT Agents are concerned, for commands, the  new **PUT** `/ngsi-ld/v1/entities/<entity-id>/attrs/<attr-name>` endpoint should be treated the same way as the existing **PATCH**  `/ngsi-ld/v1/entities/<entity-id>/attrs/<attr-name>`  endpoint.

- New **PUT** route is serviced
- Additional Unit test.