### PR TITLE
[NGSILD] fix ENTITY_GENERIC_ERROR when context broker respond with status code… (201 code)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - Fix: allow send multiple measures to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (iotagent-json#825, #1612)
 - Fix: default express limit to 1Mb instead default 100Kb and allow change it throught a conf env var 'IOTA_EXPRESS_LIMIT' (iotagent-json#827)
+- Fix: accept 201 status code from context broker with NGSI-LD interface when first measure is sent and device is created in it (#1617)

--- a/lib/services/ngsi/entities-NGSI-LD.js
+++ b/lib/services/ngsi/entities-NGSI-LD.js
@@ -341,7 +341,7 @@ function generateNGSILDOperationHandler(operationName, entityName, typeInformati
         } else if (
             response &&
             operationName === 'update' &&
-            (response.statusCode === 200 || response.statusCode === 204)
+            (response.statusCode === 200 || response.statusCode === 204 || response.statusCode === 201)
         ) {
             logger.info(context, 'Received the following response from the CB: Value updated successfully\n');
             alarms.release(constants.ORION_ALARM);


### PR DESCRIPTION
… in update operation

with orion ld 1.5.1 during the transmission of the first measure operation the context broker respond with 201 status code.
The log reports
```
time=2024-05-30T16:55:53.988Z | lvl=DEBUG | corr=01307aed-e06c-4a1f-84b5-2719df05fde3 | trans=01307aed-e06c-4a1f-84b5-2719df05fde3 | op=IoTAgentNGSI.Request | from=n/a | srv=openiot | subsrv=/ | msg=Options: {
    "url": "http://orion:1026/ngsi-ld/v1/entityOperations/upsert/?options=update",
    "method": "POST",
    "headers": {
        "fiware-service": "openiot",
        "fiware-servicepath": "/",
        "Content-Type": "application/ld+json",
        "NGSILD-Tenant": "openiot",
        "NGSILD-Path": "/"
    },
    "json": [
        {
            "@context": "http://context/datamodels.context.jsonld",
            "id": "urn:ngsi-ld:HeightSensor:hsensor31061690_a",
            "type": "HeightSensor",
            "height": {
                "type": "Property",
                "value": 7,
                "observedAt": "2024-05-30T16:55:53.984Z"
            }
        }
    ]
} | comp=IoTAgent
time=2024-05-30T16:55:54.000Z | lvl=DEBUG | corr=01307aed-e06c-4a1f-84b5-2719df05fde3 | trans=01307aed-e06c-4a1f-84b5-2719df05fde3 | op=IoTAgentNGSI.Request | from=n/a | srv=openiot | subsrv=/ | msg=Response [
    "urn:ngsi-ld:HeightSensor:hsensor31061690_a"
] | comp=IoTAgent
time=2024-05-30T16:55:54.000Z | lvl=DEBUG | corr=01307aed-e06c-4a1f-84b5-2719df05fde3 | trans=01307aed-e06c-4a1f-84b5-2719df05fde3 | op=IoTAgentNGSI-LD | from=n/a | srv=openiot | subsrv=/ | msg=Unknown error executing update operation | comp=IoTAgent
time=2024-05-30T16:55:54.001Z | lvl=ERROR | corr=01307aed-e06c-4a1f-84b5-2719df05fde3 | trans=01307aed-e06c-4a1f-84b5-2719df05fde3 | op=IOTAUL.HTTP.Binding | from=n/a | srv=openiot | subsrv=/ | msg=MEASURES-002: Couldn't send the updated values to the Context Broker due to an error: {"name":"ENTITY_GENERIC_ERROR","message":"Error accesing entity data for device: urn:ngsi-ld:HeightSensor:hsensor31061690_a of type: HeightSensor and {\"timestamp\":true,\"defaultResource\":\"/iot/d\",\"explicitAttrs\":true,\"multiCore\":false,\"relaxTemplateValidation\":false,\"defaultEntityNameConjunction\":\":\",\"defaultType\":\"Thing\",\"lazy\":[],\"commands\":[],\"staticAttributes\":[{\"name\":\"category\",\"type\":\"Property\",\"value\":\"sensor\"},{\"name\":\"supportedProtocol\",\"type\":\"Property\",\"value\":\"ul20\"}],\"_id\":\"6658af9976ff3b1fc9d81d1d\",\"creationDate\":\"2024-05-30T16:55:53.973Z\",\"id\":\"hsensor31061690_a\",\"type\":\"HeightSensor\",\"name\":\"urn:ngsi-ld:HeightSensor:hsensor31061690_a\",\"service\":\"openiot\",\"subservice\":\"/\",\"apikey\":\"dummykeyasdasd\",\"__v\":0,\"active\":[{\"object_id\":\"h\",\"name\":\"height\",\"type\":\"Property\"},{\"object_id\":\"b\",\"name\":\"batteryLevel\",\"type\":\"Property\"},{\"object_id\":\"gps\",\"name\":\"location\",\"type\":\"geo:point\"}],\"subscriptions\":[]}","details":["urn:ngsi-ld:HeightSensor:hsensor31061690_a"],"code":201} | comp=IoTAgent

```



I think this would fix https://github.com/FIWARE/tutorials.IoT-Agent/issues/23