### PR TITLE
Update to offer NGSI-LD 1.6.1. Registration

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
-
+- Update to offer NGSI-LD 1.6.1. Registrations #1302
+- Document removal of support for NGSI-LD 1.3.1 Interface

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -18,7 +18,7 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v8 in iotagent-node-lib 2.12.0 (finally removed in 2.13.0)
 -   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 -   Support to Node.js v12 in iotagent-node-lib 2.24.0 (finally removed in 2.25.0)
--   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0
+-   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0 (finally removed in 2.26.0)
 
 The use of Node.js v14 is highly recommended.
 
@@ -46,3 +46,4 @@ The following table provides information about the last iotagent-node-lib versio
 | Support to Node.js v8  | 2.12.0                                                | April 7th, 2020               |
 | Support to Node.js v10 | 2.15.0                                                | February 18th, 2021           |
 | Support to Node.js v12 | 2.24.0                                                | September 2nd, 2022           |
+| Support to NGSI-LD 1.3 | 2.25.0                                                | January 24th, 2023          |

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -362,6 +362,12 @@ function sendRegistrationsNgsiLD(unregister, deviceData, callback) {
             mode: 'exclusive',
             operations,
             endpoint: config.getConfig().providerUrl,
+            contextSourceInfo: [
+                {
+                    'key': 'jsonldContext',
+                    'value': config.getConfig().contextBroker.jsonLdContext
+                }
+            ],
             '@context': config.getConfig().contextBroker.jsonLdContext
         },
         headers: {

--- a/lib/services/devices/registrationUtils.js
+++ b/lib/services/devices/registrationUtils.js
@@ -310,6 +310,7 @@ function sendRegistrationsNgsiLD(unregister, deviceData, callback) {
         return sendUnregistrationsNgsiLD(deviceData, callback);
     }
 
+    const operations = [];
     const properties = [];
     const lazy = deviceData.lazy || [];
     const commands = deviceData.commands || [];
@@ -320,6 +321,13 @@ function sendRegistrationsNgsiLD(unregister, deviceData, callback) {
     commands.forEach((element) => {
         properties.push(element.name);
     });
+
+    if (lazy.length > 0){
+        operations.push('retrieveOps');  
+    }
+    if (commands.length > 0){
+         operations.push('updateOps'); 
+    }
 
     if (properties.length === 0) {
         logger.debug(context, 'Registration with Context Provider is not needed. Device without lazy atts or commands');
@@ -348,9 +356,11 @@ function sendRegistrationsNgsiLD(unregister, deviceData, callback) {
             information: [
                 {
                     entities: [{ type: deviceData.type, id }],
-                    properties
+                    propertyNames: properties
                 }
             ],
+            mode: 'exclusive',
+            operations,
             endpoint: config.getConfig().providerUrl,
             '@context': config.getConfig().contextBroker.jsonLdContext
         },

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent1.json
@@ -1,20 +1,28 @@
 {
-    "@context": "http://context.json-ld",
-    "endpoint": "http://smartgondor.com",
-    "information": [
+  "type": "ContextSourceRegistration",
+  "information": [
+    {
+      "entities": [
         {
-            "entities": [
-                {
-                    "id": "urn:ngsi-ld:Light:light1",
-                    "type": "Light"
-                }
-            ],
-            "propertyNames": [
-                "temperature"
-            ]
+          "type": "Light",
+          "id": "urn:ngsi-ld:Light:light1"
         }
-    ],
-    "mode": "exclusive",
-    "operations" :["retrieveOps"],
-    "type": "ContextSourceRegistration"
+      ],
+      "propertyNames": [
+        "temperature"
+      ]
+    }
+  ],
+  "mode": "exclusive",
+  "operations": [
+    "retrieveOps"
+  ],
+  "endpoint": "http://smartgondor.com",
+  "contextSourceInfo": [
+    {
+      "key": "jsonldContext",
+      "value": "http://context.json-ld"
+    }
+  ],
+  "@context": "http://context.json-ld"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent1.json
@@ -9,10 +9,12 @@
                     "type": "Light"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "temperature"
             ]
         }
     ],
+    "mode": "exclusive",
+    "operations" :["retrieveOps"],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent2.json
@@ -1,18 +1,22 @@
 {
-  "type": "ContextSourceRegistration",
-  "information": [
-    {
-      "entities": [
+    "type": "ContextSourceRegistration",
+    "information": [
         {
-          "type": "Motion",
-          "id": "urn:ngsi-ld:Motion:motion1"
+            "entities": [
+                {
+                    "type": "Motion",
+                    "id": "urn:ngsi-ld:Motion:motion1"
+                }
+            ],
+            "propertyNames": [
+                "moving"
+            ]
         }
-      ],
-      "properties": [
-        "moving"
-      ]
-    }
-  ],
-  "endpoint": "http://smartgondor.com",
-  "@context": "http://context.json-ld"
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "retrieveOps"
+    ],
+    "endpoint": "http://smartgondor.com",
+    "@context": "http://context.json-ld"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent2.json
@@ -18,5 +18,11 @@
         "retrieveOps"
     ],
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "@context": "http://context.json-ld"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent4.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgent4.json
@@ -4,15 +4,25 @@
     {
       "entities": [
         {
-          "type": "RobotPre",
-          "id": "urn:ngsi-ld:RobotPre:TestRobotPre"
+          "type": "Light",
+          "id": "urn:ngsi-ld:Light:light1"
         }
       ],
-      "properties": [
-        "moving"
+      "propertyNames": [
+        "temperature"
       ]
     }
   ],
+  "mode": "exclusive",
+  "operations": [
+    "retrieveOps"
+  ],
   "endpoint": "http://smartgondor.com",
+  "contextSourceInfo": [
+    {
+      "key": "jsonldContext",
+      "value": "http://context.json-ld"
+    }
+  ],
   "@context": "http://context.json-ld"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerIoTAgentCommands.json
@@ -9,11 +9,13 @@
                     "type": "Robot"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "position",
                 "orientation"
             ]
         }
     ],
