### PR TITLE
add timeinstant to explicitAttrs true case

### DIFF
--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -541,6 +541,8 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
         } else if (typeInformation.explicitAttrs && typeof typeInformation.explicitAttrs === 'boolean') {
             // explicitAtts is true => Add just measures which are defined in active attributes
             // and active attributes with expressions
+            // and TimeInstant
+            selectedAttrs = ['TimeInstant'];
             typeInformation.active.forEach((attr) => {
                 // Measures
                 if (attr.expression !== undefined) {
@@ -552,7 +554,7 @@ function sendUpdateValueNgsi2(entityName, attributes, typeInformation, token, ca
                     let found = false;
                     while (i < attributes.length && !found) {
                         if (attributes[i].name && attributes[i].type) {
-                            if (attributes[i].name === attr.object_id) {
+                            if (attributes[i].name === attr.object_id || attributes[i].name === attr.name) {
                                 selectedAttrs.push(attr.name);
                                 selectedAttrs.push(attr.object_id);
                                 found = true;

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin35.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin35.json
@@ -1,2 +1,22 @@
 {
+    "TimeInstant": {
+        "type": "DateTime",
+        "value": "2015-08-05T07:35:01.468+00:00"
+    },
+    "location": {
+        "value": {
+            "coordinates": [
+                13,
+                52
+            ],
+            "type": "Point"
+        },
+        "type": "geo:json",
+        "metadata": {
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "2015-08-05T07:35:01.468+00:00"
+            }
+        }
+    }
 }

--- a/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin41.json
+++ b/test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin41.json
@@ -1,16 +1,32 @@
 {
-  "location": {
-    "type": "geo:json",
-    "value": {
-      "coordinates": [
-        13,
-        52
-      ],
-      "type": "Point"
+    "TimeInstant": {
+        "type": "DateTime",
+        "value": "2015-08-05T07:35:01.468+00:00"
+    },
+    "location": {
+        "value": {
+            "coordinates": [
+                13,
+                52
+            ],
+            "type": "Point"
+        },
+        "type": "geo:json",
+        "metadata": {
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "2015-08-05T07:35:01.468+00:00"
+            }
+        }
+    },
+    "temperature": {
+        "value": null,
+        "type": "Number",
+        "metadata": {
+            "TimeInstant": {
+                "type": "DateTime",
+                "value": "2015-08-05T07:35:01.468+00:00"
+            }
+        }
     }
-  },
-  "temperature":{
-      "value": null,
-      "type": "Number"
-  }
 }

--- a/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
@@ -1172,7 +1172,7 @@ describe('Java expression language (JEXL) based transformations plugin', functio
                 .patch(
                     '/v2/entities/gps1/attrs',
                     utils.readExampleFile(
-                        './test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin34.json'
+                        './test/unit/ngsiv2/examples/contextRequests/updateContextExpressionPlugin35.json'
                     )
                 )
                 .query({ type: 'GPS' })


### PR DESCRIPTION
Continuation of PR https://github.com/telefonicaid/iotagent-node-lib/pull/1355
Adds TimeInstant as is expected by https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/advanced-topics.md#explicitly-defined-attributes-explicitattrs
Case 2:

"explicitAttrs": true

just measures defined in active, static (plus conditionally TimeInstant) will be propagated to NGSI interface.

Allow refer to measure by attr name or attr object_id