### PR TITLE
check array access in jexlPlugin when bidirectionalPlugin (extractVariables)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: check array access in extractVariables of jexlPlugin when bidirectionalPlugin is enabled
 - Fix: explicitAttrs of device was tainted even if not defined
 - Fix: do not include static, lazy and commands from group to device to avoid duplicate them in device (#1377) 
 - Add: Evaluate group entityNameExp with a context including measures (#1334)

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -77,7 +77,7 @@ function extractVariables(expression) {
         variables = tokens.filter(function (token, index, array) {
             return (
                 (token.type === ' ' && array[index - 1].type !== 'dot') ||
-                (token.type === 'identifier' && array[index + 1].type !== 'openParen')
+                (token.type === 'identifier' && array[index + 1] && array[index + 1].type !== 'openParen')
             );
         });
 


### PR DESCRIPTION
Check access extracting variables in jexlPlugin when bidirectional plugin

Related with https://github.com/telefonicaid/iotagent-node-lib/pull/1361/


time=2023-07-06T10:14:45.871Z | lvl=DEBUG | corr=1a11c061-2335-4a66-9e3f-682f83307bfe | trans=205a2746-78a2-481f-8dce-bd9881e52010 | op=IoTAgentNGSI.GenericMiddlewares | from=172.17.0.1 | srv=fi014 | subsrv=/ssfi014sc01 | msg=Body:

{
    "devices": [
        {
            "attributes": [
                {
                    "expression": "\" + latitude + \",\" + longitude + \"",
                    "type": "percent",
                    "name": "location",
                    "object_id": "location",
                    "reverse": [
                        {
                            "expression": "location | substr(location | indexOf(',') + 1, location | length) | trim",
                            "type": "string",
                            "object_id": "longitude"
                        },
                        {
                            "expression": " location | substr(0, location | indexOf(',')) | trim",
                            "type": "string",
                            "object_id": "latitude"
                        }
                    ]
                }
            ],
            "entity_type": "sensor",
            "protocol": "IoTA-UL",
            "entity_name": "e0140102",
            "device_id": "dev0140102"
        }
    ]
}

 | comp=IoTAgent
time=2023-07-06T10:14:45.871Z | lvl=DEBUG | corr=1a11c061-2335-4a66-9e3f-682f83307bfe | trans=205a2746-78a2-481f-8dce-bd9881e52010 | op=IoTAgentNGSI.DeviceProvisioning | from=172.17.0.1 | srv=fi014 | subsrv=/ssfi014sc01 | msg=Handling device provisioning request. | comp=IoTAgent
time=2023-07-06T10:14:45.871Z | lvl=DEBUG | corr=1a11c061-2335-4a66-9e3f-682f83307bfe | trans=205a2746-78a2-481f-8dce-bd9881e52010 | op=IoTAgentNGSI.MongoDBGroupRegister | from=172.17.0.1 | srv=n/a | subsrv=n/a | msg=Looking for group params ["service","subservice","type","apikey"] with queryObj {"service":"fi014","subservice":"/ssfi014sc01","type":"sensor"} | comp=IoTAgent
time=2023-07-06T10:14:45.873Z | lvl=DEBUG | corr=n/a | trans=n/a | op=IoTAgentNGSI.MongoDBGroupRegister | from=n/a | srv=fi014 | subsrv=/ssfi014sc01 | msg=Device group data found: {"_id":"64a685153914e4b1cc849ee7","resource":"/iot/d","apikey":"apk01401","type":"sensor","service":"fi014","subservice":"/ssfi014sc01"} | comp=IoTAgent
time=2023-07-06T10:14:45.873Z | lvl=DEBUG | corr=n/a | trans=n/a | op=IoTAgentNGSI.BidirectionalPlugin | from=n/a | srv=n/a | subsrv=n/a | msg=Extracting attribute list | comp=IoTAgent
time=2023-07-06T10:14:45.873Z | lvl=DEBUG | corr=n/a | trans=n/a | op=IoTAgentNGSI.BidirectionalPlugin | from=n/a | srv=n/a | subsrv=n/a | msg=Sending bidirectionality subscriptions for device [dev0140102] | comp=IoTAgent
time=2023-07-06T10:14:45.874Z | lvl=WARN | corr=n/a | trans=n/a | op=IoTAgentNGSI.JEXL | from=n/a | srv=n/a | subsrv=n/a | msg=Wrong expression found "["location | substr(location | indexOf(',') + 1, location | length) | trim"]" error: "[TypeError: Cannot read properties of undefined (reading 'type')
    at /opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/jexlParser.js:80:66
    at Array.filter (<anonymous>)
    at Object.extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/jexlParser.js:77:28)
    at Object.extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/expressionPlugin.js:61:23)
    at extractFromExpression (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:78:27)
    at Array.map (<anonymous>)
    at extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:84:51)
    at sendSingleSubscriptionNgsi2 (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:100:27)
    at /opt/iotaul/node_modules/async/dist/async.js:1138:9
    at eachOfArrayLike (/opt/iotaul/node_modules/async/dist/async.js:1072:9)
    at eachOf (/opt/iotaul/node_modules/async/dist/async.js:1120:5)
    at _asyncMap (/opt/iotaul/node_modules/async/dist/async.js:1136:5)
    at Object.map (/opt/iotaul/node_modules/async/dist/async.js:1125:16)
    at sendSubscriptions (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:116:11)
    at /opt/iotaul/node_modules/async/dist/async.js:66:19
    at nextTask (/opt/iotaul/node_modules/async/dist/async.js:5327:14)
    at next (/opt/iotaul/node_modules/async/dist/async.js:5334:9)
    at /opt/iotaul/node_modules/async/dist/async.js:972:16
    at extractBidirectionalAttributes (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:64:5)
    at /opt/iotaul/node_modules/async/dist/async.js:66:19
    at nextTask (/opt/iotaul/node_modules/async/dist/async.js:5327:14)
    at Object.waterfall (/opt/iotaul/node_modules/async/dist/async.js:5337:5)]", it will be ignored | comp=IoTAgent
