### PR TITLE
store in device commands from group after CB registration

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,2 @@
-- FIX: store commands from Group at Device level at provision device time
+- Fix: store commands from Group at Device level at provision device time
 - Log device id when BadTimestamp error

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- FIX: store commands from Group at Device level at provision device time
 - Log device id when BadTimestamp error

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -352,7 +352,7 @@ function registerDevice(deviceObj, callback) {
                     deviceObj.subservice = deviceData.subservice;
                     deviceObj.type = deviceData.type;
                     deviceObj.staticAttributes = deviceObj.staticAttributes ? deviceObj.staticAttributes : [];
-                    deviceObj.commands = deviceObj.commands ? deviceObj.commands : [];
+                    deviceObj.commands = deviceData.commands ? deviceData.commands : [];
                     deviceObj.lazy = deviceObj.lazy ? deviceObj.lazy : [];
                     if ('apikey' in deviceData && deviceData.apikey !== undefined) {
                         deviceObj.apikey = deviceData.apikey;

--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -1476,6 +1476,66 @@ const testCases = [
             }
         ]
     },
+    // 0200 - COMMANDS TESTS
+    {
+        describeName: '0200 - Simple group with commands',
+        provision: {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+            method: 'POST',
+            json: {
+                services: [
+                    {
+                        resource: '/iot/json',
+                        apikey: globalEnv.apikey,
+                        entity_type: globalEnv.entity_type,
+                        commands: [
+                            {
+                                name: 'cmd1',
+                                type: 'command'
+                            }
+                        ],
+                        lazy: [],
+                        attributes: [],
+                        static_attributes: []
+                    }
+                ]
+            },
+            headers: {
+                'fiware-service': globalEnv.service,
+                'fiware-servicepath': globalEnv.servicePath
+            }
+        },
+        should: [
+            {
+                loglevel: 'fatal',
+                shouldName:
+                    'A - WHEN sending not provisioned object_ids (measures) through http IT should store commands into Context Broker',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        b: 10
+                    }
+                },
+                expectation: {
+                    id: globalEnv.entity_name,
+                    type: globalEnv.entity_type,
+                    b: {
+                        value: 10,
+                        type: 'string'
+                    },
+                    cmd1: {
+                        type: 'command'
+                    }
+                }
+            }
+        ]
+    },
     // 0300 - STATIC ATTRIBUTES TESTS
     {
         describeName:

--- a/test/functional/testUtils.js
+++ b/test/functional/testUtils.js
@@ -139,6 +139,8 @@ function groupToIoTAConfigType(group, service, subservice) {
                 type.type = group.entity_type;
             } else if (key === 'static_attributes') {
                 type.staticAttributes = group.static_attributes;
+            } else if (key === 'commands') {
+                type.commands = group.commands;
             } else if (key !== 'resource') {
                 type[key] = group[key];
             }


### PR DESCRIPTION
Bug introduced in 3.3.0 by https://github.com/telefonicaid/iotagent-node-lib/pull/1396

commands from groups should be stored in device since registration is only possible against device entity.

Otherwise commands is stored in entity as normal string type attribute.

Moreover any command group modification requires device registration would be done again, and then implies device and entity should be deleted previously.