### PR TITLE
Ensure GET `http://{{iot-agent}}/ngsi-ld/v1/entities/<entity-id>` returns a valid response

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- Fix: Ensure GET /ngsi-ld/v1/entities/<entity-id> returns a valid response (#1276)
 

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -290,7 +290,7 @@ function handleQueryNgsiLD(req, res, next) {
 
         if (device.staticAttributes) {
             let selectedAttributes = [];
-            if (attributes === undefined || attributes.length === 0) {
+            if (attributes === null || attributes === undefined || attributes.length === 0) {
                 selectedAttributes = device.staticAttributes;
             } else {
                 selectedAttributes = device.staticAttributes.filter(inAttributes);
@@ -316,8 +316,8 @@ function handleQueryNgsiLD(req, res, next) {
             const results = device.lazy.map(getName);
             callback(null, results);
         } else {
-            logger.debug(context, "Couldn't find any attributes. Handling with null reference");
-            callback(null, null);
+            logger.debug(context, "Couldn't find any attributes. Handling with empty reference");
+            callback(null, []);
         }
     }
 

--- a/test/unit/ngsi-ld/lazyAndCommands/command-test.js
+++ b/test/unit/ngsi-ld/lazyAndCommands/command-test.js
@@ -615,4 +615,42 @@ describe('NGSI-LD - Command functionalities', function () {
             });
         });
     });
+
+    describe('When a query arrives to the IoT Agent with registered commands but no lazy attributes', function () {
+        const options = {
+            url:
+                'http://localhost:' +
+                iotAgentConfig.server.port +
+                '/ngsi-ld/v1/entities/urn:ngsi-ld:Robot:r2d2',
+            method: 'GET',
+            headers: {
+                'fiware-service': 'smartgondor',
+                'content-type': 'application/ld+json'
+            }
+        };
+
+        beforeEach(function (done) {
+            logger.setLevel('ERROR');
+            iotAgentLib.register(device3, function (error) {
+                done();
+            });
+        });
+
+        it('should return the a valid empty response', function (done) {
+            iotAgentLib.setDataQueryHandler(function (id, type, service, subservice, attributes, callback) {
+                should.exist(attributes);
+                attributes.length.should.equal(0);
+                callback(null, {
+                        id: 'urn:ngsi-ld:Robot:r2d2',
+                        type: 'Robot'
+                });
+            });
+
+            request(options, function (error, response, body) {
+                should.not.exist(error);
+                response.statusCode.should.equal(200);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
In NGSI-LD, normally `http://{{iot-agent}}/ngsi-ld/v1/entities/<entity-id>` will return lazy attributes , however, I just noticed a bug related to commands. If a device had registered commands, but no registered lazy attribute it was failing with a null pointer and the response was not valid:

- Defensive Programming - add null check to attributes
- Add Test.

`http://{{iot-agent}}/ngsi-ld/v1/entities/<entity-id>` is one of the **valid** NGSI-LD endpoints defined in the 1.5.3 spec which the IoT Agent should service. 

Admittedly, ideally the context broker **shouldn't** need to call the IoT Agent at all in this case (with commands but no lazy attributes) but since  is a valid request when a device has lazy attributes or when a device has lazy attributes **and** commands, it shouldn't error in this case, but give a valid empty response.
