### PR TITLE
Add Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,134 @@
+name: 'Bug report'
+description: Create a report to help us improve
+labels: ['bug']
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: version
+    attributes:
+      label: IoT Agent Node Libe version the issue has been seen with
+      description: |
+        Do not submit bug reports about anything but the two most recently released *major* systemd versions upstream!
+        If there have been multiple stable releases for that major version, please consider updating to a recent one before reporting an issue.
+        See https://github.com/telefonicaid/iotagent-node-lib/releases/ for the list of most recent releases.
+      placeholder: '3.2.0'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: port
+    attributes:
+      label: Bound or port used (API interaction)
+      description: Select with part of the API is motivating this issue creation.
+      multiple: true
+      options:
+        - 'Southbound (Devices data API)'
+        - 'Northbound (Provision API and NGSI Interactions)'
+        - 'Other'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ngsi-version
+    attributes:
+      label: NGSI version
+      description: Please chose the NGSI version configured
+      multiple: true
+      options:
+        - 'NGSIv2'
+        - 'NGSI-LD'
+        - 'Mixed Mode'
+        - 'Other'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: containerized
+    attributes:
+      label: Are you running a container?
+      description: In case you are using a container, please select the image type the issue was seen on
+      options:
+        - 'Yes, I am using a contaner (Docker, Kubernetes...)'
+        - 'No, I am running it natively'
+    validations:
+      required: false
+
+  - type: dropdown
+    id: image-type
+    attributes:
+      label: Image type
+      description: In case you are using a container, please select the image type the issue was seen on
+      options:
+        - normal
+        - pm2
+        - distroless
+    validations:
+      required: false
+      
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour you didn't see
+    validations:
+      required: false
+
+  - type: textarea
+    id: unexpected-behaviour
+    attributes:
+      label: Unexpected behaviour you saw
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce the problem
+      description: Please fill this field with all the required information and steps to reproduce the issue described above. 
+        Consider including curl requests if required
+      placeholder: |
+        ```sh
+        # Get IoTA version
+        `curl -iX GET 'http://localhost:4041/iot/about'`
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configs
+      description: |
+        Please provide details about your environment vars or config file by copying and pasting the enviroments variables 
+        or the config.js file.
+      value: |
+        ```yaml
+        environment:
+            - "IOTA_CB_HOST=orion"
+            - "IOTA_CB_PORT=1026"
+            - "IOTA_NORTH_PORT=4041"
+            - "IOTA_REGISTRY_TYPE=mongodb"
+            - "IOTA_MONGO_HOST=mongodb"
+            - "IOTA_MONGO_PORT=27017"
+            - "IOTA_MONGO_DB=iotagent-json"
+            - "IOTA_HTTP_PORT=7896"
+            - "IOTA_PROVIDER_URL=http://iot-agent:4041"
+        ```
+
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Log output
+      description: |
+        Please paste the output log here, ideally when generated in debug mode (try setting the `IOTA_LOG_LEVEL=debug` environment variable).
+        For very long copy/pasted data consider using a service like https://gist.github.com/. Where copy/paste is not possible, a photo of the screen might do too, but text is always much preferred.
+      placeholder: Paste your log here
+      render: sh
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+blank_issues_enabled: true
+contact_links:
+  - name: IoT Agent documentation
+    url: https://iotagent-node-lib.readthedocs.io/en/latest/
+    about: check the documentation before asking help or reporting a bug.
+  - name: Community Support
+    url: https://stackoverflow.com/questions/ask?tags=iot-agent+fiware
+    about: |
+      Volunteers from the Open Source FIWARE community monitor the 𝚏𝚒𝚠𝚊𝚛𝚎 tag
+      and related tags over on Stack Overflow. For 𝗱𝗲𝘃𝗲𝗹𝗼𝗽𝗺𝗲𝗻𝘁 𝗾𝘂𝗲𝘀𝘁𝗶𝗼𝗻𝘀 𝗼𝗻𝗹𝘆 you can ask questions
+      over on Stack Overflow provided you follow their rules and guidance on posting and respond to any feedback given.
+      
+      Stack Overflow is a crowd-sourced question and answer website for professional and enthusiast programmers. It is not affliated with this
+      software and 𝗱𝗼𝗲𝘀 𝗻𝗼𝘁 𝗮𝗻𝘀𝘄𝗲𝗿 𝗰𝘂𝘀𝘁𝗼𝗺𝗲𝗿 𝘀𝗲𝗿𝘃𝗶𝗰𝗲 𝗿𝗲𝗹𝗮𝘁𝗲𝗱 𝗾𝘂𝗲𝘀𝘁𝗶𝗼𝗻𝘀.
+      
+      Do not raise a Stack Overflow question for bug reports or feature requests, stick with opening an issue directly within this repository.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest an improvement
+labels: ["Feature Request"]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this feature request!
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Component
+      description: Please chose components related to this feature request.
+      multiple: true
+      options:
+        - 'New feature'
+        - 'Feature enhancement'
+        - 'Techdeb'
+        - 'Other'
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Is your feature request related to a problem? Please describe
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: The systemd version you checked that didn't have the feature you are asking for
+      description: If this is not the most recently released upstream version, then please check first if it has that feature already.
+      placeholder: '3.2.0'
+    validations:
+      required: false

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,22 @@
+policy:
+  - template: [bug_report.yml]
+    section:
+      - id: [ngsi-version]
+        block-list: ['None', 'Other', 'Mixed Mode']
+        label:
+          - name: 'NGSIv2'
+            keys: ['NGSIv2']
+          - name: 'NGSI-LD'
+            keys: ['NGSI-LD']
+
+  - template: [feature_request.yml]
+    section:
+      - id: [type]
+        block-list: ['None', 'Other']
+        label:
+          - name: 'Feature request'
+            keys: ['New feature']
+          - name: 'Enhancement'
+            keys: ['Feature enhancement']
+          - name: 'Techdeb'
+            keys: ['Techdeb']

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,3 +1,11 @@
+#
+# This file is used by .github/workflows/issue-labeler.yml
+# Here, you can configure which dropdown fields are used
+# to assing a label (keys) to the issue and the name of the label (name)
+#
+# More info: https://github.com/marketplace/actions/advanced-issue-labeler
+#
+
 policy:
   - template: [bug_report.yml]
     section:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,3 +1,11 @@
+#
+# This workflow is used to asign labels to issues created through the templates. 
+# There is another file associated that maps a issue label name to each field on the 
+# issue template. You can find that file in /.github/advanced-issue-labeler.yml 
+#
+# More info: https://github.com/marketplace/actions/advanced-issue-labeler
+#
+
 name: Issue labeler
 on:
   issues:
@@ -14,9 +22,6 @@ jobs:
       # required for all workflows
       issues: write
 
-      # only required for workflows in private repositories
-      # actions: read
-      # contents: read
     strategy:
       matrix:
         template: [ bug_report.yml, feature_request.yml ]

--- a/.github/workflows/issue-labelert.yml
+++ b/.github/workflows/issue-labelert.yml
@@ -1,0 +1,38 @@
+name: Issue labeler
+on:
+  issues:
+    types: [ opened ]
+
+permissions:
+  contents: read
+
+jobs:
+  label-component:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      issues: write
+
+      # only required for workflows in private repositories
+      # actions: read
+      # contents: read
+    strategy:
+      matrix:
+        template: [ bug_report.yml, feature_request.yml ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Set labels based on policy
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v2
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR add issue template to the repo. 

2 templates added:
- Bug report
- Feature request

Additionally, a GH action - [Advanced Issue Labeler](https://github.com/marketplace/actions/advanced-issue-labeler) -  is included, in order to label issues according to the options choose under dropdown selectors in templates.

This issue labeler assigns, for each type of issues:

**Bug report**
NGSI Version. Possible values:
- NGSIv2
- NGSI-LD

**Feature request**
Type. Possible values:
- New feature
- Enhancement
- Techdeb