+    "mode": "exclusive",
+    "operations" :["updateOps"],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice.json
@@ -9,11 +9,16 @@
                     "type": "TheLightType"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "luminance",
                 "commandAttr"
             ]
         }
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "retrieveOps",
+        "updateOps"
     ],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice2.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDevice2.json
@@ -9,10 +9,12 @@
                     "type": "TheLightType"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "luminance"
             ]
         }
     ],
+    "mode": "exclusive",
+    "operations" :["retrieveOps"],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup.json
@@ -9,13 +9,18 @@
                     "type": "TheLightType"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "luminance",
                 "luminescence",
                 "commandAttr",
                 "wheel1"
             ]
         }
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "retrieveOps",
+        "updateOps"
     ],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup2.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup2.json
@@ -9,13 +9,18 @@
                     "type": "SensorMachine"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "luminance",
                 "luminescence",
                 "commandAttr",
                 "wheel1"
             ]
         }
+    ],
+    "mode": "exclusive",
+    "operations" : [
+        "retrieveOps",
+        "updateOps"
     ],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup3.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup3.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup3.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/registerProvisionedDeviceWithGroup3.json
@@ -9,10 +9,12 @@
                     "type": "Light"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "temperature"
             ]
         }
     ],
+    "mode": "exclusive",
+    "operations" :["retrieveOps"],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateCommands1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateCommands1.json
@@ -8,11 +8,13 @@
                     "id":"urn:ngsi-ld:Light:light1"
                 }
             ],
-            "properties":[
+            "propertyNames":[
                 "move"
             ]
         }
     ],
+    "mode": "exclusive",
+    "operations":["updateOps"],
     "endpoint":"http://smartgondor.com",
     "@context": "http://context.json-ld"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateCommands1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateCommands1.json
@@ -1,5 +1,11 @@
 {
     "type":"ContextSourceRegistration",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information":[
         {
             "entities":[

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent1.json
@@ -9,10 +9,14 @@
                     "type": "Light"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "pressure"
             ]
         }
+    ],
+    "mode": "exclusive",
+    "operations": [
+        "retrieveOps"
     ],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent1.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent1.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent2.json
@@ -9,11 +9,16 @@
                     "type": "TheLightType"
                 }
             ],
-            "properties": [
+            "propertyNames": [
                 "luminance",
                 "commandAttr"
             ]
         }
+    ],
+    "mode": "exclusive",
+    "operations" : [
+        "retrieveOps",
+        "updateOps"
     ],
     "type": "ContextSourceRegistration"
 }

--- a/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent2.json
+++ b/test/unit/ngsi-ld/examples/contextAvailabilityRequests/updateIoTAgent2.json
@@ -1,6 +1,12 @@
 {
     "@context": "http://context.json-ld",
     "endpoint": "http://smartgondor.com",
+    "contextSourceInfo":[
+      {
+        "key": "jsonldContext",
+        "value": "http://context.json-ld"
+      }
+    ],
     "information": [
         {
             "entities": [


### PR DESCRIPTION
Related to https://github.com/telefonicaid/iotagent-ul/issues/573#issuecomment-1203172196

The [NGSI-LD 1.6.1 Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf), clarifies the definition of registrations and defines `operations` and `mode` attributes to be supplied within NGSI-LD **CSourceRegistrations**.  A default Registration is considered to be `federationOps/inclusive` (which is what [Scorpio 3](https://github.com/ScorpioBroker/ScorpioBroker/releases) already offers and [Orion-LD 1.2](https://github.com/FIWARE/context.Orion-LD/releases) is aiming for.

This is a potentially **breaking change** for provisioning NGSI-LD devices - the existing functionality  aligns with the Orion-LD 1.1 prototype only - there is little point in continuing to offer the provisional NGSI-LD 1.3.1. interface.  Additionally `properties` was updated to `propertyNames` in NGSI-LD 1.4.1, Orion-LD offers a backwards compatible option, other context brokers may not.

#### How are devices affected?

1) Basic Sensors are not affected by this change
2) Sensors with lazy attributes should  register as `retrieveOps/exclusive`
3) Actuation command attributes should  register as `updateOps/exclusive`

The default `federationOps/inclusive`  offers a superset of these commands so previously provisioned devices will cause unnecessary polling traffic to the IoT Agent (which the IoT Agent already rejects as unsupported see #1277). 

This really isn't a big issue for this library (and the fix is really small) but for semantic versioning it would make sense to update the semantic versioning from 2.x.x to 3.x.x when it lands to indicate the move from the "experimental" operations defined in #849  et seq. which work with Orion-LD only, up to the well defined common interface supported by all NGSI-LD brokers.