time=2023-07-06T10:14:45.875Z | lvl=WARN | corr=n/a | trans=n/a | op=IoTAgentNGSI.JEXL | from=n/a | srv=n/a | subsrv=n/a | msg=Wrong expression found "[" location | substr(0, location | indexOf(',')) | trim"]" error: "[TypeError: Cannot read properties of undefined (reading 'type')
    at /opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/jexlParser.js:80:66
    at Array.filter (<anonymous>)
    at Object.extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/jexlParser.js:77:28)
    at Object.extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/expressionPlugin.js:61:23)
    at extractFromExpression (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:78:27)
    at Array.map (<anonymous>)
    at extractVariables (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:84:51)
    at sendSingleSubscriptionNgsi2 (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:100:27)
    at /opt/iotaul/node_modules/async/dist/async.js:1138:9
    at eachOfArrayLike (/opt/iotaul/node_modules/async/dist/async.js:1072:9)
    at eachOf (/opt/iotaul/node_modules/async/dist/async.js:1120:5)
    at _asyncMap (/opt/iotaul/node_modules/async/dist/async.js:1136:5)
    at Object.map (/opt/iotaul/node_modules/async/dist/async.js:1125:16)
    at sendSubscriptions (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:116:11)
    at /opt/iotaul/node_modules/async/dist/async.js:66:19
    at nextTask (/opt/iotaul/node_modules/async/dist/async.js:5327:14)
    at next (/opt/iotaul/node_modules/async/dist/async.js:5334:9)
    at /opt/iotaul/node_modules/async/dist/async.js:972:16
    at extractBidirectionalAttributes (/opt/iotaul/node_modules/iotagent-node-lib/lib/plugins/bidirectionalData.js:64:5)
    at /opt/iotaul/node_modules/async/dist/async.js:66:19
    at nextTask (/opt/iotaul/node_modules/async/dist/async.js:5327:14)
    at Object.waterfall (/opt/iotaul/node_modules/async/dist/async.js:5337:5)]", it will be ignored | comp=IoTAgent
time=2023-07-06T10:14:45.875Z | lvl=DEBUG | corr=n/a | trans=n/a | op=IoTAgentNGSI.BidirectionalPlugin | from=n/a | srv=n/a | subsrv=n/a | msg=Extracted variables: [false] | comp=IoTAgent
