### PR TITLE
Add deprecation notice

### DIFF
--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -18,8 +18,9 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v8 in iotagent-node-lib 2.12.0 (finally removed in 2.13.0)
 -   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 -   Support to Node.js v12 in iotagent-node-lib 2.24.0 (finally removed in 2.25.0)
+-   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0
 
-The use of Node.js v12 is highly recommended.
+The use of Node.js v14 is highly recommended.
 
 ## Using old iotagent-node-lib versions
 

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -12,7 +12,7 @@ longer. In particular:
 
 A list of deprecated features and the version in which they were deprecated follows:
 
--   Support to NGSI v1.
+-   Support to NGSI v1 (finally removed in 2.18.0)
 -   Support to Node.js v4 in iotagent-node-lib 2.8.1 (finally removed in 2.9.0)
 -   Support to Node.js v6 in iotagent-node-lib 2.9.0 (finally removed in 2.10.0)
 -   Support to Node.js v8 in iotagent-node-lib 2.12.0 (finally removed in 2.13.0)
@@ -40,9 +40,9 @@ The following table provides information about the last iotagent-node-lib versio
 
 | **Removed feature**    | **Last iotagent-node-lib version supporting feature** | **That version release date** |
 | ---------------------- | ----------------------------------------------------- | ----------------------------- |
-| NGSI v1 API            | Not yet defined                                       | Not yet defined               |
-| Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018                 |
-| Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                      |
-| Support to Node.js v8  | 2.12.0                                                | April 7th, 2020                    |
-| Support to Node.js v10 | 2.15.0   | February 18th, 2021                |
-| Support to Node.js v12 | 2.24.0   | September 2nd, 2022                |
+| NGSI v1 API            | 2.18.0                                                | November 12th, 2021           |
+| Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018           |
+| Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                |
+| Support to Node.js v8  | 2.12.0                                                | April 7th, 2020               |
+| Support to Node.js v10 | 2.15.0                                                | February 18th, 2021           |
+| Support to Node.js v12 | 2.24.0                                                | September 2nd, 2022           |

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -40,7 +40,7 @@ The following table provides information about the last iotagent-node-lib versio
 
 | **Removed feature**    | **Last iotagent-node-lib version supporting feature** | **That version release date** |
 | ---------------------- | ----------------------------------------------------- | ----------------------------- |
-| NGSI v1 API            | 2.18.0                                                | November 12th, 2021           |
+| NGSI v1 API            | 2.17.0                                                | August 30th, 2021             |
 | Support to Node.js v4  | 2.8.1                                                 | December 19th, 2018           |
 | Support to Node.js v6  | 2.9.0                                                 | May 22nd, 2019                |
 | Support to Node.js v8  | 2.12.0                                                | April 7th, 2020               |


### PR DESCRIPTION
Related #1302 - You should provide a heads up that the supported NGSI-LD interface will no longer accept the 1.3.1 `property` attribute in the `CSourceRegistration` at some point. This is just preparatory work before that PR can land at some time in the future.