### PR TITLE
Replace all `cbroker` references in codebase

### DIFF
--- a/doc/apiary/iotagent.apib
+++ b/doc/apiary/iotagent.apib
@@ -80,7 +80,7 @@ Fields in JSON object representing a configuration group are:
 |:-----------------------|:------------------------------------------------------------|
 |`apikey`                |It is a key used for devices belonging to this service. If "", service does not use apikey, but it must be specified.|
 |`token`                 |If authentication/authorization system is configured, IoT Agent works as user when it publishes information. That token allows that other components to verify the identity of IoT Agent. Depends on authentication and authorization system.|
-|`cbroker`               |Context Broker endpoint assigned to this service, it must be a real uri.|
+|`cbHost`                |Context Broker endpoint assigned to this service, it must be a real uri.|
 |`outgoing_route`        |It is an identifier for VPN/GRE tunnel. It is used when device is into a VPN and a command is sent.|
 |`resource`              |Path in IoTAgent. When protocol is HTTP a device could send information to this uri. In general, it is a uri in a HTTP server needed to load and execute a module.|
 |`entity_type`           |Entity type used in entity publication (overload default).|
@@ -126,7 +126,7 @@ Retrieve a configuration group.
                     "service": "service2",
                     "service_path": "/srvpath2",
                     "token": "token2",
-                    "cbroker": "http://127.0.0.1:1026",
+                    "cbHost": "http://127.0.0.1:1026",
                     "entity_type": "thing",
                     "resource": "/iot/d"
                 }
@@ -152,7 +152,7 @@ Retrieve a configuration group.
                     "service": "service2",
                     "service_path": "/srvpath2",
                     "token": "token2",
-                    "cbroker": "http://127.0.0.1:1026",
+                    "cbHost": "http://127.0.0.1:1026",
                     "entity_type": "thing",
                     "resource": "/iot/d"
                 }
@@ -162,7 +162,7 @@ Retrieve a configuration group.
 
 ### Create a configuration group [POST]
 
-Create a new configuration group. From service model, mandatory fields are: apikey, resource (cbroker field is temporary mandatory).
+Create a new configuration group. From service model, mandatory fields are: apikey, resource (cbHost field is temporary mandatory).
 
 + Request (application/json)
 
@@ -178,7 +178,7 @@ Create a new configuration group. From service model, mandatory fields are: apik
                 {
                   "apikey": "apikey3",
                   "token": "token2",
-                  "cbroker": "http://127.0.0.1:1026",
+                  "cbHost": "http://127.0.0.1:1026",
                   "entity_type": "thing",
                   "resource": "/iot/d"
                 }

