### PR TITLE
Add NGSI-LD LanguageProperty support

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -29,4 +29,5 @@
 - Upgrade textlint dev dependency from 11.7.6 to 12.2.1 
 - Upgrade textlint-rule-terminology dev dependency from 2.1.4 to 3.0.2
 - Upgrade textlint-rule-write-good dev dependency from 1.6.2 to 2.0.0
+- Add: Support for NGSI-LD LanguageProperty
 - Add: NGSI-LD PUT support

--- a/doc/advanced-topics.md
+++ b/doc/advanced-topics.md
@@ -197,7 +197,7 @@ e.g.:
 When provisioning devices for an NGSI-LD Context Broker, `type` values should typically correspond to one of the
 following:
 
--   `Property`, `Relationship`, `Geoproperty`
+-   `Property`, `Relationship`, `GeoProperty`, `LanguageProperty`
 -   Native JSON types (e.g. `String`, `Boolean`, `Float` , `Integer` `Number`)
 -   Temporal Properties (e.g. `Datetime`, `Date` , `Time`)
 -   GeoJSON types (e.g `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`)

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -160,6 +160,13 @@ function convertAttrNGSILD(attr) {
             delete obj.value;
             break;
 
+        // LanguageProperties
+        case 'languageproperty':
+            obj.type = 'LanguageProperty';
+            obj.languageMap = attr.value;
+            delete obj.value;
+            break;
+
         default:
             obj.value = { '@type': attr.type, '@value': attr.value };
     }

--- a/test/unit/ngsi-ld/examples/contextRequests/updateContextLanguageProperties1.json
+++ b/test/unit/ngsi-ld/examples/contextRequests/updateContextLanguageProperties1.json
@@ -1,0 +1,15 @@
+[
+  {
+    "@context": "http://context.json-ld",
+    "name": {
+      "type": "LanguageProperty",
+      "languageMap": {
+        "el": "Κωνσταντινούπολις",
+        "en": "Constantinople",
+        "tr": "İstanbul"
+      }
+    },
+    "id": "urn:ngsi-ld:Light:light1",
+    "type": "Light"
+  }
+]

--- a/test/unit/ngsi-ld/ngsiService/languageProperties-test.js
+++ b/test/unit/ngsi-ld/ngsiService/languageProperties-test.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, see http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ *
+ * Modified by: Daniel Calvo - ATOS Research & Innovation
+ */
+
+/* eslint-disable no-unused-vars */
+
+const iotAgentLib = require('../../../../lib/fiware-iotagent-lib');
+const utils = require('../../../tools/utils');
+const request = utils.request;
+const should = require('should');
+const logger = require('logops');
+const nock = require('nock');
+let contextBrokerMock;
+const iotAgentConfig = {
+    autocast: true,
+    contextBroker: {
+        host: '192.168.1.1',
+        port: '1026',
+        ngsiVersion: 'ld',
+        jsonLdContext: 'http://context.json-ld'
+    },
+    server: {
+        port: 4041
+    },
+    types: {
+        Light: {
+            commands: [],
+            type: 'Light',
+            active: [
+                {
+                    name: 'name',
+                    type: 'LanguageProperty'
+                }
+            ]
+        }
+    },
+    service: 'smartgondor',
+    subservice: 'gardens',
+    providerUrl: 'http://smartgondor.com'
+};
+
+describe('NGSI-LD - LanguageProperty test', function () {
+    beforeEach(function () {
+        logger.setLevel('FATAL');
+    });
+
+    afterEach(function (done) {
+        iotAgentLib.deactivate(done);
+    });
+
+    describe(
+        'When the IoT Agent receives new exonym from a device.' +
+            'name with LanguageProperty type and a JSON object',
+        function () {
+            const values = [
+                {
+                    name: 'name',
+                    type: 'LanguageProperty',
+                    value:  {
+                       el: "Κωνσταντινούπολις",
+                       en: "Constantinople",
+                       tr: "İstanbul"
+                    }
+                }
+            ];
+
+            beforeEach(function (done) {
+                nock.cleanAll();
+
+                contextBrokerMock = nock('http://192.168.1.1:1026')
+                    .matchHeader('fiware-service', 'smartgondor')
+                    .post(
+                        '/ngsi-ld/v1/entityOperations/upsert/?options=update',
+                        utils.readExampleFile(
+                            './test/unit/ngsi-ld/examples/contextRequests/updateContextLanguageProperties1.json'
+                        )
+                    )
+                    .reply(204);
+
+                iotAgentLib.activate(iotAgentConfig, done);
+            });
+
+            it('should change the value of the corresponding attribute in the context broker', function (done) {
+                iotAgentLib.update('light1', 'Light', '', values, function (error) {
+                    should.not.exist(error);
+                    contextBrokerMock.done();
+                    done();
+                });
+            });
+        }
+    );
+});

--- a/test/unit/ngsi-ld/ngsiService/languageProperties-test.js
+++ b/test/unit/ngsi-ld/ngsiService/languageProperties-test.js
@@ -70,8 +70,7 @@ describe('NGSI-LD - LanguageProperty test', function () {
     });
 
     describe(
-        'When the IoT Agent receives new exonym from a device.' +
-            'name with LanguageProperty type and a JSON object',
+        'When the IoT Agent receives new exonym from a device name with LanguageProperty type and a JSON object',
         function () {
             const values = [
                 {


### PR DESCRIPTION
`LanguageProperty` has been defined in the NGSI-LD spec since 1.4.1. This PR correctly maps LanguageProperty to a `languageMap` attribute which is defined in the core `@context` as a JSON-LD `@container: @lang`. 

`LanguageProperty` is most likely to be a static attribute, but active measures can also be supported - it is basically the same idea as mapping `Relationship` and the `object` attribute.

- Update Docs
- Update Unit Test
- Add `LanguageProperty` exception clause to `switch`