### PR TITLE
Add `deviceRegistry.type=memory` deprecation message

### DIFF
--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -19,7 +19,9 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 -   Support to Node.js v12 in iotagent-node-lib 2.24.0 (finally removed in 2.25.0)
 -   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0
--   Support to `deviceRegistry.type=memory` value. 
+-   Support groups (provision) statically defined by configuration.
+-   Support to `deviceRegistry.type=memory` value.
+ 
 
 The use of Node.js v14 is highly recommended.
 

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -19,8 +19,8 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 -   Support to Node.js v12 in iotagent-node-lib 2.24.0 (finally removed in 2.25.0)
 -   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0 (finally removed in 2.26.0)
--   Support groups (provision) statically defined by configuration.
--   Support to `deviceRegistry.type=memory` value.
+-   Support groups (provision) statically defined by configuration
+-   Support to in-memory registry (i.e.`deviceRegistry.type=memory`)
 
 The use of Node.js v14 is highly recommended.
 

--- a/doc/deprecated.md
+++ b/doc/deprecated.md
@@ -19,6 +19,7 @@ A list of deprecated features and the version in which they were deprecated foll
 -   Support to Node.js v10 in iotagent-node-lib 2.15.0 (finally removed in 2.16.0)
 -   Support to Node.js v12 in iotagent-node-lib 2.24.0 (finally removed in 2.25.0)
 -   Support to NGSI-LD v1.3 in iotagent-node-lib 2.25.0
+-   Support to `deviceRegistry.type=memory` value. 
 
 The use of Node.js v14 is highly recommended.
 


### PR DESCRIPTION
Should other parts of the doc edited? 

I.E:

https://github.com/telefonicaid/iotagent-ul/blob/b7e3099e3eb08dc03f45f1f2d5595f6381326971/docker/README.md?plain=1#L19-L27