### PR TITLE
[Fix] Parse authSource variable into mongo url string

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -14,3 +14,4 @@
 - Fix: null values arithmetics in JEXL expressions (#1440)
 - Fix: remove mongo `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated` by setting `useUnifiedTopology = true`
 - Upgrade mongodb dev dep from 4.17.0 to 4.17.1
+- Fix: mongodb.authSource / IOTA_MONGO_AUTH_SOURCE was not correctly supported (#1526)

--- a/lib/model/dbConn.js
+++ b/lib/model/dbConn.js
@@ -210,22 +210,26 @@ function configureDb(callback) {
                 options.replicaSet = currentConfig.mongodb.replicaSet;
             }
 
-            if (currentConfig.mongodb.user && currentConfig.mongodb.password) {
-                options.auth = {};
-                options.auth.user = currentConfig.mongodb.user;
-                options.auth.password = currentConfig.mongodb.password;
-            }
-
-            if (currentConfig.mongodb.authSource) {
-                options.authSource = currentConfig.mongodb.authSource;
-            }
-
             if (currentConfig.mongodb.ssl) {
                 options.ssl = currentConfig.mongodb.ssl;
             }
 
             if (currentConfig.mongodb.extraArgs) {
                 options.extraArgs = currentConfig.mongodb.extraArgs;
+            }
+
+            if (currentConfig.mongodb.user && currentConfig.mongodb.password) {
+                options.auth = {};
+                options.auth.user = currentConfig.mongodb.user;
+                options.auth.password = currentConfig.mongodb.password;
+                // authSource only applies if auth is set
+                if (currentConfig.mongodb.authSource) {
+                    // Overload extraArgs if it was set
+                    options.extraArgs = {
+                        ...options.extraArgs,
+                        authSource: currentConfig.mongodb.authSource
+                    };
+                }
             }
 
             init(config.getConfig().mongodb.host, dbName, port, options, callback);

--- a/test/unit/mongodb/mongodb-connectionoptions-test.js
+++ b/test/unit/mongodb/mongodb-connectionoptions-test.js
@@ -173,7 +173,6 @@ describe('dbConn.configureDb', function () {
                 expected: {
                     url: 'mongodb://example.com:27017/' + dbConn.DEFAULT_DB_NAME,
                     options: {
-                        authSource: 'admin',
                         useNewUrlParser: true,
                         useUnifiedTopology: true
                     }
@@ -190,14 +189,13 @@ describe('dbConn.configureDb', function () {
                     authSource: 'admin'
                 },
                 expected: {
-                    url: 'mongodb://user01:pass01@example.com:98765/examples',
+                    url: 'mongodb://user01:pass01@example.com:98765/examples?authSource=admin',
                     options: {
                         replicaSet: 'rs0',
                         auth: {
                             user: 'user01',
                             password: 'pass01'
                         },
-                        authSource: 'admin',
                         useNewUrlParser: true,
                         useUnifiedTopology: true
                     }
@@ -308,14 +306,13 @@ describe('dbConn.configureDb', function () {
                     unknownparam: 'unknown'
                 },
                 expected: {
-                    url: 'mongodb://user01:pass01@example.com:98765/examples?retryWrites=true&readPreference=nearest&w=majority',
+                    url: 'mongodb://user01:pass01@example.com:98765/examples?retryWrites=true&readPreference=nearest&w=majority&authSource=admin',
                     options: {
                         replicaSet: 'rs0',
                         auth: {
                             user: 'user01',
                             password: 'pass01'
                         },
-                        authSource: 'admin',
                         ssl: true,
                         useNewUrlParser: true,
                         useUnifiedTopology: true


### PR DESCRIPTION
*Edit:* issue #1526 

    - Overriding when user:pass is present in extraArgs
    - Fix tests
    
    I see that authSource had an independant ENV variable and treatment along the code, but the truth it's that authSource should concat in the string as an extraArgs. 
    In my opinion the best way to allow backwards compatibility is to still parsing if comes in extraArgs, but overriding if the specific env variable is present. 
    Also authSource should only used if user:pass are present so i included in the if statemente