### PR TITLE
Update package.json: express from 4.19 to 4.20

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- Upgrade express de from 4.19.2 to 4.20.0

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "async": "2.6.4",
     "body-parser": "~1.20.3",
-    "express": "~4.19.2",
+    "express": "~4.20.0",
     "got": "~11.8.5",
     "jexl": "2.3.0",
     "jison": "0.4.18",


### PR DESCRIPTION
https://github.com/telefonicaid/iotagent-node-lib/issues/1658

Curerntly iotagents are using express 4.20 already