### PR TITLE
Update uuid dependency to version 14.0.0

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-
+- Upgrade uuid dep from 8.3.2 to 14.0.0 due to CWE-787 CWE-1285

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "query-string": "7.1.1",
     "revalidator": "~0.3.1",
     "underscore": "~1.13.4",
-    "uuid": "~8.3.2"
+    "uuid": "~14.0.0"
   },
   "devDependencies": {
     "async-mqtt": "~2.6.3",


### PR DESCRIPTION
Mimics https://github.com/telefonicaid/fiware-pep-steelskin/pull/586

The same change log and the same usage (just uuid.v4())