### PR TITLE
re-add getDeviceById

### DIFF
--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -243,6 +243,14 @@ function getDeviceById(id, apikey, service, subservice, callback) {
 function getDevice(id, apikey, service, subservice, callback) {
     getDeviceById(id, apikey, service, subservice, function (error, data) {
         if (error) {
+            // Try without apikey: apikey will be added to device later
+            getDeviceById(id, null, service, subservice, function (error, data) {
+                if (error) {
+                    callback(error);
+                } else {
+                    callback(null, data);
+                }
+            });
             callback(error);
         } else {
             callback(null, data);
@@ -252,9 +260,9 @@ function getDevice(id, apikey, service, subservice, callback) {
 
 function getByNameAndType(name, type, service, servicepath, callback) {
     context = fillService(context, { service, subservice: servicepath });
-    let optionsQuery = {
-        name: name,
-        service: service,
+    const optionsQuery = {
+        name,
+        service,
         subservice: servicepath
     };
     if (type) {

--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -251,7 +251,6 @@ function getDevice(id, apikey, service, subservice, callback) {
                     callback(null, data);
                 }
             });
-            callback(error);
         } else {
             callback(null, data);
         }


### PR DESCRIPTION
Fixes  #1624

Checking with NGSI-v2,  4c44db307f2e2723c4c8a47fdde462ced28ba754 is fine, 964ee270fea64d36c1872e3050dd45031071bd59 onwards manifests an incorrect payload as:

```json
 "undefined": {
	"type": "None",
	"value": null,
	"metadata": {
	"TimeInstant": {
	    "type": "DateTime",
	    "value": "2024-06-27T09:28:53.963Z"
	}
}
```

The only config functions that has changed at this point is `getDevice()` where the fallback to ` getDeviceById()` had been removed


```diff
function getDevice(id, apikey, service, subservice, callback) {
    getDeviceById(id, apikey, service, subservice, function (error, data) {
        if (error) {
+            // Try without apikey: apikey will be added to device later
+           getDeviceById(id, null, service, subservice, function (error, data) {
+                if (error) {
+                    callback(error);
+               } else {
+                    callback(null, data);
+               }
+            });
-            callback(error);
        } else {
            callback(null, data);
        }
    });
}
```

Re-adding the code fixes this direct issue - although linked entities are still not present in NGSI-LD
