### PR TITLE
 allow update timestamp and other config fields of device

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- Add: allow update timestamp and other config fields of device
 - Fix: appendMode at general level (config.js / env var) changes its default from false to true

--- a/lib/templates/updateDevice.json
+++ b/lib/templates/updateDevice.json
@@ -204,10 +204,6 @@
       "description": "Timestamp",
       "type": "boolean"
     },
-    "expressionLanguage": {
-      "description": "Expression language used to apply expressions for this device",
-      "type": "string"
-    },
     "explicitAttrs": {
       "description": "Flag to decide update of active attributes only"
     },

--- a/lib/templates/updateDevice.json
+++ b/lib/templates/updateDevice.json
@@ -200,6 +200,14 @@
       "description": "Free form array of data to be appended to the target entity",
       "type": "array"
     },
+    "timestamp": {
+      "description": "Timestamp",
+      "type": "boolean"
+    },
+    "expressionLanguage": {
+      "description": "Expression language used to apply expressions for this device",
+      "type": "string"
+    },
     "explicitAttrs": {
       "description": "Flag to decide update of active attributes only"
     },

--- a/lib/templates/updateDeviceLax.json
+++ b/lib/templates/updateDeviceLax.json
@@ -159,10 +159,6 @@
       "description": "Timestamp",
       "type": "boolean"
     },
-    "expressionLanguage": {
-      "description": "Expression language used to apply expressions for this device",
-      "type": "string"
-    },
     "explicitAttrs": {
       "description": "Flag to decide update of active attributes only"
     },

--- a/lib/templates/updateDeviceLax.json
+++ b/lib/templates/updateDeviceLax.json
@@ -154,6 +154,21 @@
     "static_attributes": {
       "description": "Free form array of data to be appended to the target entity",
       "type": "array"
+    },
+    "timestamp": {
+      "description": "Timestamp",
+      "type": "boolean"
+    },
+    "expressionLanguage": {
+      "description": "Expression language used to apply expressions for this device",
+      "type": "string"
+    },
+    "explicitAttrs": {
+      "description": "Flag to decide update of active attributes only"
+    },
+    "ngsiVersion": {
+        "description": "NGSI Interface for this device",
+        "type": "string"
     }
   }
 }


### PR DESCRIPTION
Templating stuff are preventing of update (via device API)  some fields of devices as timestamp




time=2023-06-27T08:51:51.354Z | lvl=DEBUG | corr=a40fa76d-fdfd-486c-b08d-67587e2f8ef0 | trans=4f8350e7-3d70-400a-9d4c-94ecabfb9443 | op=IoTAgentNGSI.GenericMiddlewares | from=172.17.0.21 | srv=smartcity | subsrv=/ | msg=Body:

{
    "entity_type": "thing",
    "static_attributes": [],
    "commands": [],
    "apikey": "7xbfgqg25bz0ersloin9gqd7h",
    "explicitAttrs": false,
    "timestamp": true,
    "expressionLanguage": "jexl"
}

 | comp=IoTAgent
time=2023-06-27T08:51:51.354Z | lvl=DEBUG | corr=a40fa76d-fdfd-486c-b08d-67587e2f8ef0 | trans=4f8350e7-3d70-400a-9d4c-94ecabfb9443 | op=IoTAgentNGSI.RestUtils | from=172.17.0.21 | srv=smartcity | subsrv=/ | msg=Errors found validating request: {"valid":false,"errors":[{"attribute":"additionalProperties","property":"timestamp","actual":true,"message":"must not exist"},{"attribute":"additionalProperties","property":"expressionLanguage","actual":"jexl","message":"must not exist"}]} | comp=IoTAgent
