### PR TITLE
Update Bidirectional plugin to use expressionPlugin

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -5,3 +5,4 @@
 - Add: datasetId and metadata support for NGSI-LD Notifications (bidirectional attributes)
 - Add: metadata support to NGSI-v2 notifications (bidirectional attributes)
 - Fix: ensure circular error objects are logged correctly (#1280)
+- Add: Update Bidirectional plugin to reuse expressionPlugin (#1281)

--- a/lib/plugins/bidirectionalData.js
+++ b/lib/plugins/bidirectionalData.js
@@ -187,6 +187,7 @@ function getReverseTransformations(list, values, callback) {
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
+ * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
  */
 function processTransformationsNGSIv2(values, transformations, typeInformation, callback) {
     let cleanedExpression;
@@ -222,6 +223,7 @@ function processTransformationsNGSIv2(values, transformations, typeInformation, 
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
+ * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
  */
 function processTransformationsNGSILD(values, transformations, typeInformation, callback) {
     let cleanedExpression;
@@ -298,8 +300,9 @@ function processTransformationsNGSILD(values, transformations, typeInformation, 
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
+ * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
  */
-function processTransformations(values, typeInformation, transformations, callback) {
+function processTransformations(values, transformations, typeInformation, callback) {
     if (config.checkNgsiLD({})) {
         processTransformationsNGSILD(values, transformations, typeInformation, callback);
     } else {
@@ -354,7 +357,7 @@ function handleNotification(device, values, callback) {
                         apply(getReverseTransformations, deviceAttributes, values),
                         apply(getReverseTransformations, groupAttributes, values)
                     ]),
-                    apply(processTransformations, values, device)
+                    apply(processTransformations, device, values)
                 ],
                 function (error, results) {
                     callback(error, device, results);

--- a/lib/plugins/bidirectionalData.js
+++ b/lib/plugins/bidirectionalData.js
@@ -186,10 +186,10 @@ function getReverseTransformations(list, values, callback) {
  * For NGSI-v2 this consists of value transformations only
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
- * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
+ * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformationsNGSIv2(values, transformations, typeInformation, callback) {
+function processTransformationsNGSIv2(values, typeInformation, transformations, callback) {
     let cleanedExpression;
     const ctx = parser.extractContext(values, typeInformation);
     let resultTransformations = [];
@@ -222,10 +222,10 @@ function processTransformationsNGSIv2(values, transformations, typeInformation, 
  * For NGSI-LD the output includes value, metadata and datasetId
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
- * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
+ * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformationsNGSILD(values, transformations, typeInformation, callback) {
+function processTransformationsNGSILD(values, typeInformation, transformations, callback) {
     let cleanedExpression;
     const defaultValues = [];
     const datasetIds = {};
@@ -299,14 +299,14 @@ function processTransformationsNGSILD(values, transformations, typeInformation, 
  * Apply a list of transformations to the reported values, generating a new array of values with the additional data.
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
- * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  * @param {Object} typeInformation      Provisioning information about the device represented by the entity.
+ * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformations(values, transformations, typeInformation, callback) {
+function processTransformations(values, typeInformation, transformations, callback) {
     if (config.checkNgsiLD({})) {
-        processTransformationsNGSILD(values, transformations, typeInformation, callback);
+        processTransformationsNGSILD(values, typeInformation, transformations, callback);
     } else {
-        processTransformationsNGSIv2(values, transformations, typeInformation, callback);
+        processTransformationsNGSIv2(values, typeInformation, transformations, callback);
     }
 }
 
@@ -357,7 +357,7 @@ function handleNotification(device, values, callback) {
                         apply(getReverseTransformations, deviceAttributes, values),
                         apply(getReverseTransformations, groupAttributes, values)
                     ]),
-                    apply(processTransformations, device, values)
+                    apply(processTransformations, values, device)
                 ],
                 function (error, results) {
                     callback(error, device, results);

--- a/lib/plugins/bidirectionalData.js
+++ b/lib/plugins/bidirectionalData.js
@@ -26,7 +26,7 @@
 const async = require('async');
 const apply = async.apply;
 const _ = require('underscore');
-const parser = require('./expressionParser');
+const parser = require('./expressionPlugin');
 const logger = require('logops');
 const config = require('../commonConfig');
 const subscriptions = require('../services/ngsi/subscriptionService');
@@ -181,16 +181,16 @@ function getReverseTransformations(list, values, callback) {
 }
 
 /**
- * Apply a list of transformations to the reported values, 
+ * Apply a list of transformations to the reported values,
  * generating a new array of values with the additional data.
  * For NGSI-v2 this consists of value transformations only
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformationsNGSIv2(values, transformations, callback) {
+function processTransformationsNGSIv2(values, transformations, typeInformation, callback) {
     let cleanedExpression;
-    const ctx = parser.extractContext(values);
+    const ctx = parser.extractContext(values, typeInformation);
     let resultTransformations = [];
 
     for (let j = 0; j < 2; j++) {
@@ -208,7 +208,7 @@ function processTransformationsNGSIv2(values, transformations, callback) {
         values.push({
             name: resultTransformations[i].object_id,
             type: resultTransformations[i].type,
-            value: parser.parse(cleanedExpression, ctx, 'String')
+            value: parser.parse(cleanedExpression, ctx, 'String', typeInformation)
         });
     }
 
@@ -216,14 +216,14 @@ function processTransformationsNGSIv2(values, transformations, callback) {
 }
 
 /**
- * Apply a list of transformations to the reported values, 
+ * Apply a list of transformations to the reported values,
  * generating a new array of values with the additional data.
  * For NGSI-LD the output includes value, metadata and datasetId
  *
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformationsNGSILD(values, transformations, callback) {
+function processTransformationsNGSILD(values, transformations, typeInformation, callback) {
     let cleanedExpression;
     const defaultValues = [];
     const datasetIds = {};
@@ -258,7 +258,12 @@ function processTransformationsNGSILD(values, transformations, callback) {
                 name: resultTransformations[i].object_id,
                 type: resultTransformations[i].type,
                 metadata: {},
-                value: parser.parse(cleanedExpression, parser.extractContext(defaultValues), 'String')
+                value: parser.parse(
+                    cleanedExpression,
+                    parser.extractContext(defaultValues, typeInformation),
+                    'String',
+                    typeInformation
+                )
             });
         }
     }
@@ -276,7 +281,12 @@ function processTransformationsNGSILD(values, transformations, callback) {
                 type: resultTransformations[i].type,
                 datasetId,
                 metadata: {},
-                value: parser.parse(cleanedExpression, parser.extractContext(datasetIds[datasetId]), 'String')
+                value: parser.parse(
+                    cleanedExpression,
+                    parser.extractContext(datasetIds[datasetId], typeInformation),
+                    'String',
+                    typeInformation
+                )
             });
         }
     });
@@ -289,11 +299,11 @@ function processTransformationsNGSILD(values, transformations, callback) {
  * @param {Array} values                List of reported attributes (with their name, type and value).
  * @param {Array} transformations       List of transformations to apply (with their name, type and expression).
  */
-function processTransformations(values, transformations, callback) {
-    if (config.checkNgsiLD({})){
-        processTransformationsNGSILD(values, transformations, callback)
+function processTransformations(values, typeInformation, transformations, callback) {
+    if (config.checkNgsiLD({})) {
+        processTransformationsNGSILD(values, transformations, typeInformation, callback);
     } else {
-        processTransformationsNGSIv2(values, transformations, callback)
+        processTransformationsNGSIv2(values, transformations, typeInformation, callback);
     }
 }
 
@@ -344,7 +354,7 @@ function handleNotification(device, values, callback) {
                         apply(getReverseTransformations, deviceAttributes, values),
                         apply(getReverseTransformations, groupAttributes, values)
                     ]),
-                    apply(processTransformations, values)
+                    apply(processTransformations, values, device)
                 ],
                 function (error, results) {
                     callback(error, device, results);

--- a/lib/plugins/expressionPlugin.js
+++ b/lib/plugins/expressionPlugin.js
@@ -60,6 +60,13 @@ function extractContext(attributeList, typeInformation) {
     return parser.extractContext(attributeList);
 }
 
+function parse(expression, context, type, typeInformation) {
+    if (!checkJexl(typeInformation)) {
+        return legacyParser.parse(expression, context, type);
+    }
+    return jexlParser.parse(expression, context);
+}
+
 function mergeAttributes(attrList1, attrList2) {
     const finalCollection = _.clone(attrList1);
     const additionalItems = [];
@@ -156,6 +163,7 @@ function update(entity, typeInformation, callback) {
     }
 }
 
+exports.parse = parse;
 exports.update = update;
 exports.setJEXLTransforms = setJEXLTransforms;
 exports.applyExpression = applyExpression;


### PR DESCRIPTION
Related: https://github.com/telefonicaid/iotagent-node-lib/pull/1266#issuecomment-1217786005

This would remove the hardcoded `legacyParser` from the Bidirectionality plugin.