### PR TITLE
Add NGSI-LD Unsupported Endpoints

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- Add: NGSI-LD Unsupported Endpoints return valid error responses (#1277)
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -242,6 +242,13 @@ class BadGeocoordinates {
         this.code = 400;
     }
 }
+class MethodNotSupported {
+    constructor(method, path) {
+        this.name = 'METHOD_NOT_IMPLEMENTED';
+        this.message = 'IoT Agents do not support the endpoint: ' + method + ' ' + path;
+        this.code = 501;
+    }
+}
 
 module.exports = {
     RegistrationError,
@@ -273,5 +280,6 @@ module.exports = {
     InvalidExpression,
     BadAnswer,
     BadTimestamp,
-    BadGeocoordinates
+    BadGeocoordinates,
+    MethodNotSupported
 };

--- a/lib/services/northBound/contextServer-NGSI-LD.js
+++ b/lib/services/northBound/contextServer-NGSI-LD.js
@@ -564,6 +564,21 @@ function updateErrorHandlingNgsiLD(error, req, res, next) {
 }
 
 /**
+ * Load unsupported NGSI-LD entity routes and return proper NGSI-LD not supported responses
+ *
+ * @param {Object} router      Express request router object.
+ */
+function loadUnsupportedEndpointsNGSILD(router) {
+    const unsupportedEndpoint = function (req, res) {
+        return res.status(501).send(new errors.MethodNotSupported(req.method, req.path));
+    };
+    router.get('/ngsi-ld/v1/entities', unsupportedEndpoint);
+    router.post('/ngsi-ld/v1/entities', unsupportedEndpoint);
+    router.delete('/ngsi-ld/v1/entities/:entity', unsupportedEndpoint);
+    router.delete('/ngsi-ld/v1/entities/:entity/attrs/:attr', unsupportedEndpoint);
+}
+
+/**
  * Load the routes related to context dispatching (NGSI10 calls).
  *
  * @param {Object} router      Express request router object.
@@ -601,6 +616,7 @@ function loadContextRoutesNGSILD(router) {
         handleNotificationNgsiLD,
         queryErrorHandlingNgsiLD
     ]);
+    loadUnsupportedEndpointsNGSILD(router);
 }
 
 exports.loadContextRoutes = loadContextRoutesNGSILD;

--- a/test/unit/ngsi-ld/ngsiService/unsupported-endpoints-test.js
+++ b/test/unit/ngsi-ld/ngsiService/unsupported-endpoints-test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of fiware-iotagent-lib
+ *
+ * fiware-iotagent-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * fiware-iotagent-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with fiware-iotagent-lib.
+ * If not, see http://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::daniel.moranjimenez@telefonica.com
+ *
+ * Modified by: Jason Fox - FIWARE Foundation
+ */
+
+/* eslint-disable no-unused-vars */
+
+const iotAgentLib = require('../../../../lib/fiware-iotagent-lib');
+const utils = require('../../../tools/utils');
+const request = utils.request;
+const should = require('should');
+
+let contextBrokerMock;
+const iotAgentConfig = {
+    contextBroker: {
+        host: '192.168.1.1',
+        port: '1026',
+        ngsiVersion: 'ld',
+        jsonLdContext: 'http://context.json-ld'
+    },
+    server: {
+        port: 4041
+    },
+    types: {},
+    service: 'smartgondor',
+    subservice: 'gardens',
+    providerUrl: 'http://smartgondor.com'
+};
+
+describe('NGSI-LD - Unsupported Endpoints', function () {
+    beforeEach(function (done) {
+        iotAgentLib.activate(iotAgentConfig, function () {
+            iotAgentLib.clearAll(function () {
+                done();
+            });
+        });
+    });
+
+    afterEach(function (done) {
+        iotAgentLib.clearAll(function () {
+            iotAgentLib.deactivate(done);
+        });
+    });
+
+    describe('When accessing an Unsupported Endpoint', function () {
+        it('GET /entities should return a valid NSGI-LD error message', function (done) {
+            const options = {
+                url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities',
+                method: 'GET'
+            };
+            request(options, function (error, response, body) {
+                response.statusCode.should.equal(501);
+                done();
+            });
+        });
+        it('POST /entities should return a valid NSGI-LD error message', function (done) {
+            const options = {
+                url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities',
+                method: 'POST',
+                json: {}
+            };
+            request(options, function (error, response, body) {
+                response.statusCode.should.equal(501);
+                done();
+            });
+        });
+        it('DELETE /entities/<entity-id> should return a valid NSGI-LD error message', function (done) {
+            const options = {
+                url: 'http://localhost:' + iotAgentConfig.server.port + '/ngsi-ld/v1/entities/urn:ngsi-ld:entity',
+                method: 'DELETE'
+            };
+            request(options, function (error, response, body) {
+                response.statusCode.should.equal(501);
+                done();
+            });
+        });
+        it('DELETE /entities/<entity-id>/attrs/<attr-name> should return a valid NSGI-LD error message', function (done) {
+            const options = {
+                url:
+                    'http://localhost:' +
+                    iotAgentConfig.server.port +
+                    '/ngsi-ld/v1/entities/urn:ngsi-ld:entity/attrs/att',
+                method: 'DELETE'
+            };
+            request(options, function (error, response, body) {
+                response.statusCode.should.equal(501);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
-  GET `/ngsi-ld/v1/entities`
-  POST `/ngsi-ld/v1/entities`
-  DELETE `/ngsi-ld/v1/entities/<entity-id>`
-  DELETE `ngsi-ld/v1/entities/<entity-id>/attrs/<attr-name>`

Are valid NGSI-LD endpoints, but IoT Agents will never support them. Ensure that they return valid NGSI-LD error responses instead. This protects the IoT Agent and also informs the Context Broker of the reason why. For example, at the moment Scorpio assumes full federated `/ngsi-ld/v1/entities` is supported when it isn't. see: telefonicaid/iotagent-ul/issues/573