### PR TITLE
fix test

### DIFF
--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -1507,7 +1507,6 @@ const testCases = [
         },
         should: [
             {
-                loglevel: 'fatal',
                 shouldName:
                     'A - WHEN sending not provisioned object_ids (measures) through http IT should store commands into Context Broker',
                 type: 'single',
@@ -1528,9 +1527,6 @@ const testCases = [
                     b: {
                         value: 10,
                         type: 'string'
-                    },
-                    cmd1: {
-                        type: 'command'
                     }
                 }
             }


### PR DESCRIPTION
Command is not sent to entity by POST /v2/entities;  command is stored in device and command is register into CB by iota in another request (POST TO /v2/registrations ) not covered by there test framework

logLevel in tests functional framework was doing a false positive resuilt test