### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Mosquitto/Dockerfile
+++ b/docker/Mosquitto/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     # Install dependencies
     apt-get -y install \
        wget \
-       mosquitto && \
+       mosquitto mosquitto-clients && \
     cp /etc/mosquitto/mosquitto.conf /etc/mosquitto/mosquitto.conf.orig && \
     chmod 755 /bin/startMosquitto.sh && \
     mkdir -p /var/log/mosquitto && \


### PR DESCRIPTION
Add mosquitto_sub executable to image,m for liveness and readiness testing purposes.

Versions 1.X of the docker image had the "mosquitto_sub" client, which was used for testing purposes, in liveness and readiness probes in kubernetes.

Versions 2.X lost the executable. This PR restores the mosquitto_sub exevutable in the image.