### PR TITLE
Add TimeInstant + explicitAttr tests (ftest 533)

### DIFF
--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -2970,6 +2970,107 @@ const testCases = [
     },
     {
         describeName:
+            '0533 - Group with explicit attrs:[ ] (empty array) + active attributes + TimeInstant attribute + static attributes + timestamp:true',
+        provision: {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+            method: 'POST',
+            json: {
+                services: [
+                    {
+                        resource: '/iot/json',
+                        apikey: globalEnv.apikey,
+                        entity_type: globalEnv.entity_type,
+                        explicitAttrs: "['DateIssued']",
+                        timestamp: true,
+                        commands: [],
+                        lazy: [],
+                        attributes: [
+                            {
+                                name: 'attr_a',
+                                object_id: 'a',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'attr_b',
+                                object_id: 'b',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'DateIssued',
+                                object_id: 'TimeInstant',
+                                type: 'DateTime'
+                            },
+                            {
+                                name: 'TimeInstant',
+                                object_id: 't',
+                                type: 'DateTime'
+                            }
+                        ],
+                        static_attributes: [
+                            {
+                                name: 'static_a',
+                                type: 'Number',
+                                value: 3
+                            },
+                            {
+                                name: 'static_b',
+                                type: 'Number',
+                                value: 4
+                            }
+                        ]
+                    }
+                ]
+            },
+            headers: {
+                'fiware-service': globalEnv.service,
+                'fiware-servicepath': globalEnv.servicePath
+            }
+        },
+        should: [
+            {
+                shouldName:
+                    'A - WHEN sending data and a measure called "t" (defined as TimeInstant attribte) through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        t: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: {}
+            },
+            {
+                shouldName:
+                    'B - WHEN sending data and a measure called TimeInstant through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        TimeInstant: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: {} // No payload expected
+            }
+        ]
+    },
+    {
+        describeName:
             '0540 - Group with explicit attrs: JEXL expression based on measure resulting boolean + active attributes + static attributes',
         provision: {
             url: 'http://localhost:' + config.iota.server.port + '/iot/services',


### PR DESCRIPTION
A part of original PR https://github.com/telefonicaid/iotagent-node-lib/pull/1605 including test 533

>    0533 - Group with explicit attrs:[ ] (empty array) + active attributes + TimeInstant attribute + static 
>    - A - WHEN sending data and a measure called "t" (defined as TimeInstant attribte) through http IT should NOT 
>    - B - WHEN sending data and a measure called TimeInstant through http IT should NOT store anything into the 
> 
> 
> BUT some problems were discovered when using TimeInstant attribute and fucntionalities in cases 533 A) and B):
> 
> **0533 A**
> ``` diff
> Assertion Error - Context Broker received payload differs from expectation
> + expected - actual
> 
> -{
> -  "TimeInstant": {
> -    "type": "DateTime"
> -    "value": "2015-12-14T08:06:01.468Z"
> -  }
> -  "id": "TestType:TestDevice"
> -  "type": "TestType"
> -}
> +{}
> ```
> 
> **0533 B**
> ``` diff
> Assertion Error - Context Broker received payload differs from expectation
> + expected - actual
> 
> -{
> -  "DateIssued": {
> -    "metadata": {
> -      "TimeInstant": {
> -        "type": "DateTime"
> -        "value": "2024-04-29T16:07:27.281Z"
> -      }
> -    }
> -    "type": "DateTime"
> -    "value": "2015-12-14T08:06:01.468Z"
> -  }
> -  "TimeInstant": {
> -    "type": "DateTime"
> -    "value": "2024-04-29T16:07:27.281Z"
> -  }
> -  "id": "TestType:TestDevice"
> -  "type": "TestType"
> -}
> +{}
> ```

See https://github.com/telefonicaid/iotagent-node-lib/pull/1605#issuecomment-2100832653