### PR TITLE
fix doc uniqueness group

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -165,7 +165,7 @@ parameters defined at device level in database, the parameters are inherit from 
 
 ### Uniqueness of groups and devices
 
-Group uniqueness is defined by the combination of: service, subservice, resource and apikey
+Group uniqueness is defined by the combination of: resource and apikey.
 
 Device uniqueness is defined by the combination of: service, subservice, device_id and apikey. Note that several devices
 with the same device_id are allowed in the same service and subservice as long as their apikeys are different.


### PR DESCRIPTION
related with #1633 #1589

Given a measure (identified by an apikey) there is no way to identify group related if apikey is not unique for all services and subservices.

My comment https://github.com/telefonicaid/iotagent-node-lib/issues/1633#issuecomment-2272722185 was  taken directly from https://github.com/telefonicaid/iotagent-node-lib/pull/1592#discussion_r1551377609