--- a/doc/expressionLanguage.md
+++ b/doc/expressionLanguage.md
@@ -75,7 +75,7 @@ can check the following example:
     "services": [
         {
             "apikey": "801230BJKL23Y9090DSFL123HJK09H324HV8732",
-            "cbroker": "http://orion:1026",
+            "cbHost": "http://orion:1026",
             "entity_type": "Thing",
             "resource":    "/iot/d"
             "expressionLanguage": "jexl",

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -56,7 +56,7 @@ curl -iX POST \
  "services": [
    {
      "apikey":      "4jggokgpepnvsb2uv4s40d59ov",
-     "cbroker":     "http://orion:1026",
+     "cbHost":     "http://orion:1026",
      "entity_type": "Device",
      "resource":    "/iot/d",
    }

--- a/examples/TTOpen-service.json
+++ b/examples/TTOpen-service.json
@@ -3,7 +3,7 @@
     {
       "resource": "/iot/d",
       "apikey": "pipopi",
-      "cbroker": "http://127.0.0.1:10026",
+      "cbHost": "http://127.0.0.1:10026",
       "entity_type": "ThinkingThing"
     }
   ]

--- a/lib/templates/deviceGroup.json
+++ b/lib/templates/deviceGroup.json
@@ -24,7 +24,7 @@
             "description": "token",
             "type": "string"
           },
-          "cbroker": {
+          "cbHost": {
             "description": "uri for the context broker",
             "type": "string"
           },

--- a/test/unit/examples/mongoCollections/configurations.json
+++ b/test/unit/examples/mongoCollections/configurations.json
@@ -2,7 +2,7 @@
   {
     "apikey" : "7e5721f478220be21f41f4700e50be2",
     "token" : "e50b7781d5e2d39d577e7c15e4a21f470ed39d5777e7c15e2e2d39d5777e7c1e2",
-    "cbroker" : "http://10.0.0.2:1026",
+    "cbHost" : "http://10.0.0.2:1026",
     "entity_type" : "device",
     "resource" : "/iot/d",
     "service" : "smart_gondor",
@@ -10,7 +10,7 @@
   },
   {
     "apikey" : "gdb13gq3f8q4beuk263besr8eh9ri",
-    "cbroker" : "http://10.0.0.2:1026",
+    "cbHost" : "http://10.0.0.2:1026",
     "entity_type" : "device",
     "resource" : "/iot/d",
     "service" : "dumb_mordor",
@@ -25,7 +25,7 @@
   },
   {
     "apikey" : "hs4h2ke7oerfdvrexbyh54w2",
-    "cbroker" : "http://10.0.0.2:1026",
+    "cbHost" : "http://10.0.0.2:1026",
     "entity_type" : "device",
     "resource" : "/iot/d",
     "service" : "demo",

--- a/test/unit/ngsi-mixed/provisioning/ngsi-versioning-test.js
+++ b/test/unit/ngsi-mixed/provisioning/ngsi-versioning-test.js
@@ -65,7 +65,6 @@ const optionsCreationDefault = {
         services: [
             {
                 apikey: 'default-test',
-                cbHost: 'http://orion:1026',
                 entity_type: 'Device',
                 resource: '/iot/default',
                 attributes: [
@@ -90,7 +89,6 @@ const optionsCreationV2 = {
         services: [
             {
                 apikey: 'v2-test',
-                cbHost: 'http://orion:1026',
                 ngsiVersion: 'v2',
                 entity_type: 'Device',
                 resource: '/iot/v2',
@@ -117,7 +115,6 @@ const optionsCreationLD = {
         services: [
             {
                 apikey: 'ld-test',
-                cbHost: 'http://orion:1026',
                 entity_type: 'Device',
                 ngsiVersion: 'ld',
                 resource: '/iot/ld',

--- a/test/unit/ngsi-mixed/provisioning/ngsi-versioning-test.js
+++ b/test/unit/ngsi-mixed/provisioning/ngsi-versioning-test.js
@@ -65,7 +65,7 @@ const optionsCreationDefault = {
         services: [
             {
                 apikey: 'default-test',
-                cbroker: 'http://orion:1026',
+                cbHost: 'http://orion:1026',
                 entity_type: 'Device',
                 resource: '/iot/default',
                 attributes: [
@@ -90,7 +90,7 @@ const optionsCreationV2 = {
         services: [
             {
                 apikey: 'v2-test',
-                cbroker: 'http://orion:1026',
+                cbHost: 'http://orion:1026',
                 ngsiVersion: 'v2',
                 entity_type: 'Device',
                 resource: '/iot/v2',
@@ -117,7 +117,7 @@ const optionsCreationLD = {
         services: [
             {
                 apikey: 'ld-test',
-                cbroker: 'http://orion:1026',
+                cbHost: 'http://orion:1026',
                 entity_type: 'Device',
                 ngsiVersion: 'ld',
                 resource: '/iot/ld',

--- a/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
@@ -450,7 +450,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                             apikey: '801230BJKL23Y9090DSFL123HJK09H324HV8732',
                             /*jshint camelcase: false */
                             entity_type: 'MicroLights',
-                            cbroker: 'http://192.168.1.1:1026',
+                            cbHost: 'http://192.168.1.1:1026',
                             explicitAttrs: true
                         }
                     ]
@@ -516,7 +516,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                             apikey: '801230BJKL23Y9090DSFL123HJK09H324HV8732',
                             /*jshint camelcase: false */
                             entity_type: 'MicroLights',
-                            cbroker: 'http://192.168.1.1:1026',
+                            cbHost: 'http://192.168.1.1:1026',
                             explicitAttrs: true,
                             static_attributes: [
                                 {
@@ -589,7 +589,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                             apikey: '801230BJKL23Y9090DSFL123HJK09H324HV8732',
                             /*jshint camelcase: false */
                             entity_type: 'MicroLights',
-                            cbroker: 'http://192.168.1.1:1026',
+                            cbHost: 'http://192.168.1.1:1026',
                             explicitAttrs: true
                         }
                     ]
@@ -656,7 +656,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                             apikey: '801230BJKL23Y9090DSFL123HJK09H324HV8732',
                             /*jshint camelcase: false */
                             entity_type: 'MicroLights',
-                            cbroker: 'http://192.168.1.1:1026',
+                            cbHost: 'http://192.168.1.1:1026',
                             explicitAttrs: true,
                             static_attributes: [
                                 {
@@ -726,7 +726,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                         /*jshint camelcase: false */
                         entity_type: 'MicroLights',
                         entityNameExp: 'EntityNameByExp',
-                        cbroker: 'http://192.168.1.1:1026'
+                        cbHost: 'http://192.168.1.1:1026'
                     }
                 ]
             },
@@ -790,7 +790,7 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                             apikey: '801230BJKL23Y9090DSFL123HJK09H324HV8732',
                             /*jshint camelcase: false */
                             entity_type: 'MicroLights',
-                            cbroker: 'http://192.168.1.1:1026',
+                            cbHost: 'http://192.168.1.1:1026',
                             explicitAttrs: true,
                             static_attributes: [
                                 {


### PR DESCRIPTION
This PR intends to replace all occurrences of `cbroker` on the examples, documentation and tests. This can lead to misunderstanding since this field actually does not have any functionality. The right parameter is [`cbHost`](https://github.com/telefonicaid/iotagent-node-lib/search?q=cbhost)