### PR TITLE
Task/not propage unprovisioned config from group to device

### DIFF
--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -181,9 +181,6 @@ function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuratio
     if (configuration && configuration.expressionLanguage && deviceData.expressionLanguage === undefined) {
         deviceData.expressionLanguage = configuration.expressionLanguage;
     }
-    if (configuration && configuration.explicitAttrs !== undefined && deviceData.explicitAttrs === undefined) {
-        deviceData.explicitAttrs = configuration.explicitAttrs;
-    }
 
     logger.debug(context, 'deviceData after merge with conf: %j', deviceData);
     callback(null, deviceData);

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -178,9 +178,6 @@ function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuratio
     if (configuration && configuration.ngsiVersion) {
         deviceData.ngsiVersion = configuration.ngsiVersion;
     }
-    if (configuration && configuration.expressionLanguage && deviceData.expressionLanguage === undefined) {
-        deviceData.expressionLanguage = configuration.expressionLanguage;
-    }
 
     logger.debug(context, 'deviceData after merge with conf: %j', deviceData);
     callback(null, deviceData);


### PR DESCRIPTION
reopens https://github.com/telefonicaid/iotagent-node-lib/pull/1391 to include explicitAttrs
No CNR Update is needed