### PR TITLE
[WIP] use group apikey for autoprovision device

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- Save group apikey in device when autoprovision device (#1245)
 

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -605,6 +605,9 @@ function findOrCreate(deviceId, group, callback) {
             if ('expressionLanguage' in group && group.expressionLanguage !== undefined) {
                 newDevice.expressionLanguage = group.expressionLanguage;
             }
+            if (!newDevice.apikey && 'apikey' in group && group.apikey !== undefined) {
+                newDevice.apikey = group.apikey;
+            }
             // Check autoprovision flag in order to register or not device
             if (group.autoprovision === undefined || group.autoprovision === true) {
                 registerDevice(newDevice, function (error, device) {


### PR DESCRIPTION
https://github.com/telefonicaid/iotagent-node-lib/issues/1245

" Currently autoprovision is not storing a device with an apikey."