### PR TITLE
Change log level from warn to info contextAvailable exception

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,5 @@
-- Fix: change log level contextAvailable expression exception
+- Fix: change log level contextAvailable expression exception (from WARN to INFO)
+
 - Fix: null values arithmetics in JEXL expressions (#1440)
 - Fix: remove mongo `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Upgrade mongodb dev dep from 4.17.0 to 4.17.1

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,4 @@
 - Fix: change log level contextAvailable expression exception (from WARN to INFO)
-
 - Fix: null values arithmetics in JEXL expressions (#1440)
 - Fix: remove mongo `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Upgrade mongodb dev dep from 4.17.0 to 4.17.1

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
-- Fix: remove mongo `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
+- Fix: change log level contextAvailable expression exception
+- Fix: remove mongo `DeprecationWarning: current Server Discovery an7d Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Upgrade mongodb dev dep from 4.17.0 to 4.17.1

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,5 +1,4 @@
 - Fix: change log level contextAvailable expression exception
-- Fix: remove mongo `DeprecationWarning: current Server Discovery an7d Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Fix: null values arithmetics in JEXL expressions (#1440)
 - Fix: remove mongo `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Upgrade mongodb dev dep from 4.17.0 to 4.17.1

--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -141,7 +141,7 @@ function contextAvailable(expression, context) {
         jexl.evalSync(expression, context);
         return true;
     } catch (e) {
-        logger.warn(logContext, 'Wrong expression found "[%j]" over "[%j]", it will be ignored', expression, context);
+        logger.info(logContext, 'Wrong expression found "[%j]" over "[%j]", it will be ignored', expression, context);
         return false;
     }
 }


### PR DESCRIPTION
Log about "Wrong expression found .... over " is produced by contextAvailable of jexl plugin:

from https://github.com/telefonicaid/iotagent-node-lib/commit/d29e0060198355fde96153f31c5e7c8cdcf1d5f8