### PR TITLE
Avoiding  Converting circular structure to JSON error in log

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -4,3 +4,4 @@
 - Add: datasetId and metadata support for NGSI-LD PATCH+PUT operations (commands)
 - Add: datasetId and metadata support for NGSI-LD Notifications (bidirectional attributes)
 - Add: metadata support to NGSI-v2 notifications (bidirectional attributes)
+- Fix: ensure circular error objects are logged correctly (#1280)

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -26,6 +26,7 @@ const logger = require('logops');
 const context = {
     op: 'IoTAgentNGSI.Request'
 };
+const util = require('util');
 
 /**
  *  Transform the "request" options into "got" options and add additional "got" defaults
@@ -101,9 +102,9 @@ function request(options, callback) {
         .then((response) => {
             logger.debug(context, 'Response %s', JSON.stringify(response.body, null, 4));
             return callback(null, response, response.body);
-        })
+        }) 
         .catch((error) => {
-            logger.debug(context, 'Error: %s', JSON.stringify(error, null, 4));
+            logger.debug(context, 'Error: %s', JSON.stringify(util.inspect(error), null, 4));
             return callback(error);
         });
 }

--- a/lib/request-shim.js
+++ b/lib/request-shim.js
@@ -102,7 +102,7 @@ function request(options, callback) {
         .then((response) => {
             logger.debug(context, 'Response %s', JSON.stringify(response.body, null, 4));
             return callback(null, response, response.body);
-        }) 
+        })
         .catch((error) => {
             logger.debug(context, 'Error: %s', JSON.stringify(util.inspect(error), null, 4));
             return callback(error);


### PR DESCRIPTION
Use [`util.inspect(error)` ](https://nodejs.org/api/util.html#utilinspectobject-options) on error messages so that even circular objects are logged correctly.

This is particularly an issue when running the unit tests as the debug message `Converting circular structure to JSON` is useless when reading the request. Adding this in means that you get meaningful errors back from should.js e.g:

```text
 msg=An unexpected exception has been raised. Ignoring: Error [AssertionError]: expected false to be true
    at Assertion.fail (node_modules/should/cjs/should.js:275:17)
    at Assertion.value (node_modules/should/cjs/should.js:356:19)
    at ../iotagent-node-lib/test/unit/ngsi-ld/plugins/bidirectional-plugin_test.js:318:44
    at ../iotagent-node-lib/lib/request-shim.js:64:716
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  operator: 'to be',
  expected: 'true',
  showDiff: true,
  actual: 'false',
  stackStartFunction: [Function: assert],
  negate: false,
  assertion: [Assertion],
  _message: 'expected false to be true',
  generatedMessage: true,
  uncaught: true
}
```

or

```text
 Ignoring: TypeError: Cannot read properties of undefined (reading 'statusCode')
    at ../iotagent-node-lib/test/unit/ngsi-ld/plugins/bidirectional-plugin_test.js:227:30
    at ../iotagent-node-lib/lib/request-shim.js:64:716
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  uncaught: true
}
```
