### PR TITLE
Remove lava code

### DIFF
--- a/lib/services/devices/devices-NGSI-LD.js
+++ b/lib/services/devices/devices-NGSI-LD.js
@@ -57,53 +57,6 @@ function jsonConcat(json1, json2) {
 }
 
 /**
- * Creates the response handler for the initial entity creation request using NGSI-LD.
- * This handler basically deals with the errors that could have been rised during
- * the communication with the Context Broker.
- *
- * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
- * @param {Object} newDevice        Device object that will be stored in the database.
- * @return {function}               Handler to pass to the request() function.
- */
-function createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback) {
-    return function handleInitialEntityResponse(error, response, body) {
-        if (error) {
-            logger.error(
-                context,
-                'ORION-001: Connection error creating inital entity in the Context Broker: %s',
-                error
-            );
-
-            alarms.raise(constants.ORION_ALARM, error);
-
-            callback(error);
-        }
-        // Handling different response codes for batch entity upsert in NGSI-LD specification:
-        // - In v1.2.1, response code is 200
-        // - In v1.3.1, response code is 201 if some created entities, 204 if just updated existing
-        else if (
-            response &&
-            (response.statusCode === 200 || response.statusCode === 201 || response.statusCode === 204)
-        ) {
-            alarms.release(constants.ORION_ALARM);
-            logger.debug(context, 'Initial entity created successfully.');
-            callback(null, newDevice);
-        } else {
-            logger.error(
-                context,
-                'Protocol error connecting to the Context Broker [%d]: %s',
-                response.statusCode,
-                body
-            );
-
-            const errorObj = new errors.EntityGenericError(deviceData.id, deviceData.type, body);
-
-            callback(errorObj);
-        }
-    };
-}
-
-/**
  * Creates the response handler for the update entity request using NGSI-LD.
  * This handler basically deals with the errors
  * that could have been rised during the communication with the Context Broker.
@@ -154,54 +107,8 @@ function updateEntityHandlerNgsiLD(deviceData, updatedDevice, callback) {
  * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
  * @param {Object} newDevice        Device object that will be stored in the database.
  */
-function createInitialEntityNgsiLD(deviceData, newDevice, callback) {
-    let json = {
-        id: String(deviceData.name),
-        type: deviceData.type
-    };
-
-    jsonConcat(json, NGSIv2.formatAttributes(deviceData.active, false));
-    jsonConcat(json, NGSIv2.formatAttributes(deviceData.staticAttributes, true));
-    jsonConcat(json, NGSIv2.formatCommands(deviceData.commands));
-
-    if (
-        ('timestamp' in deviceData && deviceData.timestamp !== undefined
-            ? deviceData.timestamp
-            : config.getConfig().timestamp) &&
-        !utils.isTimestampedNgsi2(json)
-    ) {
-        logger.debug(context, 'config.timestamp %s %s', deviceData.timestamp, config.getConfig().timestamp);
-
-        json[constants.TIMESTAMP_ATTRIBUTE] = {
-            type: constants.TIMESTAMP_TYPE_NGSI2,
-            value: moment()
-        };
-    }
-
-    json = ngsiLD.formatAsNGSILD(json);
-
-    const options = {
-        url: config.getConfig().contextBroker.url + '/ngsi-ld/v1/entityOperations/upsert/',
-        method: 'POST',
-        json: [json],
-        headers: {
-            'fiware-service': deviceData.service,
-            'fiware-servicepath': deviceData.subservice,
-            'NGSILD-Tenant': deviceData.service,
-            'NGSILD-Path': deviceData.subservice,
-            'Content-Type': 'application/ld+json'
-        }
-    };
-
-    if (deviceData.cbHost && deviceData.cbHost.indexOf('://') !== -1) {
-        options.url = deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/';
-    } else if (deviceData.cbHost && deviceData.cbHost.indexOf('://') === -1) {
-        options.url = 'http://' + deviceData.cbHost + '/ngsi-ld/v1/entityOperations/upsert/';
-    }
-
-    logger.debug(context, 'deviceData: %j', deviceData);
-    logger.debug(context, 'Creating initial entity in the Context Broker:\n %s', JSON.stringify(options, null, 4));
-    utils.executeWithSecurity(options, newDevice, createInitialEntityHandlerNgsiLD(deviceData, newDevice, callback));
+function createInitialEntityNgsiLDFake(deviceData, newDevice, callback) {
+    callback(null, newDevice);
 }
 
 /**
@@ -281,9 +188,10 @@ function updateRegisterDeviceNgsiLD(deviceObj, entityInfoUpdated, callback) {
         return;
     }
 
-    logger.debug(context, 'Update provisioned LD device in Device Service');
+    logger.debug(context, 'Update provisioned LD device in Device Service %j %j', deviceObj, entityInfoUpdated);
 
     function combineWithNewDevice(newDevice, oldDevice, callback) {
+        logger.debug(context, 'combineWithNewDevice %j %j', newDevice, oldDevice);
         if (oldDevice) {
             oldDevice.internalId = newDevice.internalId;
             oldDevice.lazy = newDevice.lazy;
@@ -377,7 +285,7 @@ function updateRegisterDeviceNgsiLD(deviceObj, entityInfoUpdated, callback) {
                     deviceObj.subservice
                 ),
                 apply(extractDeviceDifference, deviceObj),
-                createInitialEntityNgsiLD,
+                createInitialEntityNgsiLDFake,
                 apply(combineWithNewDevice, deviceObj),
                 apply(registrationUtils.sendRegistrations, false),
                 apply(registrationUtils.processContextRegistration, deviceObj),
@@ -407,5 +315,4 @@ function updateRegisterDeviceNgsiLD(deviceObj, entityInfoUpdated, callback) {
     }
 }
 
-exports.createInitialEntity = createInitialEntityNgsiLD;
 exports.updateRegisterDevice = updateRegisterDeviceNgsiLD;

--- a/lib/services/devices/devices-NGSI-mixed.js
+++ b/lib/services/devices/devices-NGSI-mixed.js
@@ -28,19 +28,6 @@ const deviceHandlerLD = require('./devices-NGSI-LD');
 const deviceHandlerV2 = require('./devices-NGSI-v2');
 
 /**
- * Creates the initial entity representing the device in the Context Broker using both NGSI-LD and NGSI-v2
- * This is important mainly to allow the rest of the updateContext operations to be performed.
- *
- * @param {Object} deviceData       Object containing all the deviceData needed to send the registration.
- * @param {Object} newDevice        Device object that will be stored in the database.
- */
-function createInitialEntityNgsiMixed(deviceData, newDevice, callback) {
-    if (config.checkNgsiLD(deviceData)) {
-        deviceHandlerLD.createInitialEntity(deviceData, newDevice, callback);
-    }
-}
-
-/**
  * Updates the register of an existing device identified by the Id and Type in the Context Broker, and the internal
  * registry. It uses both NGSI-LD and NGSI-v2
  *
@@ -59,5 +46,4 @@ function updateRegisterDeviceNgsiMixed(deviceObj, entityInfoUpdated, callback) {
     }
 }
 
-exports.createInitialEntity = createInitialEntityNgsiMixed;
 exports.updateRegisterDevice = updateRegisterDeviceNgsiMixed;


### PR DESCRIPTION
Static analysis of the changes between 3.3.0 and 3.4.0 indicates that the `createInitialEntity` from NGSI-v2. This PR does the same for "LD "and "mixed". There is no change in the tests, but coverage should increase marginally