### PR TITLE
Add TimeInstant + explicitAttr tests (func test 533)

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
-- Feature: do not propage TimeInstnat when explicitAttrs is empty array
+- Fix: do not propage TimeInstant when explicitAttrs is empty array (#1606)
 - Fix: update device using previous device apikey to avoid error when apikey is updated (iota-json#833)
 - Fix: allow send multiple measures to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (iotagent-json#825, #1612)
 - Fix: default express limit to 1Mb instead default 100Kb and allow change it throught a conf env var 'IOTA_EXPRESS_LIMIT' (iotagent-json#827)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Feature: do not propage TimeInstnat when explicitAttrs is empty array
 - Fix: update device using previous device apikey to avoid error when apikey is updated (iota-json#833)
 - Fix: allow send multiple measures to CB in a batch (POST /v2/op/update) and sorted by TimeInstant when possible, instead of using multiples single request (iotagent-json#825, #1612)
 - Fix: default express limit to 1Mb instead default 100Kb and allow change it throught a conf env var 'IOTA_EXPRESS_LIMIT' (iotagent-json#827)

--- a/doc/api.md
+++ b/doc/api.md
@@ -464,8 +464,9 @@ element. By adding the field `explicitAttrs` with `true` value to device or conf
 measure elements that are not defined in the mappings of device or config group, persisting only the one defined in the
 mappings of the provision. If `explicitAttrs` is provided both at device and config group level, the device level takes
 precedence. Additionally `explicitAttrs` can be used to define which measures (identified by their attribute names, not
-by their object_id) defined in JSON/JEXL array will be propagated to NGSI interface. When `explicitAttrs` is an array or
-and JEXL expression resulting in to Array, if this array is empty then `TimeInstant` is not propaged to CB.
+by their object_id) defined in JSON/JEXL array will be propagated to NGSI interface.
+
+Note that when `explicitAttrs` is an array or a JEXL expression resulting in to Array, if this array is empty then `TimeInstant` is not propaged to CB.
 
 The different possibilities are summarized below:
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -464,7 +464,8 @@ element. By adding the field `explicitAttrs` with `true` value to device or conf
 measure elements that are not defined in the mappings of device or config group, persisting only the one defined in the
 mappings of the provision. If `explicitAttrs` is provided both at device and config group level, the device level takes
 precedence. Additionally `explicitAttrs` can be used to define which measures (identified by their attribute names, not
-by their object_id) defined in JSON/JEXL array will be propagated to NGSI interface.
+by their object_id) defined in JSON/JEXL array will be propagated to NGSI interface. When `explicitAttrs` is an array or
+and JEXL expression resulting in to Array, if this array is empty then `TimeInstant` is not propaged to CB.
 
 The different possibilities are summarized below:
 

--- a/lib/services/ngsi/entities-NGSI-v2.js
+++ b/lib/services/ngsi/entities-NGSI-v2.js
@@ -504,7 +504,7 @@ function sendUpdateValueNgsi2(entityName, measures, typeInformation, token, call
     if (typeof typeInformation.explicitAttrs === 'string') {
         try {
             explicit = jexlParser.applyExpression(typeInformation.explicitAttrs, jexlctxt, typeInformation);
-            if (explicit instanceof Array && mustInsertTimeInstant) {
+            if (explicit instanceof Array && explicit.length > 0 && mustInsertTimeInstant) {
                 explicit.push(constants.TIMESTAMP_ATTRIBUTE);
             }
             logger.debug(

--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -2970,6 +2970,107 @@ const testCases = [
     },
     {
         describeName:
+            '0533 - Group with explicit attrs:[ ] (empty array) + active attributes + TimeInstant attribute + static attributes + timestamp:true',
+        provision: {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+            method: 'POST',
+            json: {
+                services: [
+                    {
+                        resource: '/iot/json',
+                        apikey: globalEnv.apikey,
+                        entity_type: globalEnv.entity_type,
+                        explicitAttrs: "['DateIssued']",
+                        timestamp: true,
+                        commands: [],
+                        lazy: [],
+                        attributes: [
+                            {
+                                name: 'attr_a',
+                                object_id: 'a',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'attr_b',
+                                object_id: 'b',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'DateIssued',
+                                object_id: 'TimeInstant',
+                                type: 'DateTime'
+                            },
+                            {
+                                name: 'TimeInstant',
+                                object_id: 't',
+                                type: 'DateTime'
+                            }
+                        ],
+                        static_attributes: [
+                            {
+                                name: 'static_a',
+                                type: 'Number',
+                                value: 3
+                            },
+                            {
+                                name: 'static_b',
+                                type: 'Number',
+                                value: 4
+                            }
+                        ]
+                    }
+                ]
+            },
+            headers: {
+                'fiware-service': globalEnv.service,
+                'fiware-servicepath': globalEnv.servicePath
+            }
+        },
+        should: [
+            {
+                shouldName:
+                    'A - WHEN sending data and a measure called "t" (defined as TimeInstant attribte) through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        t: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: {}
+            },
+            {
+                shouldName:
+                    'B - WHEN sending data and a measure called TimeInstant through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        TimeInstant: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: {} // No payload expected
+            }
+        ]
+    },
+    {
+        describeName:
             '0540 - Group with explicit attrs: JEXL expression based on measure resulting boolean + active attributes + static attributes',
         provision: {
             url: 'http://localhost:' + config.iota.server.port + '/iot/services',

--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -3045,14 +3045,7 @@ const testCases = [
                         t: '2015-12-14T08:06:01.468Z'
                     }
                 },
-                expectation: {
-                    id: 'TestType:TestDevice',
-                    type: 'TestType',
-                    TimeInstant: {
-                        type: 'DateTime',
-                        value: '2015-12-14T08:06:01.468Z'
-                    }
-                }
+                expectation: []
             },
             {
                 shouldName:

--- a/test/functional/testCases.js
+++ b/test/functional/testCases.js
@@ -2980,7 +2980,7 @@ const testCases = [
                         resource: '/iot/json',
                         apikey: globalEnv.apikey,
                         entity_type: globalEnv.entity_type,
-                        explicitAttrs: "['DateIssued']",
+                        explicitAttrs: '[ ]',
                         timestamp: true,
                         commands: [],
                         lazy: [],
@@ -3045,7 +3045,14 @@ const testCases = [
                         t: '2015-12-14T08:06:01.468Z'
                     }
                 },
-                expectation: {}
+                expectation: {
+                    id: 'TestType:TestDevice',
+                    type: 'TestType',
+                    TimeInstant: {
+                        type: 'DateTime',
+                        value: '2015-12-14T08:06:01.468Z'
+                    }
+                }
             },
             {
                 shouldName:
@@ -3065,7 +3072,108 @@ const testCases = [
                         TimeInstant: '2015-12-14T08:06:01.468Z'
                     }
                 },
-                expectation: {} // No payload expected
+                expectation: [] // No payload expected
+            }
+        ]
+    },
+    {
+        describeName:
+            '0534 - Group with explicit attrs:[ ] (empty array) + active attributes + TimeInstant attribute + static attributes + timestamp:false',
+        provision: {
+            url: 'http://localhost:' + config.iota.server.port + '/iot/services',
+            method: 'POST',
+            json: {
+                services: [
+                    {
+                        resource: '/iot/json',
+                        apikey: globalEnv.apikey,
+                        entity_type: globalEnv.entity_type,
+                        explicitAttrs: '[ ]',
+                        timestamp: false,
+                        commands: [],
+                        lazy: [],
+                        attributes: [
+                            {
+                                name: 'attr_a',
+                                object_id: 'a',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'attr_b',
+                                object_id: 'b',
+                                type: 'Number'
+                            },
+                            {
+                                name: 'DateIssued',
+                                object_id: 'TimeInstant',
+                                type: 'DateTime'
+                            },
+                            {
+                                name: 'TimeInstant',
+                                object_id: 't',
+                                type: 'DateTime'
+                            }
+                        ],
+                        static_attributes: [
+                            {
+                                name: 'static_a',
+                                type: 'Number',
+                                value: 3
+                            },
+                            {
+                                name: 'static_b',
+                                type: 'Number',
+                                value: 4
+                            }
+                        ]
+                    }
+                ]
+            },
+            headers: {
+                'fiware-service': globalEnv.service,
+                'fiware-servicepath': globalEnv.servicePath
+            }
+        },
+        should: [
+            {
+                shouldName:
+                    'A - WHEN sending data and a measure called "t" (defined as TimeInstant attribte) through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        t: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: []
+            },
+            {
+                shouldName:
+                    'B - WHEN sending data and a measure called TimeInstant through http IT should NOT store anything into the Context Broker (No request to CB)',
+                type: 'single',
+                measure: {
+                    url: 'http://localhost:' + config.http.port + '/iot/json',
+                    method: 'POST',
+                    qs: {
+                        i: globalEnv.deviceId,
+                        k: globalEnv.apikey
+                    },
+                    json: {
+                        a: 3,
+                        b: 10,
+                        c: 11,
+                        TimeInstant: '2015-12-14T08:06:01.468Z'
+                    }
+                },
+                expectation: [] // No payload expected
             }
         ]
     },


### PR DESCRIPTION
This is another  suggestion to fix cases proposed in https://github.com/telefonicaid/iotagent-node-lib/pull/1610

having into account this logic This is my suggestion to fix cases proposed in https://github.com/telefonicaid/iotagent-node-lib/pull/1610

- [x] update doc with new behavior about ```explicitAttrs = [ ]``` and ```timestmap = true```