### PR TITLE
[WIP] explicitAttributes true case is just measures in active attrs and attrs with expressions

### DIFF
--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -516,11 +516,17 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                 }
             });
         } else if (typeInformation.explicitAttrs && typeof typeInformation.explicitAttrs === 'boolean') {
-            // TBD: selectedAttrs could be a boolean as a result of applyExpression
-            // explicitAtts is true => Add measures which are defined attributes
+            // explicitAtts is true => Add just measures which are defined in active attributes
             typeInformation.active.forEach((attr) => {
-                selectedAttrs.push(attr.name);
-                selectedAttrs.push(attr.object_id);
+                // Measures
+                for (let i = 0; i < attributes.length; i++) {
+                    if (attributes[i].name && attributes[i].type) {
+                        if (attributes[i].name === attr.object_id) {
+                            selectedAttrs.push(attr.name);
+                            selectedAttrs.push(attr.object_id);
+                        }
+                    }
+                }
             });
         }
         // This loop adds selected measured values (attributes) into payload entities (entity[0])

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin32.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin32.json
@@ -1,22 +1,10 @@
 {
-  "location": {
-    "type": "geo:json",
-    "value": {
-      "coordinates": [
-        13,
-        52
-      ],
-      "type": "Point"
+    "lat": {
+        "type": "Number",
+        "value": 52
     },
-    "metadata": {
-        "TimeInstant": {
-            "type": "DateTime",
-            "value": "1970-01-01T00:00:00.001Z"
-        }
+    "lon": {
+        "type": "Number",
+        "value": 13
     }
-  },
-  "TimeInstant": {
-    "type": "DateTime",
-    "value": "1970-01-01T00:00:00.001Z"
-  }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin33.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin33.json
@@ -1,22 +1,27 @@
 {
-  "location": {
-    "type": "geo:json",
-    "value": {
-      "coordinates": [
-        13,
-        52
-      ],
-      "type": "Point"
-    },
-    "metadata": {
-      "TimeInstant": {
-        "type": "DateTime",
-        "value": "2015-08-05T07:35:01.468Z"
-      }
-    }
-  },
-  "TimeInstant": {
-    "type": "DateTime",
-    "value": "2015-08-05T07:35:01.468Z"
-  }
+    "lat": {
+            "value": 52,
+            "type": "Number",
+            "metadata": {
+                "TimeInstant": {
+                    "type": "DateTime",
+                    "value": "2015-08-05T07:35:01.468Z"
+                }
+            }
+        },
+        "lon": {
+            "value": 13,
+            "type": "Number",
+            "metadata": {
+                "TimeInstant": {
+                    "type": "DateTime",
+                    "value": "2015-08-05T07:35:01.468Z"
+                }
+            }
+        },
+        "TimeInstant": {
+            "type": "DateTime",
+            "value": "2015-08-05T07:35:01.468Z"
+        }
+
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin34b.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin34b.json
@@ -1,0 +1,10 @@
+{
+    "lat": {
+        "value": 52,        
+        "type": "Number"
+    },
+    "lon": {
+        "value": 13,        
+        "type": "Number"
+    }
+}

--- a/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
@@ -230,6 +230,16 @@ const iotAgentConfig = {
                     expression: "{coordinates: [lon,lat], type: 'Point'}"
                 },
                 {
+                    object_id: 'lat',
+                    name: 'lat',
+                    type: 'Number'
+                },
+                {
+                    object_id: 'lon',
+                    name: 'lon',
+                    type: 'Number'
+                },
+                {
                     name: 'TimeInstant',
                     type: 'DateTime',
                     expression: 'ts|toisodate'
@@ -246,6 +256,16 @@ const iotAgentConfig = {
                     name: 'location',
                     type: 'geo:json',
                     expression: "{coordinates: [lon,lat], type: 'Point'}"
+                },
+                {
+                    object_id: 'lat',
+                    name: 'lat',
+                    type: 'Number'
+                },
+                {
+                    object_id: 'lon',
+                    name: 'lon',
+                    type: 'Number'
                 }
             ],
             explicitAttrs: true
@@ -403,6 +423,16 @@ const iotAgentConfigTS = {
                     name: 'location',
                     type: 'geo:json',
                     expression: "{coordinates: [lon,lat], type: 'Point'}"
+                },
+                {
+                    object_id: 'lat',
+                    name: 'lat',
+                    type: 'Number'
+                },
+                {
+                    object_id: 'lon',
+                    name: 'lon',
+                    type: 'Number'
                 }
             ],
             explicitAttrs: true
@@ -1080,7 +1110,7 @@ describe('Java expression language (JEXL) based transformations plugin', functio
                 .patch(
                     '/v2/entities/gps1/attrs',
                     utils.readExampleFile(
-                        './test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin34.json'
+                        './test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin34b.json'
                     )
                 )
                 .query({ type: 'GPS' })


### PR DESCRIPTION
There were some tests expecting this active attribute in payload
        active: [
                {
                    name: 'location',
                    type: 'geo:json',
                    expression: "{coordinates: [lon,lat], type: 'Point'}"
                },

when just lat and lon are provided ad measures

In