### PR TITLE
Add more functional tests + change describes numbers associated

### DIFF
--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -2808,7 +2808,7 @@ const testCases = [
         ]
     },
     // 0700 - FULL GROUP TESTS
-    // APIKEY RECOGNITION IS NOT WORKING FOR LIB, SKIPPED
+    // FIXME: APIKEY recognition is not working for lib, and it needs to be tested if works as it is in agents.
     // 0800 - SKIP VALUE
     {
         describeName: '0700 - skipValue test',


### PR DESCRIPTION
Added the following new tests:
```
   0540 - Group with explicit attrs: JEXL expression based on measure resulting boolean + active attributes + static attributes
      ✔ A - WHEN sending both provisioned and not object_ids (measures) through http and being the explicitAttrs JEXL result true IT should store only explicit attrs into Context Broker
      ✔ A - WHEN sending both provisioned and not object_ids (measures) through http and being the explicitAttrs JEXL result false IT should store all attrs into Context Broker
    0550 - Group with explicit attrs: JEXL expression based on measure resulting an array + active attributes + static attributes
      ✔ A - WHEN sending (a&&b) IT should store only [attr_a,attr_b] attrs into Context Broker
      ✔ B - WHEN sending only a IT should store only [attr_a,static_b] attrs into Context Broker
      ✔ C - WHEN sending only b IT should store only [{object_id:b}] attrs into Context Broker
      ✔ D - WHEN no sending any defined case IT should store [static_a,static_b] attrs into Context Broker
    0600 - Group multientity attrs
      ✔ A - WHEN sending provisioned object_ids (measures) through http IT should store both entities into Context Broker
    0610 - Group multientity attrs + value JEXL expression
      ✔ A - WHEN sending provisioned object_ids (measures) through http IT should store both entities into Context Broker
    0620 - Group multientity attrs + multientity ID JEXL expression
      ✔ A - WHEN sending provisioned object_ids (measures) through http IT should store both entities into Context Broker
    0700 - Group JEXL entityNameExpression
      ✔ A - WHEN sending provisioned object_ids (measures) through http IT should store the entity with the expression generated ID into the Context Broker
    0700 - skipValue test
      ✔ A - WHEN not matching skip conditions IT should store the entity with all the values (attr_a, attr_b, static_a) into the Context Broker
      ✔ B - WHEN matching skip conditions for attr_b IT should store the entity with some of the values (attr_a, static_a) into the Context Broker
      ✔ C - WHEN matching skip conditions for attr_a and attr_b (expression result) IT should store the entity with only some of the values (static_a) into the Context Broker
```