### PR TITLE
Add unique index for Device model

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,3 @@
-- ADD: index for Device model based on {service: 1, subservice: 1, id: 1, apikey: 1} (#1576)
-- FIX: Duplicated Devices when burst measures to non provisoned Device (iotagent-json#865)
+- Add: index for Device model based on {service: 1, subservice: 1, id: 1, apikey: 1} (#1576)
+- Fix: Duplicated Devices when burst measures to non provisioned Device (iotagent-json#865)
 - Fix: modified JEXL transformations (toisostring, gettime, parseint, etc.) to return null instead of NaN when some unexpected situation occurs (#1701)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
+- ADD: index for Device model based on {service: 1, subservice: 1, id: 1, apikey: 1} (#1576)
 - Fix: modified JEXL transformations (toisostring, gettime, parseint, etc.) to return null instead of NaN when some unexpected situation occurs (#1701)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,2 +1,3 @@
 - ADD: index for Device model based on {service: 1, subservice: 1, id: 1, apikey: 1} (#1576)
+- FIX: Duplicated Devices when burst measures to non provisoned Device (iotagent-json#865)
 - Fix: modified JEXL transformations (toisostring, gettime, parseint, etc.) to return null instead of NaN when some unexpected situation occurs (#1701)

--- a/lib/model/Device.js
+++ b/lib/model/Device.js
@@ -61,6 +61,7 @@ const Device = new Schema({
 });
 
 function load() {
+    Device.index({ service: 1, subservice: 1, apikey: 1, id: 1 }, { unique: true });
     module.exports.model = mongoose.model('Device', Device);
     module.exports.internalSchema = Device;
 }

--- a/lib/services/devices/deviceRegistryMongoDB.js
+++ b/lib/services/devices/deviceRegistryMongoDB.js
@@ -90,7 +90,7 @@ function storeDevice(newDevice, callback) {
             if (error.code === 11000) {
                 logger.debug(context, 'Tried to insert a device with duplicate ID in the database: %s', error);
 
-                callback(new errors.DuplicateDeviceId(newDevice));
+                callback(new errors.DuplicateDeviceId(newDevice), newDevice);
             } else {
                 logger.debug(context, 'Error storing device information: %s', error);
 

--- a/lib/services/devices/deviceService.js
+++ b/lib/services/devices/deviceService.js
@@ -40,6 +40,8 @@ const registrationUtils = require('./registrationUtils');
 const subscriptions = require('../ngsi/subscriptionService');
 const expressionPlugin = require('./../../plugins/expressionPlugin');
 const pluginUtils = require('./../../plugins/pluginUtils');
+const alarms = require('../common/alarmManagement');
+const constants = require('../../constants');
 const _ = require('underscore');
 const context = {
     op: 'IoTAgentNGSI.DeviceService'
@@ -250,7 +252,7 @@ function registerDevice(deviceObj, callback) {
             /* eslint-disable-next-line no-unused-vars */
             function (error, device) {
                 if (!error) {
-                    innerCb(new errors.DuplicateDeviceId(deviceObj));
+                    innerCb(new errors.DuplicateDeviceId(deviceObj), device);
                 } else {
                     innerCb();
                 }
@@ -664,7 +666,14 @@ function findOrCreate(deviceId, apikey, group, callback) {
             if (group.autoprovision === undefined || group.autoprovision === true) {
                 logger.debug(context, 'Registering autoprovision of Device %j for its conf %j', newDevice, group);
                 registerDevice(newDevice, function (error, device) {
-                    callback(error, device, group);
+                    if (error && error.name === 'DUPLICATE_DEVICE_ID') {
+                        alarms.release(constants.MONGO_ALARM, error);
+                        logger.warn(context, 'Error %j already registered autoprovisioned device: %j ', error, device);
+                        callback(null, device, group);
+                    } else {
+                        logger.debug(context, 'registered autoprovisioned device: %j ', device);
+                        callback(error, device, group);
+                    }
                 });
             } else {
                 logger.info(


### PR DESCRIPTION
Unique index for Device model + handle duplicated mongo error when device is autoprovisioned.

Issue https://github.com/telefonicaid/iotagent-node-lib/issues/1576

Related with https://github.com/telefonicaid/iotagent-node-lib/blob/master/doc/api.md#uniqueness-of-groups-and-devices

and fixes: https://github.com/telefonicaid/iotagent-json/issues/865