### PR TITLE
Support additional NGSI-LD endpoints

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -30,3 +30,4 @@
 - Upgrade textlint-rule-terminology dev dependency from 2.1.4 to 3.0.2
 - Upgrade textlint-rule-write-good dev dependency from 1.6.2 to 2.0.0
 - Add: NGSI-LD PUT support
+- Add: NGSI-LD support for multiple attribute updates.

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -42,8 +42,8 @@ const notificationTemplateNgsiLD = require('../../templates/notificationTemplate
 const contextServerUtils = require('./contextServerUtils');
 const ngsiLD = require('../ngsi/entities-NGSI-LD');
 
-const overwritePaths = ['/ngsi-ld/v1/entities/:entity/attrs/:attr'];
-const updatePaths = ['/ngsi-ld/v1/entities/:entity/attrs/:attr'];
+const overwritePaths = ['/ngsi-ld/v1/entities/:entity/attrs', '/ngsi-ld/v1/entities/:entity/attrs/:attr'];
+const updatePaths = ['/ngsi-ld/v1/entities/:entity/attrs', '/ngsi-ld/v1/entities/:entity/attrs/:attr'];
 const queryPaths = ['/ngsi-ld/v1/entities/:entity'];
 
 /**
@@ -56,8 +56,10 @@ const queryPaths = ['/ngsi-ld/v1/entities/:entity'];
 function generateUpdateActionsNgsiLD(req, contextElement, callback) {
     let entityId;
     let entityType;
+
     const attribute = req.params.attr;
     const value = req.body.value;
+    const incomingAttrs = !req.params.attr ? _.keys(req.body) : [];
 
     if (contextElement.id && contextElement.type) {
         entityId = contextElement.id;
@@ -78,6 +80,13 @@ function generateUpdateActionsNgsiLD(req, contextElement, callback) {
                         type: device.commands[j].type,
                         value,
                         name: attribute
+                    });
+                    found = true;
+                } else if (incomingAttrs.includes(device.commands[j].name)) {
+                    commands.push({
+                        type: device.commands[j].type,
+                        value: req.body[device.commands[j].name].value,
+                        name: device.commands[j].name
                     });
                     found = true;
                 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
@@ -10,7 +10,8 @@
                 }
             ],
             "properties": [
-                "position"
+                "position",
+                "orientation"
             ]
         }
     ],

--- a/test/unit/ngsi-ld/lazyAndCommands/command-test.js
+++ b/test/unit/ngsi-ld/lazyAndCommands/command-test.js
@@ -94,6 +94,10 @@ const iotAgentConfig = {
                 {
                     name: 'position',
                     type: 'Array'
+                },
+                {
+                    name: 'orientation',
+                    type: 'Array'
                 }
             ],
             lazy: [],
@@ -158,7 +162,114 @@ describe('NGSI-LD - Command functionalities', function () {
             });
         });
     });
-    describe('When a command update PATCH arrives to the IoT Agent as Context Provider', function () {
+
+    describe('When multiple command updates via PATCH /attrs arrive to the IoT Agent as Context Provider', function () {
+        const options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities/urn:ngsi-ld:Robot:r2d2/attrs',
+            method: 'PATCH',
+            json: {
+                orientation: {
+                    type: 'Property',
+                    value: [1, 2, 3]
+                },
+                position: {
+                    type: 'Property',
+                    value: [28, -104, 23]
+                }
+            },
+            headers: {
+                'fiware-service': 'smartgondor',
+                'content-type': 'application/ld+json'
+            }
+        };
+
+        beforeEach(function (done) {
+            logger.setLevel('ERROR');
+            iotAgentLib.register(device3, function (error) {
+                done();
+            });
+        });
+
+        it('should call the client handler once', function (done) {
+            let handlerCalled = 0;
+
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                id.should.equal('urn:ngsi-ld:' + device3.type + ':' + device3.id);
+                type.should.equal(device3.type);
+                attributes[0].name.should.equal('position');
+                attributes[1].name.should.equal('orientation');
+                JSON.stringify(attributes[0].value).should.equal('[28,-104,23]');
+                JSON.stringify(attributes[1].value).should.equal('[1,2,3]');
+                handlerCalled++;
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        },
+                        {
+                            name: 'orientation',
+                            type: 'Array',
+                            value: '[1, 2, 3]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                should.not.exist(error);
+                handlerCalled.should.equal(1);
+                done();
+            });
+        });
+        it('should create the attribute with the "_status" prefix in the Context Broker', function (done) {
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                should.not.exist(error);
+                done();
+            });
+        });
+        it('should create the attribute with the "_status" prefix in the Context Broker', function (done) {
+            let serviceReceived = false;
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                serviceReceived = service === 'smartgondor';
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                serviceReceived.should.equal(true);
+                done();
+            });
+        });
+    });
+
+    describe('When a command update PATCH attrs/attr-name arrives to the IoT Agent as Context Provider', function () {
         const options = {
             url:
                 'http://localhost:' +
@@ -254,7 +365,113 @@ describe('NGSI-LD - Command functionalities', function () {
         });
     });
 
-    describe('When a command overwrite PUT arrives to the IoT Agent as Context Provider', function () {
+    describe('When multiple command overwrites via PUT  /attrs arrive to the IoT Agent as Context Provider', function () {
+        const options = {
+            url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities/urn:ngsi-ld:Robot:r2d2/attrs',
+            method: 'PUT',
+            json: {
+                orientation: {
+                    type: 'Property',
+                    value: [1, 2, 3]
+                },
+                position: {
+                    type: 'Property',
+                    value: [28, -104, 23]
+                }
+            },
+            headers: {
+                'fiware-service': 'smartgondor',
+                'content-type': 'application/ld+json'
+            }
+        };
+
+        beforeEach(function (done) {
+            logger.setLevel('ERROR');
+            iotAgentLib.register(device3, function (error) {
+                done();
+            });
+        });
+
+        it('should call the client handler once', function (done) {
+            let handlerCalled = 0;
+
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                id.should.equal('urn:ngsi-ld:' + device3.type + ':' + device3.id);
+                type.should.equal(device3.type);
+                attributes[0].name.should.equal('position');
+                attributes[1].name.should.equal('orientation');
+                JSON.stringify(attributes[0].value).should.equal('[28,-104,23]');
+                JSON.stringify(attributes[1].value).should.equal('[1,2,3]');
+                handlerCalled++;
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        },
+                        {
+                            name: 'orientation',
+                            type: 'Array',
+                            value: '[1, 2, 3]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                should.not.exist(error);
+                handlerCalled.should.equal(1);
+                done();
+            });
+        });
+        it('should create the attribute with the "_status" prefix in the Context Broker', function (done) {
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                should.not.exist(error);
+                done();
+            });
+        });
+        it('should create the attribute with the "_status" prefix in the Context Broker', function (done) {
+            let serviceReceived = false;
+            iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
+                serviceReceived = service === 'smartgondor';
+                callback(null, {
+                    id,
+                    type,
+                    attributes: [
+                        {
+                            name: 'position',
+                            type: 'Array',
+                            value: '[28, -104, 23]'
+                        }
+                    ]
+                });
+            });
+
+            request(options, function (error, response, body) {
+                serviceReceived.should.equal(true);
+                done();
+            });
+        });
+    });
+
+    describe('When a command overwrite PUT  attrs/attr-name arrives to the IoT Agent as Context Provider', function () {
         const options = {
             url:
                 'http://localhost:' +
@@ -282,8 +499,7 @@ describe('NGSI-LD - Command functionalities', function () {
             let handlerCalled = 0;
 
             iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
-                
-                console.error(attributes)
+                console.error(attributes);
                 id.should.equal('urn:ngsi-ld:' + device3.type + ':' + device3.id);
                 type.should.equal(device3.type);
                 attributes[0].name.should.equal('position');
@@ -351,7 +567,6 @@ describe('NGSI-LD - Command functionalities', function () {
             });
         });
     });
-
 
     describe('When an update arrives from the south bound for a registered command', function () {
         beforeEach(function (done) {

--- a/test/unit/ngsi-ld/lazyAndCommands/command-test.js
+++ b/test/unit/ngsi-ld/lazyAndCommands/command-test.js
@@ -499,7 +499,6 @@ describe('NGSI-LD - Command functionalities', function () {
             let handlerCalled = 0;
 
             iotAgentLib.setCommandHandler(function (id, type, service, subservice, attributes, callback) {
-                console.error(attributes);
                 id.should.equal('urn:ngsi-ld:' + device3.type + ':' + device3.id);
                 type.should.equal(device3.type);
                 attributes[0].name.should.equal('position');


### PR DESCRIPTION
Extend the existing NGSI-LD support to more of the actuation endpoints defined in the 1.5.3 spec.

#### Overwrite attributes

-  PUT '/ngsi-ld/v1/entities/:entity/attrs'  🆕 
-  PUT '/ngsi-ld/v1/entities/:entity/attrs/:attr'

#### Partial Update attributes

- PATCH '/ngsi-ld/v1/entities/:entity/attrs' 🆕 
- PATCH '/ngsi-ld/v1/entities/:entity/attrs/:attr'