### PR TITLE
Add value picker JEXL function

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -663,6 +663,9 @@ Current common transformation set:
 | localestring: (d, timezone, options) | `new Date(d).toLocaleString(timezone, options)`                                                                         |
 | now: ()                              | `Date.now()`                                                                                                            |
 | hextostring: (val)                   | `new TextDecoder().decode(new Uint8Array(val.match(/.{1,2}/g).map(byte => parseInt(byte, 16))))`                        |
+| valuePicker: (val,pick)              | <code>valuePicker: (val,pick) => Object.entries(val).filter(([_, v]) => v === pick).map(([k, _]) => k)</code> |
+| valuePickerMulti: (val,pick)              | <code>valuePickerMulti: (val,pick) => Object.entries(val).filter(([_, v]) => pick.includes(v)).map(([k, _]) => k)</code> |
+
 
 You have available this [JEXL interactive playground][99] with all the transformations already loaded, in which you can
 test all the functions described above.

--- a/lib/jexlTranformsMap.js
+++ b/lib/jexlTranformsMap.js
@@ -80,7 +80,9 @@ const map = {
     localestring: (d, timezone, options) => new Date(d).toLocaleString(timezone, options),
     now: () => Date.now(),
     hextostring: (val) =>
-        new TextDecoder().decode(new Uint8Array(val.match(/.{1,2}/g).map((byte) => parseInt(byte, 16))))
+        new TextDecoder().decode(new Uint8Array(val.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)))),
+    valuePicker: (val,pick) => Object.entries(val).filter(([_, v]) => v === pick).map(([k, _]) => k),
+    valuePickerMulti: (val,pick) => Object.entries(val).filter(([_, v]) => pick.includes(v)).map(([k, _]) => k)
 };
 
 exports.map = map;


### PR DESCRIPTION
This function picks all keys of a certain object and includes the name of the key into an array.

For a given expression like this:

```js
{a:1,b:2,c:3}|valuePicker(1)
```

The output result will be `["a"]`

Same for valuePickerMulti, that uses an array with possibles match:

```js
{a:1,b:2,c:3}|valuePickerMulti([1,3])
```

The output result will be `["a","c"]`