### PR TITLE
Task/badtimestamp error log

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Log device id when BadTimestamp error

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -229,9 +229,9 @@ class BadAnswer {
     }
 }
 class BadTimestamp {
-    constructor(payload) {
+    constructor(payload, entityName) {
         this.name = 'BAD_TIMESTAMP';
-        this.message = 'Invalid ISO8601 timestamp [' + payload + ']';
+        this.message = 'Invalid ISO8601 timestamp [' + payload + '] in [' + entityName + ']';
         this.code = 400;
     }
 }

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -1015,7 +1015,7 @@ function sendUpdateValueNgsiLD(entityName, attributes, typeInformation, token, c
                 } else if (!utils.IsValidTimestampedNgsi2(payload[n])) {
                     // legacy check needed?
                     logger.error(context, 'Invalid timestamp:%s', JSON.stringify(payload[0]));
-                    callback(new errors.BadTimestamp(payload));
+                    callback(new errors.BadTimestamp(payload, entityName));
                     return;
                 }
             }

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -311,7 +311,7 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
             if (moment(plainMeasures[constants.TIMESTAMP_ATTRIBUTE], moment.ISO_8601, true).isValid()) {
                 timestamp.value = plainMeasures[constants.TIMESTAMP_ATTRIBUTE];
             } else {
-                callback(new errors.BadTimestamp(null, entityName));
+                callback(new errors.BadTimestamp(plainMeasures[constants.TIMESTAMP_ATTRIBUTE], entityName));
             }
         } else if (!typeInformation.timezone) {
             timestamp.value = new Date().toISOString();
@@ -387,10 +387,11 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
             typeof currentAttr.entity_name == 'string'
         ) {
             try {
-                logger.debug(context, 
+                logger.debug(
+                    context,
                     'Evaluating attribute: %j, for entity_name(exp):%j, with ctxt: %j',
-                    currentAttr.name, 
-                    currentAttr.entity_name, 
+                    currentAttr.name,
+                    currentAttr.entity_name,
                     jexlctxt
                 );
                 attrEntityName = jexlParser.applyExpression(currentAttr.entity_name, jexlctxt, typeInformation);
@@ -451,10 +452,11 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
             } catch (e) {
                 valueExpression = null;
             }
-            logger.debug(context, 
-                'Evaluated attr: %j, with expression: %j, and ctxt: %j resulting: %j', 
+            logger.debug(
+                context,
+                'Evaluated attr: %j, with expression: %j, and ctxt: %j resulting: %j',
                 currentAttr.name,
-                currentAttr.expression, 
+                currentAttr.expression,
                 jexlctxt,
                 valueExpression
             );
@@ -564,7 +566,7 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
             }
         }
     }
-  
+
     let url = '/v2/op/update';
     let options = NGSIUtils.createRequestObject(url, typeInformation, token);
     options.json = payload;
@@ -607,15 +609,9 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
         } // else: keep current options object created for a batch update
 
         //Send the NGSI request
-        logger.debug(context, 
-            'Updating device value in the Context Broker at: %j', 
-            options.url
-        );
-        logger.debug(context, 
-            'Using the following NGSI v2 request: %j', 
-            options
-        );
-        
+        logger.debug(context, 'Updating device value in the Context Broker at: %j', options.url);
+        logger.debug(context, 'Using the following NGSI v2 request: %j', options);
+
         request(
             options,
             generateNGSI2OperationHandler('update', entityName, typeInformation, token, options, callback)


### PR DESCRIPTION
For a case: 
curl -i -X POST 'http://localhost:7897/iot/json?i=dispNew&k=izc9cokegoy7kyfgdd6etipt6&t=null' -d '{ "c": 3, "d": 4}' -H 'content-type: application/json'

{"name":"BAD_TIMESTAMP","message":"Invalid ISO8601 timestamp [null]"}


this error will be: 

{"name":"BAD_TIMESTAMP","message":"Invalid ISO8601 timestamp [null] in [thing:dispNew]"}