### PR TITLE
Revert "Update deviceService.js"

### DIFF
--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -178,6 +178,9 @@ function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuratio
     if (configuration && configuration.ngsiVersion) {
         deviceData.ngsiVersion = configuration.ngsiVersion;
     }
+    if (configuration && configuration.explicitAttrs !== undefined && deviceData.explicitAttrs === undefined) {
+        deviceData.explicitAttrs = configuration.explicitAttrs;
+    }
     if (configuration && configuration.entityNameExp !== undefined) {
         deviceData.entityNameExp = configuration.entityNameExp;
     }


### PR DESCRIPTION
Reverts telefonicaid/iotagent-node-lib#1400


explicitAttrs from config only needs be deleted from findorCreate as was done in https://github.com/telefonicaid/iotagent-node-lib/pull/1391
But mergeWithConfig needs that all non defined flags in device were filled with group values