### PR TITLE
[WIP] notify by apikey instead of name and type of device

### DIFF
--- a/lib/services/northBound/contextServer-NGSI-v2.js
+++ b/lib/services/northBound/contextServer-NGSI-v2.js
@@ -282,7 +282,7 @@ function handleNotificationNgsi2(req, res, next) {
         const atts = [];
         for (const key in dataElement) {
             if (dataElement.hasOwnProperty(key)) {
-                if (key !== 'id' && key !== 'type') {
+                if (key !== 'id' && key !== 'type' && key !== 'apikey') {
                     const att = {};
                     att.type = dataElement[key].type;
                     att.value = dataElement[key].value;
@@ -292,9 +292,9 @@ function handleNotificationNgsi2(req, res, next) {
                 }
             }
         }
-        deviceService.getDeviceByNameAndType(
-            dataElement.id,
-            dataElement.type,
+        deviceService.getDevice(
+            dataElement.id, // device.id is entity.id ?
+            dataElement.apikey,
             req.headers['fiware-service'],
             req.headers['fiware-servicepath'],
             function (error, device) {

--- a/lib/services/northBound/contextServer-NGSI-v2.js
+++ b/lib/services/northBound/contextServer-NGSI-v2.js
@@ -292,19 +292,35 @@ function handleNotificationNgsi2(req, res, next) {
                 }
             }
         }
-        deviceService.getDevice(
-            dataElement.id, // device.id is entity.id ?
-            dataElement.apikey,
-            req.headers['fiware-service'],
-            req.headers['fiware-servicepath'],
-            function (error, device) {
-                if (error) {
-                    callback(error);
-                } else {
-                    callback(null, device, atts);
+        if (dataElement.deviceId && dataElement.apikey) {
+            deviceService.getDevice(
+                dataElement.deviceId,
+                dataElement.apikey,
+                req.headers['fiware-service'],
+                req.headers['fiware-servicepath'],
+                function (error, device) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        callback(null, device, atts);
+                    }
                 }
-            }
-        );
+            );
+        } else if (dataElement.id && dataElement.type) {
+            deviceService.getDeviceByNameAndType(
+                dataElement.id,
+                dataElement.type,
+                req.headers['fiware-service'],
+                req.headers['fiware-servicepath'],
+                function (error, device) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        callback(null, device, atts);
+                    }
+                }
+            );
+        }
     }
 
     function applyNotificationMiddlewares(device, values, callback) {

--- a/test/unit/ngsiv2/examples/subscriptionRequests/simpleNotification.json
+++ b/test/unit/ngsiv2/examples/subscriptionRequests/simpleNotification.json
@@ -6,6 +6,7 @@
           "type": "string",
           "value": "The Attribute Value"
       },
+      "apikey": "theApikey",
       "type": "MicroLights",
       "id": "FirstMicroLight"
     }

--- a/test/unit/ngsiv2/examples/subscriptionRequests/simpleNotification.json
+++ b/test/unit/ngsiv2/examples/subscriptionRequests/simpleNotification.json
@@ -6,7 +6,6 @@
           "type": "string",
           "value": "The Attribute Value"
       },
-      "apikey": "theApikey",
       "type": "MicroLights",
       "id": "FirstMicroLight"
     }

--- a/test/unit/ngsiv2/ngsiService/subscriptions-test.js
+++ b/test/unit/ngsiv2/ngsiService/subscriptions-test.js
@@ -33,7 +33,7 @@ const should = require('should');
 const nock = require('nock');
 let contextBrokerMock;
 const iotAgentConfig = {
-    logLevel: 'FATAL',
+    logLevel: 'DEBUG',
     contextBroker: {
         host: '192.168.1.1',
         port: '1026',
@@ -183,7 +183,7 @@ describe('NGSI-v2 - Subscription tests', function () {
     });
     describe('When a new notification comes to the IoTAgent', function () {
         beforeEach(function (done) {
-            iotAgentLib.getDevice('MicroLight1', 'theApikey', 'smartgondor', '/gardens', function (error, device) {
+            iotAgentLib.getDevice('MicroLight1', null, 'smartgondor', '/gardens', function (error, device) {
                 iotAgentLib.subscribe(device, ['attr_name'], null, function (error) {
                     done();
                 });
@@ -275,7 +275,6 @@ describe('NGSI-v2 - Subscription tests', function () {
                     device &&
                     device.id === 'MicroLight1' &&
                     device.name === 'FirstMicroLight' &&
-                    device.apikey === 'theApikey' &&
                     data &&
                     data.length === 1 &&
                     data[0].name === 'attr_name'

--- a/test/unit/ngsiv2/ngsiService/subscriptions-test.js
+++ b/test/unit/ngsiv2/ngsiService/subscriptions-test.js
@@ -183,7 +183,7 @@ describe('NGSI-v2 - Subscription tests', function () {
     });
     describe('When a new notification comes to the IoTAgent', function () {
         beforeEach(function (done) {
-            iotAgentLib.getDevice('MicroLight1', null, 'smartgondor', '/gardens', function (error, device) {
+            iotAgentLib.getDevice('MicroLight1', 'theApikey', 'smartgondor', '/gardens', function (error, device) {
                 iotAgentLib.subscribe(device, ['attr_name'], null, function (error) {
                     done();
                 });
@@ -275,6 +275,7 @@ describe('NGSI-v2 - Subscription tests', function () {
                     device &&
                     device.id === 'MicroLight1' &&
                     device.name === 'FirstMicroLight' &&
+                    device.apikey === 'theApikey' &&
                     data &&
                     data.length === 1 &&
                     data[0].name === 'attr_name'


### PR DESCRIPTION
To allow a notification like: 

curl -i -X POST http://localhost:4052/notify -d '{ "subscriptionId": "abc1234", "data": [{"id": "disp1", "type": "Thing", "apikey": "theapikey"}] }' -H 'content-type: application/json'