### PR TITLE
[WIP] increase bodyparser limit from 100kbs to 1mb

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- FIX: set bodyparser limit from 100Kbs to 1Mb
 

--- a/lib/services/northBound/northboundServer.js
+++ b/lib/services/northBound/northboundServer.js
@@ -56,8 +56,8 @@ function start(config, callback) {
     northboundServer.app.set('port', config.server.port);
     northboundServer.app.set('host', config.server.host || '0.0.0.0');
     northboundServer.app.use(domainUtils.requestDomain);
-    northboundServer.app.use(bodyParser.json({ limit: '200mb' }));
-    northboundServer.app.use(bodyParser.json({ limit: '200mb', type: 'application/*+json' }));
+    northboundServer.app.use(bodyParser.json({ limit: '1mb' }));
+    northboundServer.app.use(bodyParser.json({ limit: '1mb', type: 'application/*+json' }));
 
     if (config.logLevel && config.logLevel === 'DEBUG') {
         northboundServer.app.use(middlewares.traceRequest);

--- a/lib/services/northBound/northboundServer.js
+++ b/lib/services/northBound/northboundServer.js
@@ -56,8 +56,8 @@ function start(config, callback) {
     northboundServer.app.set('port', config.server.port);
     northboundServer.app.set('host', config.server.host || '0.0.0.0');
     northboundServer.app.use(domainUtils.requestDomain);
-    northboundServer.app.use(bodyParser.json());
-    northboundServer.app.use(bodyParser.json({ type: 'application/*+json' }));
+    northboundServer.app.use(bodyParser.json({ limit: '200mb' }));
+    northboundServer.app.use(bodyParser.json({ limit: '200mb', type: 'application/*+json' }));
 
     if (config.logLevel && config.logLevel === 'DEBUG') {
         northboundServer.app.use(middlewares.traceRequest);


### PR DESCRIPTION
With a huge number of groups in iotagent-json, iotagent-manager is getting:

time=2022-08-10T08:00:42.937Z | lvl=DEBUG | corr=6a8d75e6-e10f-45ea-8ab0-730ca1334f69 | trans=6a8d75e6-e10f-45ea-8ab0-730ca1334f69 | op=IoTAManager.Redirector | from=n/a | srv=n/a | subsrv=n/a | msg=Error [PayloadTooLargeError] handling request: request entity too large | comp=IoTAgentManager

So we need try, as woraround, increase limits:

https://stackoverflow.com/questions/50988891/payloadtoolargeerror-with-limit-set


https://github.com/expressjs/body-parser


limit

Controls the maximum request body size. If this is a number, then the value specifies the number of [bytes](https://www.npmjs.com/package/bytes); if it is a string, the value is passed to the bytes library for parsing. Defaults to '100kb'.