### PR TITLE
Do not propage group config to autoprovision device

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Do not propage group config (timestamp, expresisonLanguage) to autoprovision device (#1391)
 - Fix: appendMode at general level (config.js / env var) changes its default from false to true

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Fix: do not propagate group config (timestamp and explicitAttrs) to autoprovisioned devices (at database level) (#1391)
+- Fix: do not propagate group config (timestamp and explicitAttrs) to autoprovisioned devices (at database level) (#1377)
 - Fix: appendMode at general level (config.js / env var) changes its default from false to true

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- Do not propage group config (timestamp, expresisonLanguage) to autoprovision device (#1391)
+- Fix: do not propagate group config (timestamp and explicitAttrs) to autoprovisioned devices (at database level) (#1391)
 - Fix: appendMode at general level (config.js / env var) changes its default from false to true

--- a/doc/api.md
+++ b/doc/api.md
@@ -141,6 +141,15 @@ subservice mapping, security information and attribute configuration can be spec
 relaying on the config group configuration. The specific parameters that can be configured for a given device are
 described in the [Device datamodel](#device-datamodel) section.
 
+If devices are not pre-registered, they will be automatically created when a measure arrives to the IoT Agent - this
+process is known as autoprovisioning. The IoT Agent will create an empty device with the group `apiKey` and `type` - the
+associated document created in database doesn't include config group parameters (`timestamp` and `explicitAttrs` in
+particular). The IoT Agent will also create the entity in the Context Broker if it does not exist yet.
+
+This behavior allows that autoprovisioned parameters can freely established modifying the device information after
+creation using the provisioning API. However, note that if a device (autoprovisioned or not) doesn't have these
+parameters defined at device level in database, the parameters are inherit from config group parameters.
+
 ## Entity attributes
 
 In the config group/device model there are four list of attributes with different purpose to configure how the
@@ -376,7 +385,8 @@ By default, when a measure arrives to the IoTAgent, if the `device_id` does not 
 IoTA creates a new device and a new entity according to the config group. Defining the field `autoprovision` to `false`
 when provisioning the config group, the IoTA to reject the measure at the southbound, allowing only to persist the data
 to devices that are already provisioned. It makes no sense to use this field in device provisioning since it is intended
-to avoid provisioning devices (and for it to be effective, it would have to be provisional).
+to avoid provisioning devices (and for it to be effective, it would have to be provisional). Further information can be
+found in section [Devices](#devices)
 
 ### Explicitly defined attributes (explicitAttrs)
 

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -618,19 +618,9 @@ function findOrCreate(deviceId, group, callback) {
             if (config.getConfig().iotManager && config.getConfig().iotManager.protocol) {
                 newDevice.protocol = config.getConfig().iotManager.protocol;
             }
-            // Do not propage unprovisioned device config fro group to device (#1377)
-            // if ('timestamp' in group && group.timestamp !== undefined) {
-            //     newDevice.timestamp = group.timestamp;
-            // }
             if ('ngsiVersion' in group && group.ngsiVersion !== undefined) {
                 newDevice.ngsiVersion = group.ngsiVersion;
             }
-            // if ('explicitAttrs' in group && group.explicitAttrs !== undefined) {
-            //     newDevice.explicitAttrs = group.explicitAttrs;
-            // }
-            // if ('expressionLanguage' in group && group.expressionLanguage !== undefined) {
-            //     newDevice.expressionLanguage = group.expressionLanguage;
-            // }
             if (
                 (!('apikey' in newDevice) || newDevice.apikey === undefined) &&
                 'apikey' in group &&

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -365,13 +365,12 @@ function registerDevice(deviceObj, callback) {
                     deviceObj.staticAttributes = deviceData.staticAttributes;
                     deviceObj.commands = deviceData.commands;
                     deviceObj.lazy = deviceData.lazy;
-                    // Do not propage unprovisioned device config fro group to device (#1377)
-                    // if ('timestamp' in deviceData && deviceData.timestamp !== undefined) {
-                    //     deviceObj.timestamp = deviceData.timestamp;
-                    // }
-                    // if ('explicitAttrs' in deviceData && deviceData.explicitAttrs !== undefined) {
-                    //     deviceObj.explicitAttrs = deviceData.explicitAttrs;
-                    // }
+                    if ('timestamp' in deviceData && deviceData.timestamp !== undefined) {
+                        deviceObj.timestamp = deviceData.timestamp;
+                    }
+                    if ('explicitAttrs' in deviceData && deviceData.explicitAttrs !== undefined) {
+                        deviceObj.explicitAttrs = deviceData.explicitAttrs;
+                    }
                     if ('apikey' in deviceData && deviceData.apikey !== undefined) {
                         deviceObj.apikey = deviceData.apikey;
                     }
@@ -619,19 +618,19 @@ function findOrCreate(deviceId, group, callback) {
             if (config.getConfig().iotManager && config.getConfig().iotManager.protocol) {
                 newDevice.protocol = config.getConfig().iotManager.protocol;
             }
-
-            if ('timestamp' in group && group.timestamp !== undefined) {
-                newDevice.timestamp = group.timestamp;
-            }
+            // Do not propage unprovisioned device config fro group to device (#1377)
+            // if ('timestamp' in group && group.timestamp !== undefined) {
+            //     newDevice.timestamp = group.timestamp;
+            // }
             if ('ngsiVersion' in group && group.ngsiVersion !== undefined) {
                 newDevice.ngsiVersion = group.ngsiVersion;
             }
-            if ('explicitAttrs' in group && group.explicitAttrs !== undefined) {
-                newDevice.explicitAttrs = group.explicitAttrs;
-            }
-            if ('expressionLanguage' in group && group.expressionLanguage !== undefined) {
-                newDevice.expressionLanguage = group.expressionLanguage;
-            }
+            // if ('explicitAttrs' in group && group.explicitAttrs !== undefined) {
+            //     newDevice.explicitAttrs = group.explicitAttrs;
+            // }
+            // if ('expressionLanguage' in group && group.expressionLanguage !== undefined) {
+            //     newDevice.expressionLanguage = group.expressionLanguage;
+            // }
             if (
                 (!('apikey' in newDevice) || newDevice.apikey === undefined) &&
                 'apikey' in group &&

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -365,12 +365,13 @@ function registerDevice(deviceObj, callback) {
                     deviceObj.staticAttributes = deviceData.staticAttributes;
                     deviceObj.commands = deviceData.commands;
                     deviceObj.lazy = deviceData.lazy;
-                    if ('timestamp' in deviceData && deviceData.timestamp !== undefined) {
-                        deviceObj.timestamp = deviceData.timestamp;
-                    }
-                    if ('explicitAttrs' in deviceData && deviceData.explicitAttrs !== undefined) {
-                        deviceObj.explicitAttrs = deviceData.explicitAttrs;
-                    }
+                    // Do not propage unprovisioned device config fro group to device (#1377)
+                    // if ('timestamp' in deviceData && deviceData.timestamp !== undefined) {
+                    //     deviceObj.timestamp = deviceData.timestamp;
+                    // }
+                    // if ('explicitAttrs' in deviceData && deviceData.explicitAttrs !== undefined) {
+                    //     deviceObj.explicitAttrs = deviceData.explicitAttrs;
+                    // }
                     if ('apikey' in deviceData && deviceData.apikey !== undefined) {
                         deviceObj.apikey = deviceData.apikey;
                     }


### PR DESCRIPTION
issue https://github.com/telefonicaid/iotagent-node-lib/issues/1377

This way autorpovisioned devices with remain without some flags defined like timestamp, expressionLanguage (which will take in runtime from group configuration)

- [x] Similar PRs in iotagent-json and iotagent-ul to align with local  findOrCreate