### PR TITLE
Fix: Remove nulls from context before evaluating expressions

### DIFF
--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -125,10 +125,22 @@ function extractContext(attributeList) {
 
 function applyExpression(expression, context, typeInformation) {
     logContext = fillService(logContext, typeInformation);
+    // Delete null values from context. Related:
+    // https://github.com/telefonicaid/iotagent-node-lib/issues/1440
+    // https://github.com/TomFrost/Jexl/issues/133
+    deleteNulls(context);
     const result = parse(expression, context);
     logger.debug(logContext, 'applyExpression "[%j]" over "[%j]" result "[%j]" ', expression, context, result);
     const expressionResult = result !== undefined ? result : expression;
     return expressionResult;
+}
+
+function deleteNulls(object) {
+    for (let key in object) {
+        if (object[key] === null) {
+            delete object[key];
+        }
+    }
 }
 
 function isTransform(identifier) {

--- a/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
+++ b/test/unit/ngsiv2/expressions/jexlBasedTransformations-test.js
@@ -744,7 +744,6 @@ describe('Java expression language (JEXL) based transformations plugin', functio
 
         beforeEach(function () {
             nock.cleanAll();
-            // logger.setLevel('DEBUG');
 
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartgondor')
@@ -754,10 +753,6 @@ describe('Java expression language (JEXL) based transformations plugin', functio
                     type: 'testNull',
                     v: {
                         value: null,
-                        type: 'Number'
-                    },
-                    b: {
-                        value: 0,
                         type: 'Number'
                     },
                     c: {
@@ -877,7 +872,7 @@ describe('Java expression language (JEXL) based transformations plugin', functio
                         type: 'Number'
                     },
                     b: {
-                        value: 0,
+                        value: null,
                         type: 'Number'
                     },
                     c: {
@@ -925,7 +920,6 @@ describe('Java expression language (JEXL) based transformations plugin', functio
 
         beforeEach(function () {
             nock.cleanAll();
-            logger.setLevel('DEBUG');
 
             contextBrokerMock = nock('http://192.168.1.1:1026')
                 .matchHeader('fiware-service', 'smartgondor')
@@ -997,10 +991,6 @@ describe('Java expression language (JEXL) based transformations plugin', functio
                 .post('/v2/entities?options=upsert', {
                     id: 'testNullExplicit1',
                     type: 'testNullExplicit',
-                    b: {
-                        value: 0,
-                        type: 'Number'
-                    },
                     c: {
                         value: true,
                         type: 'Boolean'
@@ -1514,6 +1504,7 @@ describe('Java expression language (JEXL) based transformations plugin', functio
             });
         });
     });
+
     describe('When a measure arrives and there is not enough information to calculate an expression', function () {
         const values = [
             {


### PR DESCRIPTION
This PR delete null elements from context. This fix arithmetic problems due to JEXL library bug:
https://github.com/telefonicaid/iotagent-node-lib/issues/1440
https://github.com/TomFrost/Jexl/issues/133

Overpasses:
https://github.com/telefonicaid/iotagent-node-lib/pull/1471