### PR TITLE
Remove unsued dependencies from jexlParser.js

### DIFF
--- a/lib/plugins/jexlParser.js
+++ b/lib/plugins/jexlParser.js
@@ -28,8 +28,6 @@
 /* eslint-disable no-unused-vars */
 
 const jexl = require('jexl');
-const grammar = require('jexl/dist/grammar').getGrammar();
-const Lexer = require('jexl/dist/Lexer');
 const errors = require('../errors');
 const logger = require('logops');
 const fillService = require('../services/common/domain').fillService;


### PR DESCRIPTION
After removing the code related to extractVariables function (used by bidirectional plugin) in this PR: https://github.com/telefonicaid/iotagent-node-lib/pull/1495

Those 2 dependencies are not required anymore