### PR TITLE
Fix/log level tp info no context available for expr warn

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-
+- Fix: change level of log about not context available for apply expression from warn to info
 

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -697,7 +697,7 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     if (expressionPlugin.contextAvailable(attr.expression, ctxt, typeInformation)) {
                         res = expressionPlugin.applyExpression(attr.expression, ctxt, typeInformation);
                     } else {
-                        logger.warn(
+                        logger.info(
                             context,
                             'sendUpdateValueNgsi2 \n no context available for apply expression %j \n',
                             attr.expression
@@ -759,7 +759,7 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                         if (expressionPlugin.contextAvailable(attr.entity_name, ctxt, typeInformation)) {
                             newEntityName = expressionPlugin.applyExpression(attr.entity_name, ctxt, typeInformation);
                         } else {
-                            logger.warn(
+                            logger.info(
                                 context,
                                 'sendUpdateValueNgsi2 \n MULTI no context available for apply expression %j \n',
                                 attr.entity_name


### PR DESCRIPTION
Warn level was introducing panic an so many messages in that production run level.
Three is nothing bad in "no context available for apply expression" since just expression is not evaluated