### PR TITLE
Remove MongoDB connection options from log, to avoid credentials display

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: appendMode at general level (config.js / env var) changes its default from false to true
+- Fix: remove sensitive MongoDB connection parameters from log traces (remove 'option' object from logs)

--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -106,13 +106,7 @@ function init(host, db, port, options, callback) {
     }
 
     function connectionAttempt(url, options, callback) {
-        logger.info(
-            context,
-            'Attempting to connect to MongoDB instance with url %j and options %j. Attempt %d',
-            url,
-            options,
-            retries
-        );
+        logger.info(context, 'Attempting to connect to MongoDB instance with url %j. Attempt %d', url, retries);
         // FIXME: useNewUrlParser is no longer used in underlying mongodb driver 4.x
         // (see https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_4.0.0.md)
         // but not sure if current mongoose version is still using mongodb 3.x internally


### PR DESCRIPTION
Currently, the full MongoDB connection **options** object is displayed at INFO level in logs. This **options** object contains the db credentials, so the log exposes those credentials. I think it's better to remove the **options** object from logs (the host and port are kept).