### PR TITLE
fix: autoprovision with group timestamp false

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix autoprovision with group timestamp false
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)
 - Remove: extractVariables from jexl plugin (no needed anymore since the removal of bidireational plugin)
 - Fix: ensure service and subservice in context of error handlers using req headers

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: use but no store timestamp and explicitAttrs from group with autoprovisioned devices
+- Fix: use but not store timestamp and explicitAttrs from group with autoprovisioned devices (#1504, partially)
 - Fix: MongoDB connection authentication (user and password were not actually used) (#1510)
 - Fix: add static attributes when use explicitAttrs (#1506)
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix include timestamp from gorup in device autoprovisioned
+- Fix include timestamp from group in device autoprovisioned
 - Fix: add static attributes when use explicitAttrs (#1506)
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)
 - Remove: extractVariables from jexl plugin (no needed anymore since the removal of bidireational plugin)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix include timestamp from group in device autoprovisioned
+- Fix: include timestamp from group in device autoprovisioned
 - Fix: add static attributes when use explicitAttrs (#1506)
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)
 - Remove: extractVariables from jexl plugin (no needed anymore since the removal of bidireational plugin)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: include timestamp from group in device autoprovisioned
+- Fix: use but no store timestamp and explicitAttrs from group autoprovisioned devices
 - Fix: MongoDB connection authentication (user and password were not actually used) (#1510)
 - Fix: add static attributes when use explicitAttrs (#1506)
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Fix: use but no store timestamp and explicitAttrs from group autoprovisioned devices
+- Fix: use but no store timestamp and explicitAttrs from group with autoprovisioned devices
 - Fix: MongoDB connection authentication (user and password were not actually used) (#1510)
 - Fix: add static attributes when use explicitAttrs (#1506)
 - Remove: single configuration mode (along with IOTA_SINGLE_MODE env var) (#1469)

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -351,12 +351,6 @@ function registerDevice(deviceObj, callback) {
                     deviceObj.staticAttributes = deviceObj.staticAttributes ? deviceObj.staticAttributes : [];
                     deviceObj.commands = deviceObj.commands ? deviceObj.commands : [];
                     deviceObj.lazy = deviceObj.lazy ? deviceObj.lazy : [];
-                    if ('timestamp' in deviceData && deviceData.timestamp !== undefined) {
-                        deviceObj.timestamp = deviceData.timestamp;
-                    }
-                    if ('explicitAttrs' in deviceData && deviceData.explicitAttrs !== undefined) {
-                        deviceObj.explicitAttrs = deviceData.explicitAttrs;
-                    }
                     if ('apikey' in deviceData && deviceData.apikey !== undefined) {
                         deviceObj.apikey = deviceData.apikey;
                     }

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -173,6 +173,9 @@ function mergeDeviceWithConfiguration(fields, defaults, deviceData, configuratio
     if (configuration && configuration.entityNameExp !== undefined) {
         deviceData.entityNameExp = configuration.entityNameExp;
     }
+    if (configuration && configuration.timestamp !== undefined && deviceData.timestamp === undefined) {
+        deviceData.timestamp = configuration.timestamp;
+    }
     logger.debug(context, 'deviceData after merge with conf: %j', deviceData);
     callback(null, deviceData);
 }

--- a/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
+++ b/test/unit/ngsiv2/provisioning/device-provisioning-api_test.js
@@ -366,11 +366,10 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                     done();
                 });
             });
-            it('should store the device with explicitAttrs value provided in configuration', function (done) {
+            it('should store the device without explicitAttrs', function (done) {
                 request(options, function (error, response, body) {
                     iotAgentLib.listDevices('smartgondor', '/gardens', function (error, results) {
-                        should.exist(results.devices[0].explicitAttrs);
-                        results.devices[0].explicitAttrs.should.equal(false);
+                        should.not.exist(results.devices[0].explicitAttrs);
                         done();
                     });
                 });
@@ -430,12 +429,11 @@ describe('NGSI-v2 - Device provisioning API: Provision devices', function () {
                 done();
             });
 
-            it('should store the device with explicitAttrs value provided in configuration', function (done) {
+            it('should store the device without explicitAttrs value', function (done) {
                 request(groupCreation, function (error, response, body) {
                     request(options, function (error, response, body) {
                         iotAgentLib.listDevices('smartgondor', '/gardens', function (error, results) {
-                            should.exist(results.devices[0].explicitAttrs);
-                            results.devices[0].explicitAttrs.should.equal(true);
+                            should.not.exist(results.devices[0].explicitAttrs);
                             done();
                         });
                     });


### PR DESCRIPTION
typeInformation should contain that timestamp=false in an autoprovision of device with a group with timestamp=false

Related with issue https://github.com/telefonicaid/iotagent-node-lib/issues/1504 and the expected new tests about it