### PR TITLE
set polling for autoprovisioned devices

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
+- Fix: set polling and transport for autoprovisioned devices
 - Add: option to force to use CB flow control with new API field useCBflowControl at group and device device level  (#1420)
 - Add: useCBflowControl config setting (IOTA_CB_FLOW_CONTROL env var) to set CB flow control behaviour at instance level (#1420)
 - Add: store last measure in device (by id, apikey, service and subservice) and new API field storeLastMeasure at group and device levels (#1669)

--- a/lib/commonConfig.js
+++ b/lib/commonConfig.js
@@ -352,6 +352,11 @@ function processEnvironmentVariables() {
         config.defaultResource = process.env.IOTA_DEFAULT_RESOURCE;
     }
 
+    // Default transport
+    if (process.env.IOTA_DEFAULT_TRANSPORT !== undefined) {
+        config.defaultTransport = process.env.IOTA_DEFAULT_TRANSPORT;
+    }
+
     // Default explicitAttrs
     if (process.env.IOTA_EXPLICIT_ATTRS !== undefined) {
         config.explicitAttrs = process.env.IOTA_EXPLICIT_ATTRS;

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -285,16 +285,16 @@ function registerDevice(deviceObj, callback) {
         }
         // polling for autoprovision?
         if (!deviceData.transport && config.getConfig().defaultTransport) {
-            device.transport =
+            deviceData.transport =
                 configuration && configuration.transport
                     ? configuration.transport
                     : config.getConfig().defaultTransport;
         }
-        if (device.transport === 'HTTP') {
-            if (device.endpoint) {
-                device.polling = false;
+        if (deviceData.transport === 'HTTP') {
+            if (deviceData.endpoint) {
+                deviceData.polling = false;
             } else {
-                device.polling = !(group && group.endpoint);
+                deviceData.polling = !(configuration && configuration.endpoint);
             }
         }
         if (!deviceData.name) {

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -283,7 +283,7 @@ function registerDevice(deviceObj, callback) {
                 deviceData.ngsiVersion = configuration.ngsiVersion;
             }
         }
-        // polling for autoprovision?
+        // polling and transport for autoprovisioned devices
         if (!deviceData.transport && config.getConfig().defaultTransport) {
             deviceData.transport =
                 configuration && configuration.transport
@@ -375,6 +375,12 @@ function registerDevice(deviceObj, callback) {
                     deviceObj.lazy = deviceObj.lazy ? deviceObj.lazy : [];
                     if ('apikey' in deviceData && deviceData.apikey !== undefined) {
                         deviceObj.apikey = deviceData.apikey;
+                    }
+                    if ('transport' in deviceData && deviceData.transport !== undefined) {
+                        deviceObj.transport = deviceData.transport;
+                    }
+                    if ('polling' in deviceData && deviceData.polling !== undefined) {
+                        deviceObj.polling = deviceData.polling;
                     }
                     logger.debug(context, 'Storing device :\n%s', JSON.stringify(deviceObj, null, 4));
                     config.getRegistry().store(deviceObj, callback);

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -283,7 +283,7 @@ function registerDevice(deviceObj, callback) {
                 deviceData.ngsiVersion = configuration.ngsiVersion;
             }
         }
-        // polling and transport for autoprovisioned devices
+        // Set polling and transport for autoprovisioned devices
         if (!deviceData.transport && config.getConfig().defaultTransport) {
             deviceData.transport =
                 configuration && configuration.transport

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -283,7 +283,20 @@ function registerDevice(deviceObj, callback) {
                 deviceData.ngsiVersion = configuration.ngsiVersion;
             }
         }
-
+        // polling for autoprovision?
+        if (!deviceData.transport && config.getConfig().defaultTransport) {
+            device.transport =
+                configuration && configuration.transport
+                    ? configuration.transport
+                    : config.getConfig().defaultTransport;
+        }
+        if (device.transport === 'HTTP') {
+            if (device.endpoint) {
+                device.polling = false;
+            } else {
+                device.polling = !(group && group.endpoint);
+            }
+        }
         if (!deviceData.name) {
             let entityName = null;
             if (configuration && configuration.entityNameExp !== undefined && configuration.entityNameExp !== '') {


### PR DESCRIPTION
Autoprovisioned devices are not setting polling and transport when are created. When related group has no info about transport nither endpoint then if defaultTransport in agent is HTTP polling true is not defined in autoprovisioned device.

This bug was introduced by https://github.com/telefonicaid/iotagent-json/pull/794