### PR TITLE
FIX reference in CHANGES_NEXT_RELEASE

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Add: process JEXL expressions in metadata attributes (#1601)
+- Add: process JEXL expressions in metadata attributes (#1598)
 - Fix: TimeInstant mapped from attribute overrides default behaviours (#1557)
 - Fix: reduce information showed handling errors to just config flags (#1594)
 - Upgrade pymongo dep from 4.3.3 to 4.6.3


### PR DESCRIPTION
Given that #1598 (issue) has been closed and PR #1601 refers to that issue, I wonder if changelog should be changed in the way this PR does.

