### PR TITLE
[WIP] FIX change to mongo 5.0 in regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     needs: unit-test
     services:
       mongodb:
-        image: mongo:4.2
+        image: mongo:5.0
         ports:
         - 27017:27017
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:4.2
+        image: mongo:5.0
         ports:
         - 27017:27017
     strategy:


### PR DESCRIPTION
https://www.mongodb.com/docs/drivers/node/current/compatibility/

4.17.0 nodejs driver for mongo is just fully compatible with mongo 5.0 and 6.0 but not for all new features 7.0