### PR TITLE
add to ctxt all active attrs for explicitAttrs when is a jexl

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- Fix: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expression
+- Fix: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expression (#1351)
 - Fix: disable device attribute entity_name validation using pattern
 - Fix: change level of log about not context available for apply expression from warn to info

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- Fix: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expresison (#1349)
+- Fix: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expression
 - Fix: disable device attribute entity_name validation using pattern
 - Fix: change level of log about not context available for apply expression from warn to info

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- FIX: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expresison
 

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- FIX: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expresison
+- FIX: add missed active attributes (with expressions) for ctxt for evaluate explicitAttrs expresison (#1349)
 

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -457,24 +457,18 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
             // typeInformation.active attrs with expressions expanded by current ctxt
             if (typeInformation.active) {
                 typeInformation.active.forEach(function (att) {
-                    if (att.expression) {
-                        if (expressionPlugin.contextAvailable(att.expression, ctxt, typeInformation)) {
-                            let expandedAttr = {
-                                name: att.name,
-                                value: att.expression, // it doesn't matter final value here
-                                type: att.type
-                            };
-                            attributesCtxt.push(expandedAttr);
-                            ctxt = expressionPlugin.extractContext(
-                                attributesCtxt.concat(idTypeSSSList),
-                                typeInformation
-                            );
-                        }
-                    }
+                    let expandedAttr = {
+                        name: att.name,
+                        value: att.expression !== undefined ? att.expression : att.name, // it doesn't matter final value here
+                        type: att.type
+                    };
+                    attributesCtxt.push(expandedAttr);
+                    ctxt = expressionPlugin.extractContext(attributesCtxt.concat(idTypeSSSList), typeInformation);
                 });
             }
             // calculate expression for explicitAttrs
             try {
+                logger.debug(context, 'sendUpdateValueNgsi2 selectedAttrs ctxt %j', ctxt);
                 let res = jexlParser.applyExpression(typeInformation.explicitAttrs, ctxt, typeInformation);
                 if (res === true) {
                     // like explicitAttrs == true

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -455,12 +455,12 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     let found = false;
                     while (j < typeInformation.active.length && !found) {
                         if (attributes[i].name === typeInformation.active[j].name) {
-                            let measureAttr_by_object_id = {
+                            let measureAttrByObjectId = {
                                 name: typeInformation.active[j].object_id,
                                 value: attributes[i].value,
                                 type: attributes[i].type
                             };
-                            attributesCtxt.push(measureAttr_by_object_id);
+                            attributesCtxt.push(measureAttrByObjectId);
                             found = true;
                         }
                         j++;
@@ -480,12 +480,12 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                         };
                         attributesCtxt.push(expandedAttr);
                         if (att.object_id !== undefined) {
-                            let expandedAttr_by_object_id = {
+                            let expandedAttrByObjectId = {
                                 name: att.object_id,
                                 value: att.expression,
                                 type: att.type
                             };
-                            attributesCtxt.push(expandedAttr_by_object_id);
+                            attributesCtxt.push(expandedAttrByObjectId);
                         }
                         ctxt = expressionPlugin.extractContext(attributesCtxt.concat(idTypeSSSList), typeInformation);
                     }

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -580,10 +580,11 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
             selectedAttrs
         );
         let selectedAttrsByObjectId = selectedAttrs
-            .filter((o) => o.object_id)
+            .filter((o) => o !== undefined && o.object_id)
             .map(function (el) {
                 return el.object_id;
             });
+
         // Loop for add seleted attrs from type.information.active into pyaload entities (entity[0])
         if (typeInformation.active) {
             typeInformation.active.forEach((attr) => {
@@ -604,7 +605,7 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                             type: attr.type
                         };
                     }
-                } else if (attr.object_id && selectedAttrsByObjectId.includes(attr.object_id)) {
+                } else if (attr.object_id !== undefined && selectedAttrsByObjectId.includes(attr.object_id)) {
                     payload.entities[0][attr.object_id] = {
                         value: payload.entities[0][attr.object_id]
                             ? payload.entities[0][attr.object_id].value

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -450,20 +450,45 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                         type: attributes[i].type
                     };
                     attributesCtxt.push(measureAttr);
+                    // check measureAttr by object_id -> if in active
+                    let j = 0;
+                    let found = false;
+                    while (j < typeInformation.active.length && !found) {
+                        if (attributes[i].name === typeInformation.active[j].name) {
+                            let measureAttr_by_object_id = {
+                                name: typeInformation.active[j].object_id,
+                                value: attributes[i].value,
+                                type: attributes[i].type
+                            };
+                            attributesCtxt.push(measureAttr_by_object_id);
+                            found = true;
+                        }
+                        j++;
+                    }
                 }
             }
             // This context is just to calculate explicitAttrs when is an expression
             let ctxt = expressionPlugin.extractContext(attributesCtxt.concat(idTypeSSSList), typeInformation);
-            // typeInformation.active attrs with expressions expanded by current ctxt
+            // typeInformation.active all attrs with expressions
             if (typeInformation.active) {
                 typeInformation.active.forEach(function (att) {
-                    let expandedAttr = {
-                        name: att.name,
-                        value: att.expression !== undefined ? att.expression : att.name, // it doesn't matter final value here
-                        type: att.type
-                    };
-                    attributesCtxt.push(expandedAttr);
-                    ctxt = expressionPlugin.extractContext(attributesCtxt.concat(idTypeSSSList), typeInformation);
+                    if (att.expression !== undefined) {
+                        let expandedAttr = {
+                            name: att.name,
+                            value: att.expression,
+                            type: att.type
+                        };
+                        attributesCtxt.push(expandedAttr);
+                        if (att.object_id !== undefined) {
+                            let expandedAttr_by_object_id = {
+                                name: att.object_id,
+                                value: att.expression,
+                                type: att.type
+                            };
+                            attributesCtxt.push(expandedAttr_by_object_id);
+                        }
+                        ctxt = expressionPlugin.extractContext(attributesCtxt.concat(idTypeSSSList), typeInformation);
+                    }
                 });
             }
             // calculate expression for explicitAttrs

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -454,9 +454,9 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     let j = 0;
                     let found = false;
                     while (j < typeInformation.active.length && !found) {
-                        if (attributes[i].name === typeInformation.active[j].name) {
+                        if (attributes[i].name === typeInformation.active[j].object_id) {
                             let measureAttrByObjectId = {
-                                name: typeInformation.active[j].object_id,
+                                name: typeInformation.active[j].name,
                                 value: attributes[i].value,
                                 type: attributes[i].type
                             };
@@ -579,7 +579,11 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
             payload,
             selectedAttrs
         );
-
+        let selectedAttrsByObjectId = selectedAttrs
+            .filter((o) => o.object_id)
+            .map(function (el) {
+                return el.object_id;
+            });
         // Loop for add seleted attrs from type.information.active into pyaload entities (entity[0])
         if (typeInformation.active) {
             typeInformation.active.forEach((attr) => {
@@ -600,6 +604,16 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                             type: attr.type
                         };
                     }
+                } else if (attr.object_id && selectedAttrsByObjectId.includes(attr.object_id)) {
+                    payload.entities[0][attr.object_id] = {
+                        value: payload.entities[0][attr.object_id]
+                            ? payload.entities[0][attr.object_id].value
+                            : payload.entities[0][attr.name]
+                            ? payload.entities[0][attr.name].value
+                            : undefined,
+                        type: attr.type,
+                        object_id: attr.object_id
+                    };
                 }
             });
         }

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -533,6 +533,10 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                 if (selectedAttrs.includes(attr.name)) {
                     selectedAttrs.push(attr.object_id);
                 }
+                // Check if selectedAttrs includes an attribute with format {object_id: xxxx}
+                if (selectedAttrs.includes({ object_id: attr.object_id })) {
+                    selectedAttrs.push(attr.object_id);
+                }
             });
         } else if (typeInformation.explicitAttrs && typeof typeInformation.explicitAttrs === 'boolean') {
             // TBD: selectedAttrs could be a boolean as a result of applyExpression

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin40.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin40.json
@@ -1,0 +1,46 @@
+{
+        "entities": [
+            {
+                "id": "water1",
+                "type": "WaterTank",
+                "contB": {
+                    "value": "31450.000",
+                    "type": "Number",
+                    "metadata": {
+                        "TimeInstant": {
+                            "type": "DateTime",
+                            "value": "2015-08-05T07:35:01.468Z"
+                        }
+                    }
+                },
+                "TimeInstant": {
+                    "type": "DateTime",
+                    "value": "2015-08-05T07:35:01.468Z"
+                }
+            },
+            {
+                "id": "PA_B_0001",
+                "type": "WaterTank",
+                "waterLeavingTanks": {
+                    "value": 3145,
+                    "type": "Number",
+                    "metadata": {
+                        "TimeInstant": {
+                            "type": "DateTime",
+                            "value": "2015-08-05T07:35:01.468Z"
+                        }
+                    }
+                },
+                "TimeInstant": {
+                    "type": "DateTime",
+                    "value": "2015-08-05T07:35:01.468Z"
+                },
+                "status": {
+                    "value": null,
+                    "type": "Text"
+                }
+            }
+        ],
+        "actionType": "update"
+}
+

--- a/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
@@ -1425,7 +1425,7 @@ describe('Java expression language (JEXL) based transformations plugin', functio
 
 describe('Java expression language (JEXL) based transformations plugin - Timestamps', function () {
     beforeEach(function (done) {
-        logger.setLevel('DEBUG');
+        logger.setLevel('FATAL');
 
         iotAgentLib.activate(iotAgentConfigTS, function () {
             iotAgentLib.clearAll(function () {

--- a/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
@@ -321,8 +321,31 @@ const iotAgentConfig = {
                 }
             ],
             explicitAttrs: "theLocation ? ['mylocation'] :  []"
-            // #1267 this is not working:
-            //explicitAttrs: "theLocation ? [{object_id: 'theLocation'}] :  []"
+        },
+        GPS5b: {
+            commands: [],
+            type: 'GPS',
+            lazy: [],
+            static: [
+                {
+                    name: 'lat',
+                    type: 'string',
+                    value: '52'
+                }
+            ],
+            active: [
+                {
+                    name: 'price',
+                    type: 'number'
+                },
+                {
+                    object_id: 'theLocation',
+                    name: 'mylocation',
+                    type: 'geo:json',
+                    expression: "{coordinates: [lon,lat], type: 'Point'}"
+                }
+            ],
+            explicitAttrs: "theLocation ? [{object_id: 'theLocation'}] : []"
         },
         GPS6: {
             commands: [],
@@ -1280,6 +1303,46 @@ describe('Java expression language (JEXL) based transformations plugin', functio
 
         it('should calculate them and remove non-explicitAttrs by jexl expression with context from the payload ', function (done) {
             iotAgentLib.update('gps1', 'GPS5', '', values, function (error) {
+                should.not.exist(error);
+                contextBrokerMock.done();
+                done();
+            });
+        });
+    });
+
+    describe('When there is an extra TimeInstant sent by the device to be removed by jexl expression with context defined with object_id', function () {
+        // Case: Expression which results is sent as a new attribute
+        const values = [
+            {
+                name: 'lon',
+                type: 'Number',
+                value: 13
+            },
+            {
+                name: 'TimeInstant',
+                type: 'DateTime',
+                value: '2015-08-05T07:35:01.468+00:00'
+            }
+        ];
+
+        beforeEach(function () {
+            nock.cleanAll();
+
+            contextBrokerMock = nock('http://192.168.1.1:1026')
+                .matchHeader('fiware-service', 'smartgondor')
+                .matchHeader('fiware-servicepath', 'gardens')
+                .patch(
+                    '/v2/entities/gps1/attrs',
+                    utils.readExampleFile(
+                        './test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin36.json'
+                    )
+                )
+                .query({ type: 'GPS' })
+                .reply(204);
+        });
+
+        it('should calculate them and remove non-explicitAttrs by jexl expression with context from the payload ', function (done) {
+            iotAgentLib.update('gps1', 'GPS5b', '', values, function (error) {
                 should.not.exist(error);
                 contextBrokerMock.done();
                 done();


### PR DESCRIPTION
Add to context for explictAttrs jexl evaluation the following missed concepts:
- active attributes with expressions (and also indentified by its object_id)
- Measures identified by its object_id)

Check if explicitAttr list contains attributes identified by its object_id

- [x] Add test about explicitAttrs with jexl and multientity: https://github.com/telefonicaid/iotagent-node-lib/issues/1351